### PR TITLE
fix: skip HTML comments in checkBrokenLinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **checkBrokenLinks false positives from HTML comments** — `checkBrokenLinks` now skips links inside HTML comments (`<!-- ... -->`), both single-line and multi-line. Previously, template examples in comments (e.g., in `patterns/INDEX.md`) were flagged as broken links.
+
 ## [0.6.1] - 2026-06-14
 
 ### Added

--- a/src/drift/checkers/broken-link.ts
+++ b/src/drift/checkers/broken-link.ts
@@ -24,7 +24,7 @@ export function checkBrokenLinks(
     const fileDir = dirname(filePath);
     // Strip complete HTML comments before line processing. Unclosed <!-- stays
     // as plain text (matches checkIndexSync behavior).
-    const lines = content.replace(/<!--[\s\S]*?-->/g, "").split("\n");
+    const lines = content.replace(/<!--[\s\S]*?-->/g, (m) => "\n".repeat(m.split("\n").length - 1)).split("\n");
     let inFence = false;
 
     for (let i = 0; i < lines.length; i++) {

--- a/src/drift/checkers/broken-link.ts
+++ b/src/drift/checkers/broken-link.ts
@@ -22,7 +22,9 @@ export function checkBrokenLinks(
     }
 
     const fileDir = dirname(filePath);
-    const lines = content.split("\n");
+    // Strip complete HTML comments before line processing. Unclosed <!-- stays
+    // as plain text (matches checkIndexSync behavior).
+    const lines = content.replace(/<!--[\s\S]*?-->/g, "").split("\n");
     let inFence = false;
 
     for (let i = 0; i < lines.length; i++) {

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -595,4 +595,50 @@ describe("checkBrokenLinks", () => {
     expect(issues).toHaveLength(1);
     expect(issues[0].severity).toBe("warning");
   });
+
+  it("ignores links inside HTML comments", () => {
+    const file = join(tmpDir, "INDEX.md");
+    writeFileSync(
+      file,
+      "# Index\n\n<!-- Example: [foo.md](foo.md) -->\n\n| Pattern | Use |\n|---|---|\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("ignores links inside multi-line HTML comments", () => {
+    const file = join(tmpDir, "INDEX.md");
+    writeFileSync(
+      file,
+      "# Index\n\n<!--\n[foo.md](foo.md)\n[bar.md](bar.md)\n-->\n\nReal content.\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("scans links after an unclosed HTML comment as plain text", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "guide.md");
+    // Unclosed <!-- stays as plain text; link after it should still be checked
+    writeFileSync(
+      file,
+      "# Guide\n\n<!-- this comment never closes\n\nSee [missing](./context/nowhere.md).\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("nowhere.md");
+  });
+
+  it("scans links on lines with inline HTML comments", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    writeFileSync(join(tmpDir, "context/target.md"), "# Target\n");
+    const file = join(tmpDir, "guide.md");
+    // Link before comment should be scanned; link inside comment should not
+    writeFileSync(
+      file,
+      "[real](./context/target.md) <!-- [fake](./missing.md) -->\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
 });

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -594,6 +594,7 @@ describe("checkBrokenLinks", () => {
     const issues = checkBrokenLinks([file], tmpDir, tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].severity).toBe("warning");
+    expect(issues[0].line).toBe(1);
   });
 
   it("ignores links inside HTML comments", () => {
@@ -627,6 +628,7 @@ describe("checkBrokenLinks", () => {
     const issues = checkBrokenLinks([file], tmpDir, tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].message).toContain("nowhere.md");
+    expect(issues[0].line).toBe(5);
   });
 
   it("scans links on lines with inline HTML comments", () => {
@@ -640,5 +642,29 @@ describe("checkBrokenLinks", () => {
     );
     const issues = checkBrokenLinks([file], tmpDir, tmpDir);
     expect(issues).toHaveLength(0);
+  });
+
+  it("reports correct line numbers for broken links after multi-line HTML comments", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "guide.md");
+    writeFileSync(
+      file,
+      "# Doc\n\n<!--\ncomment body\n-->\n\n[broken](./context/nowhere.md)\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(7);
+  });
+
+  it("reports correct line numbers for broken links after single-line HTML comments", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "guide.md");
+    writeFileSync(
+      file,
+      "# Doc\n\n<!-- some note -->\n\n[broken](./context/nowhere.md)\n",
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].line).toBe(5);
   });
 });


### PR DESCRIPTION
## What

`checkBrokenLinks` now strips complete `<!-- ... -->` HTML comment spans before scanning for links. Previously, links inside HTML comments were flagged as broken — producing false `BROKEN_LINK` warnings in scaffold files like `patterns/INDEX.md` where template examples live in comment blocks.

Unclosed `<!--` (no matching `-->`) is left as plain text, consistent with `checkIndexSync`'s behavior.

**Line numbering fix:** The initial implementation stripped comments with an empty replacement, which collapsed line numbers for any real broken links appearing after a comment block. The replacement now preserves newline characters so the line array stays the same length as the original file — reported line numbers match the actual source location.

## Why

The `patterns/INDEX.md` template generated by `mex setup` includes example links inside HTML comments. After setup, running `mex check` on the scaffold produced 7 false `BROKEN_LINK` warnings from these comment examples — dropping the score to 79/100 even when the scaffold is otherwise correct.

Verified against [`Taegost/homelab-k8s` (`feat/mex-integration` branch)](https://github.com/Taegost/homelab-k8s/tree/feat/mex-integration).

## Changes

- `src/drift/checkers/broken-link.ts` — Strip `<!-- ... -->` from content before line processing, replacing with newline-preserving padding so line numbers remain accurate
- `test/checkers.test.ts` — 4 new tests: single-line comments, multi-line comments, inline comments with surrounding content, unclosed comments. Added `line` assertions to 2 existing tests. 2 regression tests verifying correct line numbers for broken links after single-line and multi-line HTML comments.
- `CHANGELOG.md` — Entry under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

The additions vs. the original:
- New "Line numbering fix" paragraph under "What" explaining the follow-up commit
- Updated the broken-link.ts bullet to mention newline-preserving padding
- Updated the checkers.test.ts bullet to mention the line assertions and regression tests