### PR TITLE
docs: honest results framing, CODEOWNERS, and a stale eval fixture

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners are requested for review automatically when a pull request
+# touches a matching path. Patterns are gitignore-style; the LAST matching
+# rule wins. Owners must have write access to the repository, otherwise the
+# rule is silently ignored.
+
+# Default owner for everything in the repo.
+*       @theDakshJaitly

--- a/README.md
+++ b/README.md
@@ -191,13 +191,26 @@ Agent-facing graph commands use deterministic JSONL envelopes so tools can relia
 
 ## Results
 
-On the mex repository benchmark:
+### What the graph catches that grep does not
+
+The graph resolves call sites structurally, so it finds calls whose syntax a regex would have to anticipate. In an independent blind evaluation on a 1,600-file Rails codebase, mex enumerated 23/23 call sites of a method where a `\.method_name` regex found 15/23 — the eight it missed were bare self-calls with no explicit receiver, and nothing in the grep output signalled the answer was incomplete ([#115](https://github.com/mex-memory/mex/issues/115)). That is the failure mode the graph exists to prevent.
+
+### Retrieval payload size
+
+`graph scope` returns a compact fact set instead of whole files. On the mex repository, across six symbol-lookup tasks:
 
 | Measurement | Result |
 |---|---:|
-| Full repository corpus ÷ graph scope | **916.38×** |
-| Grep top-3 output ÷ graph scope | **10.74×** |
+| ÷ full repository corpus | **916.38×** smaller |
+| ÷ entire contents of grep's top-3 files | **10.74×** smaller |
 | Expected-symbol recall | **100%** |
+
+Both ratios measure **retrieval output size only**. The denominator is the complete text of the files an agent would otherwise open — not the token cost of a real agent session, which these numbers do not measure. See the caveat below.
+
+### Real-agent task completion
+
+| Measurement | Result |
+|---|---:|
 | Minimal-context agent tasks completed | **5/5** |
 | Minimal-context tasks requiring fallback Read/Grep | **0/5** |
 | Inline-source tasks requiring fallback Read/Grep | **4/5** |
@@ -211,7 +224,9 @@ The measured repository contained:
 - 2,892 relationships
 - approximately 7.2 seconds to build the graph
 
-These are directional results from one repository, six scripted retrieval tasks, and five real-agent tasks. They demonstrate compact retrieval behavior, not a universal end-to-end graph-versus-no-graph token-savings claim.
+These are directional results from one repository, six scripted retrieval tasks, and five real-agent tasks.
+
+**What these numbers do not show.** The harness does not run an agent with the graph against the same agent using only Read/Grep/Glob, so none of the above supports an end-to-end graph-versus-no-graph token-savings claim. Independent measurement on a large Rails codebase found mex spending 1.3–1.7× grep's total session tokens across three real tasks — winning decisively on the call-site enumeration above, and tying on the other two ([#115](https://github.com/mex-memory/mex/issues/115)). A smaller payload per call does not automatically recover the cost of extra round-trips. The controlled three-arm experiment that would settle this is specified in [`evaluate/README.md`](evaluate/README.md).
 
 See the [benchmark results](evaluate/RESULTS.md) and [evaluation harness](evaluate/README.md) for the methodology, raw results, caveats, and reproduction commands.
 

--- a/evaluate/fixtures/nl-tasks.json
+++ b/evaluate/fixtures/nl-tasks.json
@@ -14,8 +14,8 @@
   {
     "id": "budget",
     "query": "How is the output token budget enforced during graph retrieval?",
-    "expected": ["BudgetedEmitter"],
-    "rubric": ["BudgetedEmitter"]
+    "expected": ["BudgetLedger"],
+    "rubric": ["BudgetLedger"]
   },
   {
     "id": "compact-fact",


### PR DESCRIPTION
Three separable commits, all following from the findings in #115.

## 1. README results framing

The Results table led with **916.38x** and **10.74x** under a bare "Results" heading. Both numbers are accurate for what they compute, but neither measures what a reader assumes.

The denominator in `evaluate/lib/grep-baseline.mjs` is `ceil(chars/4)` over the **entire contents of grep's top-3 files**, and no agent runs in that harness at all. It is a retrieval-payload ratio against a favourable baseline. `evaluate/README.md` already states plainly that the harness cannot support an end-to-end graph-versus-no-graph claim; the top-level README did not carry that across.

Independent measurement on a 1,600-file Rails codebase found mex spending 1.3-1.7x grep's total session tokens across three real tasks. A smaller payload per call does not recover the cost of extra round-trips, each of which re-sends full context.

Changes:
- Lead with the correctness result — 23/23 call sites found where a `\.method_name` regex found 15/23, the missing eight being bare self-calls with no explicit receiver. That is the claim the data supports, and it is the stronger argument.
- State the denominator inline in the table so the ratio cannot be misread.
- Replace the soft closing caveat with the measured 1.3-1.7x finding and a pointer to the three-arm experiment `evaluate/README.md` specifies.

## 2. CODEOWNERS

Contributors had no way to tell who reviews what, and were asking directly in issue threads. Starts minimal with a single default owner. The header comment records the three rules that make CODEOWNERS silently do nothing: last match wins, owners need write access, and it is advisory unless branch protection requires it.

## 3. Stale eval fixture

`evaluate/fixtures/nl-tasks.json` expected `BudgetedEmitter` for the budget task. That symbol does not exist anywhere in `src/` and appears only in the fixture. The task was unpassable, so every natural-language retrieval measurement — including ones taken before this branch — was scored against a target that could not be hit.

The budget is enforced by `BudgetLedger` (`src/graph/agent-protocol.ts`, constructed in `cli-agent.ts#beginResponse`). Correcting it raises measured baseline recall on the NL fixture set from 3/7 to 4/7 with no code change.

## Scope

Documentation, config, and one test fixture. No source changes.

## Verification

`npm run build` clean, `npx vitest run` 369/369 passing.
