### PR TITLE
Filter English stopwords out of graph scope's exact-match boost

### DIFF
--- a/src/graph/__tests__/scope.test.ts
+++ b/src/graph/__tests__/scope.test.ts
@@ -106,6 +106,19 @@ describe("scored scope selection", () => {
     expect(matchedCount).toBeGreaterThan(1);
   });
 
+  it("does not let stopword tokens in the task phrasing win an exact-match boost", () => {
+    const onNode = node("function:on", "on", 1);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query: string) => (query === "on" ? [onNode] : [])),
+      getNode: (id) => (id === onNode.id ? onNode : null),
+      getCallers: () => [], getCallees: () => [],
+    };
+    const { candidates } = selectScope(graph, "find every call site that invokes mark_failed on a model", 10);
+    const onCandidate = candidates.find((c) => c.id === "function:on");
+    expect(onCandidate).toBeUndefined();
+  });
+
   it("routes test-file nodes into the test quota bucket", () => {
     const testNode = node("function:seed", "seed", 2, { filePath: "src/__tests__/seed.test.ts", signature: "s" });
     const graph: GraphEngine = {

--- a/src/graph/scope.ts
+++ b/src/graph/scope.ts
@@ -78,9 +78,28 @@ function isTestNode(node: GraphNode): boolean {
   return /(^|\/)(__tests__|tests?)\//.test(node.filePath) || /\.(test|spec)\./.test(node.filePath);
 }
 
-/** Identifier-like tokens in a task string (drops trivial 1-char fragments). */
+// Exact-name-match tokens get a flat 1.0 score (see selectScope) so an
+// explicitly named symbol survives trimming. Without this list, English
+// function words and generic task-instruction verbs collide with real but
+// semantically empty identifiers (Ruby `on:`/`to:` DSL params, ActiveRecord
+// `find`) and outrank the actually relevant symbol in the task phrasing.
+const TASK_STOPWORDS = new Set([
+  "a", "an", "the", "of", "to", "in", "on", "at", "by", "for", "with", "from",
+  "up", "so", "is", "it", "as", "be", "or", "and", "not", "no", "do", "if",
+  "that", "this", "which", "into", "over", "out", "its", "every", "each",
+  "all", "any", "some", "find", "list", "trace", "locate", "show", "get",
+  "invoke", "invokes", "call", "calls",
+]);
+
+/** Identifier-like tokens in a task string (drops trivial fragments and stopwords). */
 function taskTokens(task: string): string[] {
-  return [...new Set(task.split(/[^A-Za-z0-9_$]+/).filter((t) => t.length >= 2))];
+  return [
+    ...new Set(
+      task
+        .split(/[^A-Za-z0-9_$]+/)
+        .filter((t) => t.length >= 2 && !TASK_STOPWORDS.has(t.toLowerCase())),
+    ),
+  ];
 }
 
 /**


### PR DESCRIPTION
## What

`graph scope`'s exact-match scoring in `src/graph/scope.ts` had no stopword filtering. `taskTokens()` split the free-text task string on non-identifier characters and gave every token >=2 chars a flat `1.0` "exact-name-match" boost whenever it collided with any real identifier in the repo.

In practice, task phrasing is full of English function words and generic task-instruction verbs ("on", "to", "of", "up", "find", "trace"...) that routinely collide with trivial in-repo identifiers — Ruby DSL params (`on:`), block args, ActiveRecord's `find` — and those collisions outrank the actually relevant symbol.

Repro (see #115 for the full writeup): `mex graph scope "find every call site that invokes mark_failed! on a model"` returned the literal identifier `on` at score `1.0` five times as the top hits; the real target never made it into the top 10 at all.

## Fix

Added a `TASK_STOPWORDS` set (English function words + generic task-instruction verbs) and filtered them out of `taskTokens()` before the exact-match loop runs. Whole-task semantic search (bm25-ranked, via `graph.searchNodes(task, ...)`) is untouched — this only scopes the flat-1.0 exact-match boost, which is the specific mechanism that was letting stopwords dominate.

## Verification

- Added a regression test (`scope.test.ts`) reproducing the exact collision.
- `npx vitest run` — 11/11 in `scope.test.ts`; full suite 376/377 (the one failure is the pre-existing, unrelated `tui.test.ts` issue also called out in #116).
- `npx tsc --noEmit` — clean.
- Rebuilt `dist/` and re-ran the three real repro queries against a ~1600-file Rails codebase: all three now surface the correct symbol at or near the top of the ranking with no stopword noise.

## Related

- #115 — full writeup with repro steps and a blind grep-vs-mex eval.
- #116 — the Ruby/Prism extractor PR from the same investigation (independent change, no overlap with this one).
