### PR TITLE
feat: add Pi coding agent to supported tool configs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -117,7 +117,7 @@ interface MexPersistedConfig {
   [key: string]: unknown;
 }
 
-const VALID_AI_TOOLS = new Set<string>(["claude", "cursor", "windsurf", "copilot", "opencode", "codex"]);
+const VALID_AI_TOOLS = new Set<string>(["claude", "cursor", "windsurf", "copilot", "opencode", "codex", "pi"]);
 
 function loadAiTools(raw: MexPersistedConfig | null): AiTool[] {
   const arr = raw?.aiTools;

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -55,6 +55,7 @@ const TOOL_CONFIGS: Record<string, { src: string; dest: string }> = {
   "4": { src: ".tool-configs/copilot-instructions.md", dest: ".github/copilot-instructions.md" },
   "5": { src: ".tool-configs/opencode.json", dest: ".opencode/opencode.json" },
   "6": { src: ".tool-configs/CLAUDE.md", dest: "AGENTS.md" },  // Codex reads AGENTS.md at root
+  "7": { src: ".tool-configs/CLAUDE.md", dest: "AGENTS.md" },  // Pi reads AGENTS.md at startup
 };
 
 // ── Helpers ──
@@ -346,6 +347,7 @@ const TOOL_CHOICE_MAP: Record<string, AiTool> = {
   "4": "copilot",
   "5": "opencode",
   "6": "codex",
+  "7": "pi",
 };
 
 async function selectToolConfig(
@@ -361,11 +363,12 @@ async function selectToolConfig(
   console.log("  4) GitHub Copilot");
   console.log("  5) OpenCode");
   console.log("  6) Codex (OpenAI)");
-  console.log("  7) Multiple (select next)");
-  console.log("  8) None / skip");
+  console.log("  7) Pi");
+  console.log("  8) Multiple (select next)");
+  console.log("  9) None / skip");
   console.log();
 
-  const choice = (await rl.question("Choice [1-8] (default: 1): ")).trim() || "1";
+  const choice = (await rl.question("Choice [1-9] (default: 1): ")).trim() || "1";
 
   let selectedClaude = false;
   const selectedTools: AiTool[] = [];
@@ -409,16 +412,17 @@ async function selectToolConfig(
     case "4":
     case "5":
     case "6":
+    case "7":
       copyConfig(choice);
       break;
-    case "7": {
-      const multi = (await rl.question("Enter tool numbers separated by spaces (e.g. 1 2 5): ")).trim();
+    case "8": {
+      const multi = (await rl.question("Enter tool numbers separated by spaces (e.g. 1 2 5 7): ")).trim();
       for (const c of multi.split(/\s+/)) {
         copyConfig(c);
       }
       break;
     }
-    case "8":
+    case "9":
       info("Skipped tool config — AGENTS.md in .mex/ works with any tool that can read files");
       break;
     default:

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -186,7 +186,7 @@ export async function runSync(
         case "1":
           if (!syncTool) {
             console.log(chalk.yellow("No supported AI CLI detected. Falling back to prompts mode."));
-            console.log(chalk.dim("Supported CLIs: claude, opencode, codex"));
+            console.log(chalk.dim("Supported CLIs: claude, opencode, codex, pi"));
             console.log();
             mode = "prompts";
           } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 
 // ── AI Tool ──
 
-export type AiTool = "claude" | "cursor" | "windsurf" | "copilot" | "opencode" | "codex";
+export type AiTool = "claude" | "cursor" | "windsurf" | "copilot" | "opencode" | "codex" | "pi";
 
 export interface AiToolMeta {
   name: string;
@@ -18,6 +18,7 @@ export const AI_TOOLS: Record<AiTool, AiToolMeta> = {
   copilot:  { name: "Copilot",     cli: null,       promptFlag: [] },
   opencode: { name: "OpenCode",    cli: "opencode", promptFlag: ["run"] },
   codex:    { name: "Codex",       cli: "codex",    promptFlag: [] },
+  pi:       { name: "Pi",          cli: "pi",       promptFlag: ["-p"] },
 };
 
 // ── Config ──

--- a/templates/.tool-configs/README.md
+++ b/templates/.tool-configs/README.md
@@ -13,6 +13,7 @@ Most embed the same content — a pointer to `.mex/ROUTER.md`. OpenCode uses a J
 | GitHub Copilot | `copilot-instructions.md` → copy to `.github/` in project root |
 | OpenCode | `opencode.json` → copy to `.opencode/` in project root |
 | Codex (OpenAI) | Copy `CLAUDE.md` as `AGENTS.md` to project root |
+| Pi | Copy `CLAUDE.md` as `AGENTS.md` to project root |
 | Any other tool | Point agent to `.mex/AGENTS.md` |
 
 ## Setup
@@ -36,6 +37,9 @@ mkdir -p .github && cp .tool-configs/copilot-instructions.md ./.github/copilot-i
 mkdir -p .opencode && cp .tool-configs/opencode.json ./.opencode/opencode.json
 
 # Codex (OpenAI)
+cp .tool-configs/CLAUDE.md ./AGENTS.md
+
+# Pi
 cp .tool-configs/CLAUDE.md ./AGENTS.md
 ```
 


### PR DESCRIPTION
## What

Add Pi coding agent to the list of supported AI tools in mex.

## Why

Pi is an open-source coding agent that reads AGENTS.md at startup from the project root (same as Codex). Adding native support allows users to select Pi during `mex setup` and use `mex sync` with Pi CLI for auto-repair.

## Changes

- `src/types.ts`: Add "pi" to AiTool union, add AI_TOOLS.pi with cli: "pi", promptFlag: ["-p"]
- `src/config.ts`: Add "pi" to VALID_AI_TOOLS
- `src/setup/index.ts`: Pi as option 7 in menu (renumber Multiple→8, None→9)
- `src/sync/index.ts`: Add "pi" to supported CLIs message
- `templates/.tool-configs/README.md`: Add Pi to table and examples

## How it works

- `mex setup` → select "7) Pi" → copies CLAUDE.md as AGENTS.md to project root
- Pi reads AGENTS.md at startup → loads routing table from ROUTER.md
- `mex sync` → detects pi CLI → runs `pi -p "<brief>"` for auto-repair

## How to test

1. `npm install && npm run build`
2. `mkdir /tmp/test && cd /tmp/test && git init`
3. `node dist/cli.js setup` → select 7) Pi
4. Verify AGENTS.md in project root
5. Run `pi` → verify it reads AGENTS.md and ROUTER.md
6. `node dist/cli.js check` → verify drift detection

## Checklist

- [x] Tests pass (245/245)
- [x] Type check passes
- [x] Build succeeds
- [x] No breaking changes
- [x] Tested locally