### PR TITLE
docs(agents): stop steering agents away from Grep for code search

### DIFF
--- a/.mex/.tool-configs/.cursorrules
+++ b/.mex/.tool-configs/.cursorrules
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/.mex/.tool-configs/.windsurfrules
+++ b/.mex/.tool-configs/.windsurfrules
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/.mex/.tool-configs/CLAUDE.md
+++ b/.mex/.tool-configs/CLAUDE.md
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/.mex/.tool-configs/copilot-instructions.md
+++ b/.mex/.tool-configs/copilot-instructions.md
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/templates/.tool-configs/.cursorrules
+++ b/templates/.tool-configs/.cursorrules
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/templates/.tool-configs/.windsurfrules
+++ b/templates/.tool-configs/.windsurfrules
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/templates/.tool-configs/copilot-instructions.md
+++ b/templates/.tool-configs/copilot-instructions.md
@@ -32,10 +32,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -35,10 +35,12 @@ last_updated: [YYYY-MM-DD]
      - Build: `npm run build` -->
 
 ## Code Graph
-The repo is indexed into `.mex/graph.db`. Prefer graph commands over grepping or reading files.
-- Explore a task with `mex graph scope "<task>"` first — it returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Treat any source the graph returns as ALREADY READ; do not re-open those files.
+The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
+- If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
+- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
+- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
 - Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
-- If you already know the symbol, skip scope: use `mex graph query <who-calls|what-calls|where-defined> <symbol>`, or `mex graph get <id>`.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
 - If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.


### PR DESCRIPTION
## What

Rewrites the `## Code Graph` guidance block in all five shipped tool configs (`AGENTS.md`, `CLAUDE.md`, `copilot-instructions.md`, `.cursorrules`, `.windsurfrules`) and this repo's own `.mex/.tool-configs/`.

## Why

The old wording opened with:

> Prefer graph commands over grepping or reading files.
> - Explore a task with `mex graph scope "<task>"` first …
> - If you already know the symbol, skip scope: use `mex graph query …`

That makes `graph scope` the first command an agent runs on every task, and positions the reliable path (`graph query`) as the exception.

`scope` matches lexically — FTS5 plus name scoring. When a task's phrasing does not share vocabulary with the code, it returns weak results. Measured on this repository, a scope response is ~1,200 tokens against ~200-500 for `graph query`, and on natural-language questions the expected symbol is frequently absent.

The old wording then discouraged the fallback that would have worked. The observed pattern is: run `scope`, get a weak manifest, expand node ids that do not help, grep anyway. Every step is billed, and correctness is preserved only because the agent eventually ignores the instruction.

External measurement in #115 found mex costing 1.3-1.7x plain grep's session tokens across three real tasks while reaching the same answers on two of them. This guidance is part of that cost.

## Changes

- `graph query` / `graph get` lead: exact and cheap when the symbol name is known. Notes that an approximate name can return a confident wrong match (`where-defined ledger` resolves to `planSource`, because FTS matches a parameter name in a signature).
- `scope` is framed as a starting point for unfamiliar tasks, with an explicit statement that it matches words rather than meaning, and should never be treated as a complete answer.
- Explicit permission to use Grep/Glob when the manifest does not contain what is needed, with a cap of one `scope` rephrasing.
- `Treat any source the graph DOES return as ALREADY READ` is retained — that instruction is sound and avoids real duplicate reads.

## Scope

Documentation only. No code, no schema, no CLI behaviour changes. The underlying retrieval issues are tracked separately; this stops the guidance from amplifying them while they are fixed.

## Verification

`npm run build` clean, `npx vitest run` 369/369 passing.
