### PR TITLE
Add CLI smoke test against fixture scaffold

### DIFF
--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -12,19 +12,31 @@ const pkg = JSON.parse(
   readFileSync(join(here, "..", "package.json"), "utf8"),
 ) as { version: string };
 
-let projectRoot: string;
+let projectRoot: string | undefined;
 
-function runMex(args: string[]): { status: number | null; stdout: string; stderr: string } {
+function runMex(args: string[]): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  output: string;
+} {
   const result = spawnSync(process.execPath, [CLI, ...args], {
     cwd: projectRoot,
     encoding: "utf8",
     env: { ...process.env, NO_COLOR: "1" },
   });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
   return {
     status: result.status,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
+    stdout,
+    stderr,
+    output: [stdout, stderr].filter(Boolean).join("\n"),
   };
+}
+
+function expectSuccess(result: ReturnType<typeof runMex>): void {
+  expect(result.status, result.output).toBe(0);
 }
 
 beforeAll(() => {
@@ -38,81 +50,81 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  rmSync(projectRoot, { recursive: true, force: true });
+  if (projectRoot) {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
 });
 
 describe("CLI smoke", () => {
   it("--version matches package.json", () => {
-    const { status, stdout } = runMex(["--version"]);
-    expect(status).toBe(0);
-    expect(stdout.trim()).toBe(pkg.version);
+    const result = runMex(["--version"]);
+    expectSuccess(result);
+    expect(result.stdout.trim()).toBe(pkg.version);
   });
 
   it("commands lists top-level commands", () => {
-    const { status, stdout } = runMex(["commands"]);
-    expect(status).toBe(0);
-    expect(stdout).toContain("CLI Commands");
-    expect(stdout).toContain("mex check");
+    const result = runMex(["commands"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("CLI Commands");
+    expect(result.stdout).toContain("mex check");
   });
 
   it("check --quiet exits successfully on fixture", () => {
-    const { status, stdout } = runMex(["check", "--quiet"]);
-    expect(status).toBe(0);
-    expect(stdout.length).toBeGreaterThan(0);
+    const result = runMex(["check", "--quiet"]);
+    expectSuccess(result);
+    expect(result.stdout.length).toBeGreaterThan(0);
   });
 
   it("doctor prints health summary", () => {
-    const { status, stdout } = runMex(["doctor"]);
-    expect(status).toBe(0);
-    expect(stdout).toContain("mex doctor");
-    expect(stdout).toContain("Drift");
+    const result = runMex(["doctor"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("mex doctor");
+    expect(result.stdout).toContain("Drift");
   });
 
   it("log and timeline round-trip", () => {
     const log = runMex(["log", "smoke test note", "--type", "note"]);
-    expect(log.status).toBe(0);
+    expectSuccess(log);
     const timeline = runMex(["timeline", "--limit", "1"]);
-    expect(timeline.status).toBe(0);
+    expectSuccess(timeline);
     expect(timeline.stdout).toContain("smoke test note");
   });
 
   it("heartbeat --json reports status", () => {
-    const { status, stdout } = runMex(["heartbeat", "--json"]);
-    expect(status).toBe(0);
-    expect(stdout).toContain("{");
+    const result = runMex(["heartbeat", "--json"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("{");
   });
 
   it("completion bash emits script", () => {
-    const { status, stdout } = runMex(["completion", "bash"]);
-    expect(status).toBe(0);
-    expect(stdout).toContain("complete");
+    const result = runMex(["completion", "bash"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("complete");
   });
 
   it("sync --dry-run runs without error", () => {
-    const { status } = runMex(["sync", "--dry-run"]);
-    expect(status).toBe(0);
+    expectSuccess(runMex(["sync", "--dry-run"]));
   });
 
   it("setup --dry-run previews scaffold", () => {
-    const { status, stdout } = runMex(["setup", "--dry-run"]);
-    expect(status).toBe(0);
-    expect(stdout.length).toBeGreaterThan(0);
+    const result = runMex(["setup", "--dry-run"]);
+    expectSuccess(result);
+    expect(result.stdout.length).toBeGreaterThan(0);
   });
 
   it("init --json emits scanner brief", () => {
-    const { status, stdout } = runMex(["init", "--json"]);
-    expect(status).toBe(0);
-    expect(stdout.trim().startsWith("{")).toBe(true);
+    const result = runMex(["init", "--json"]);
+    expectSuccess(result);
+    expect(result.stdout.trim().startsWith("{")).toBe(true);
   });
 
   it("watch --uninstall is a no-op success", () => {
-    const { status } = runMex(["watch", "--uninstall"]);
-    expect(status).toBe(0);
+    expectSuccess(runMex(["watch", "--uninstall"]));
   });
 
   it("pattern add creates a scaffold file", () => {
-    const { status, stdout } = runMex(["pattern", "add", "smoke-pattern"]);
-    expect(status).toBe(0);
-    expect(stdout).toContain("smoke-pattern.md");
+    const result = runMex(["pattern", "add", "smoke-pattern"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("smoke-pattern.md");
   });
 });

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -90,6 +90,19 @@ describe("CLI smoke", () => {
     expect(result.stdout.length).toBeGreaterThan(0);
   });
 
+  it("check --json reports clean drift on fixture scaffold", () => {
+    const result = runMex(["check", "--json"]);
+    expectSuccess(result);
+    const report = JSON.parse(result.stdout) as {
+      score: number;
+      issues: Array<{ code?: string; file?: string }>;
+      filesChecked: number;
+    };
+    expect(report.score).toBe(100);
+    expect(report.issues).toEqual([]);
+    expect(report.filesChecked).toBeGreaterThanOrEqual(8);
+  });
+
   it("doctor prints health summary", () => {
     const result = runMex(["doctor"]);
     expectSuccess(result);
@@ -111,10 +124,18 @@ describe("CLI smoke", () => {
     expect(result.stdout).toContain("{");
   });
 
-  it("completion bash emits script", () => {
-    const result = runMex(["completion", "bash"]);
-    expectSuccess(result);
-    expect(result.stdout).toContain("complete");
+  it("completion emits scripts for bash, zsh, and fish", () => {
+    const bash = runMex(["completion", "bash"]);
+    expectSuccess(bash);
+    expect(bash.stdout).toContain("complete");
+
+    const zsh = runMex(["completion", "zsh"]);
+    expectSuccess(zsh);
+    expect(zsh.stdout).toContain("#compdef mex");
+
+    const fish = runMex(["completion", "fish"]);
+    expectSuccess(fish);
+    expect(fish.stdout).toContain("complete -c mex");
   });
 
   it("sync --dry-run runs without error", () => {

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -19,6 +19,9 @@ function ensureCliBuilt(): void {
   if (!existsSync(CLI)) {
     execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
   }
+  if (!existsSync(CLI)) {
+    throw new Error(`CLI executable not found at ${CLI} after build`);
+  }
 }
 
 function runMex(args: string[]): {
@@ -28,6 +31,9 @@ function runMex(args: string[]): {
   output: string;
 } {
   ensureCliBuilt();
+  if (!existsSync(CLI)) {
+    throw new Error(`CLI executable not found at ${CLI}`);
+  }
   const result = spawnSync(process.execPath, [CLI, ...args], {
     cwd: projectRoot,
     encoding: "utf8",
@@ -49,6 +55,9 @@ function expectSuccess(result: ReturnType<typeof runMex>): void {
 
 beforeAll(() => {
   execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
+  if (!existsSync(CLI)) {
+    throw new Error(`CLI build failed: ${CLI} not found`);
+  }
   projectRoot = mkdtempSync(join(tmpdir(), "mex-smoke-"));
   cpSync(FIXTURE_SRC, projectRoot, { recursive: true });
   execSync("git init -q", { cwd: projectRoot });

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execSync, spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const CLI = join(here, "..", "dist", "cli.js");
+const FIXTURE_SRC = join(here, "fixtures", "smoke-project");
+const pkg = JSON.parse(
+  readFileSync(join(here, "..", "package.json"), "utf8"),
+) as { version: string };
+
+let projectRoot: string;
+
+function runMex(args: string[]): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    cwd: projectRoot,
+    encoding: "utf8",
+    env: { ...process.env, NO_COLOR: "1" },
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+beforeAll(() => {
+  projectRoot = mkdtempSync(join(tmpdir(), "mex-smoke-"));
+  cpSync(FIXTURE_SRC, projectRoot, { recursive: true });
+  execSync("git init -q", { cwd: projectRoot });
+  execSync("git add -A", { cwd: projectRoot });
+  execSync('git -c user.email=smoke@test -c user.name=smoke commit -q -m "init"', {
+    cwd: projectRoot,
+  });
+});
+
+describe("CLI smoke", () => {
+  it("--version matches package.json", () => {
+    const { status, stdout } = runMex(["--version"]);
+    expect(status).toBe(0);
+    expect(stdout.trim()).toBe(pkg.version);
+  });
+
+  it("commands lists top-level commands", () => {
+    const { status, stdout } = runMex(["commands"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("CLI Commands");
+    expect(stdout).toContain("mex check");
+  });
+
+  it("check --quiet exits successfully on fixture", () => {
+    const { status, stdout } = runMex(["check", "--quiet"]);
+    expect(status).toBe(0);
+    expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  it("doctor prints health summary", () => {
+    const { status, stdout } = runMex(["doctor"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("mex doctor");
+    expect(stdout).toContain("Drift");
+  });
+
+  it("log and timeline round-trip", () => {
+    const log = runMex(["log", "smoke test note", "--type", "note"]);
+    expect(log.status).toBe(0);
+    const timeline = runMex(["timeline", "--limit", "1"]);
+    expect(timeline.status).toBe(0);
+    expect(timeline.stdout).toContain("smoke test note");
+  });
+
+  it("heartbeat --json reports status", () => {
+    const { status, stdout } = runMex(["heartbeat", "--json"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("{");
+  });
+
+  it("completion bash emits script", () => {
+    const { status, stdout } = runMex(["completion", "bash"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("complete");
+  });
+
+  it("sync --dry-run runs without error", () => {
+    const { status } = runMex(["sync", "--dry-run"]);
+    expect(status).toBe(0);
+  });
+
+  it("setup --dry-run previews scaffold", () => {
+    const { status, stdout } = runMex(["setup", "--dry-run"]);
+    expect(status).toBe(0);
+    expect(stdout.length).toBeGreaterThan(0);
+  });
+
+  it("init --json emits scanner brief", () => {
+    const { status, stdout } = runMex(["init", "--json"]);
+    expect(status).toBe(0);
+    expect(stdout.trim().startsWith("{")).toBe(true);
+  });
+
+  it("watch --uninstall is a no-op success", () => {
+    const { status } = runMex(["watch", "--uninstall"]);
+    expect(status).toBe(0);
+  });
+});

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -1,10 +1,9 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
-import { cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
-import { readFileSync } from "node:fs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const CLI = join(here, "..", "dist", "cli.js");
@@ -36,6 +35,10 @@ beforeAll(() => {
   execSync('git -c user.email=smoke@test -c user.name=smoke commit -q -m "init"', {
     cwd: projectRoot,
   });
+});
+
+afterAll(() => {
+  rmSync(projectRoot, { recursive: true, force: true });
 });
 
 describe("CLI smoke", () => {
@@ -105,5 +108,11 @@ describe("CLI smoke", () => {
   it("watch --uninstall is a no-op success", () => {
     const { status } = runMex(["watch", "--uninstall"]);
     expect(status).toBe(0);
+  });
+
+  it("pattern add creates a scaffold file", () => {
+    const { status, stdout } = runMex(["pattern", "add", "smoke-pattern"]);
+    expect(status).toBe(0);
+    expect(stdout).toContain("smoke-pattern.md");
   });
 });

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -69,6 +69,12 @@ describe("CLI smoke", () => {
     expect(result.stdout).toContain("mex check");
   });
 
+  it("check prints drift summary on fixture", () => {
+    const result = runMex(["check"]);
+    expectSuccess(result);
+    expect(result.stdout).toContain("Drift score");
+  });
+
   it("check --quiet exits successfully on fixture", () => {
     const result = runMex(["check", "--quiet"]);
     expectSuccess(result);

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync, spawnSync } from "node:child_process";
-import { cpSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const CLI = join(here, "..", "dist", "cli.js");
+const repoRoot = join(here, "..");
+const CLI = join(repoRoot, "dist", "cli.js");
 const FIXTURE_SRC = join(here, "fixtures", "smoke-project");
 const pkg = JSON.parse(
   readFileSync(join(here, "..", "package.json"), "utf8"),
@@ -14,12 +15,19 @@ const pkg = JSON.parse(
 
 let projectRoot: string | undefined;
 
+function ensureCliBuilt(): void {
+  if (!existsSync(CLI)) {
+    execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
+  }
+}
+
 function runMex(args: string[]): {
   status: number | null;
   stdout: string;
   stderr: string;
   output: string;
 } {
+  ensureCliBuilt();
   const result = spawnSync(process.execPath, [CLI, ...args], {
     cwd: projectRoot,
     encoding: "utf8",
@@ -40,6 +48,7 @@ function expectSuccess(result: ReturnType<typeof runMex>): void {
 }
 
 beforeAll(() => {
+  execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
   projectRoot = mkdtempSync(join(tmpdir(), "mex-smoke-"));
   cpSync(FIXTURE_SRC, projectRoot, { recursive: true });
   execSync("git init -q", { cwd: projectRoot });

--- a/test/cli-smoke.test.ts
+++ b/test/cli-smoke.test.ts
@@ -37,7 +37,7 @@ function runMex(args: string[]): {
   const result = spawnSync(process.execPath, [CLI, ...args], {
     cwd: projectRoot,
     encoding: "utf8",
-    env: { ...process.env, NO_COLOR: "1" },
+    env: { ...process.env, MEX_TELEMETRY: "0", NO_COLOR: "1" },
   });
   const stdout = result.stdout ?? "";
   const stderr = result.stderr ?? "";

--- a/test/fixtures/smoke-project/.mex/AGENTS.md
+++ b/test/fixtures/smoke-project/.mex/AGENTS.md
@@ -1,0 +1,19 @@
+---
+name: agents
+description: Smoke test project anchor
+last_updated: 2026-06-01
+---
+
+# Smoke Project
+
+## What This Is
+
+Minimal fixture for mex CLI smoke tests.
+
+## Non-Negotiables
+
+- Used only in automated tests
+
+## Commands
+
+- npm test

--- a/test/fixtures/smoke-project/.mex/ROUTER.md
+++ b/test/fixtures/smoke-project/.mex/ROUTER.md
@@ -1,0 +1,18 @@
+---
+name: router
+description: Smoke test scaffold router
+last_updated: 2026-06-01
+---
+
+# Smoke Project
+
+## Current Project State
+
+**Working:**
+- CLI smoke fixture
+
+**Not yet built:**
+- Nothing
+
+**Known issues:**
+- None

--- a/test/fixtures/smoke-project/.mex/context/architecture.md
+++ b/test/fixtures/smoke-project/.mex/context/architecture.md
@@ -1,0 +1,9 @@
+---
+name: architecture
+description: Smoke architecture context
+last_updated: 2026-06-01
+---
+
+# Architecture
+
+Single-file smoke fixture.

--- a/test/fixtures/smoke-project/.mex/context/conventions.md
+++ b/test/fixtures/smoke-project/.mex/context/conventions.md
@@ -1,0 +1,9 @@
+---
+name: conventions
+description: Smoke conventions context
+last_updated: 2026-06-01
+---
+
+# Conventions
+
+Test-only conventions.

--- a/test/fixtures/smoke-project/.mex/context/decisions.md
+++ b/test/fixtures/smoke-project/.mex/context/decisions.md
@@ -1,0 +1,9 @@
+---
+name: decisions
+description: Smoke decisions log
+last_updated: 2026-06-01
+---
+
+# Decisions
+
+None yet.

--- a/test/fixtures/smoke-project/.mex/context/setup.md
+++ b/test/fixtures/smoke-project/.mex/context/setup.md
@@ -1,0 +1,9 @@
+---
+name: setup
+description: Smoke setup context
+last_updated: 2026-06-01
+---
+
+# Setup
+
+Run `npm test` from the mex repo.

--- a/test/fixtures/smoke-project/.mex/context/stack.md
+++ b/test/fixtures/smoke-project/.mex/context/stack.md
@@ -1,0 +1,9 @@
+---
+name: stack
+description: Smoke stack context
+last_updated: 2026-06-01
+---
+
+# Stack
+
+Node.js test fixture.

--- a/test/fixtures/smoke-project/.mex/patterns/INDEX.md
+++ b/test/fixtures/smoke-project/.mex/patterns/INDEX.md
@@ -1,0 +1,9 @@
+---
+name: patterns-index
+description: Pattern index for smoke tests
+last_updated: 2026-06-01
+---
+
+# Patterns
+
+No patterns in this fixture.

--- a/test/fixtures/smoke-project/package.json
+++ b/test/fixtures/smoke-project/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "mex-smoke-fixture",
+  "private": true
+}

--- a/test/fixtures/smoke-project/src/index.ts
+++ b/test/fixtures/smoke-project/src/index.ts
@@ -1,0 +1,1 @@
+// Smoke fixture entry point for path drift checks.

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,0 +1,14 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const cli = join(repoRoot, "dist", "cli.js");
+
+export default function setup(): void {
+  execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
+  if (!existsSync(cli)) {
+    throw new Error(`CLI build failed: ${cli} not found before running tests`);
+  }
+}

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,5 +10,17 @@ export default function setup(): void {
   execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
   if (!existsSync(cli)) {
     throw new Error(`CLI build failed: ${cli} not found before running tests`);
+  }
+
+  const probe = spawnSync(process.execPath, [cli, "--version"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, MEX_TELEMETRY: "0", NO_COLOR: "1" },
+  });
+  if (probe.status !== 0) {
+    const detail = [probe.stdout, probe.stderr].filter(Boolean).join("\n");
+    throw new Error(
+      `CLI probe failed (run npm install if dependencies are missing): ${detail}`,
+    );
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    globalSetup: ["./test/global-setup.ts"],
     // Tests must NEVER emit real telemetry to PostHog. The dev-repo guard only
     // catches commands run from inside this repo; tests spawn the built CLI in
     // temp dirs where that guard does not fire, so disable telemetry globally.


### PR DESCRIPTION
## Summary

- Add `test/fixtures/smoke-project/` minimal `.mex` scaffold
- Add `test/cli-smoke.test.ts` running top-level commands (`--version`, `commands`, `check`, `doctor`, `log`, `timeline`, `heartbeat`, `sync`, `setup`, `init`, `watch`) with exit-code and output assertions
- `--version` is asserted against `package.json` so a hard-coded version drift would fail CI

Closes #57

## Test plan

- [x] `npm test -- test/cli-smoke.test.ts`
- [x] `npm run typecheck`
