### PR TITLE
chore(release): 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-05
+
+### Changed
+- Agent guidance in the shipped tool configs now describes when to use each graph command, rather than preferring graph commands over text search in all cases. `mex graph query` and `mex graph get` lead when a symbol name is known — they are exact and typically 200-500 output tokens. `mex graph scope` is positioned as a starting point for unfamiliar tasks, with an explicit note that it matches on words rather than meaning, so a task phrased in vocabulary the code does not use will return weak results.
+- Agents are now told to fall back to Grep/Glob when a scope manifest does not contain what they need, and to rephrase a scope task at most once. The previous wording discouraged text search, which could lead an agent to spend additional calls expanding a manifest that was not going to answer the question.
+- Applied to `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, `.windsurfrules`, and `.github/copilot-instructions.md`.
+
+### Note for existing scaffolds
+Upgrading does not modify an existing `.mex/` scaffold. To pick up the new guidance, replace the `## Code Graph` section of your tool config files with the version in `templates/AGENTS.md`.
+
 ## [0.7.0] - 2026-07-25
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mex-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mex-agent",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mex-agent",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Persistent project memory and deterministic local code graphs for AI coding agents",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release carrying the agent guidance fix merged in #119. Documentation and tool-config changes only — no source, schema, or CLI behaviour changes.

## Contents

- `package.json` / `package-lock.json` -> `0.7.1`
- `CHANGELOG.md` entry

`src/version.ts` reads the version from `package.json` at runtime, so there is no second place to bump.

## Why a release rather than waiting

The guidance in #119 only reaches users through the published package — `templates/` ships via the `files` whitelist, and `mex setup` copies from it. Until it is published, the fix is only on GitHub.

## Known limitation, stated in the changelog

Upgrading does **not** rewrite an existing `.mex/` scaffold. Tool configs are copied at setup time (`src/setup/index.ts`), and there is no refresh command, so existing users keep the old `## Code Graph` block. The changelog tells them to replace that section from `templates/AGENTS.md`.

Extending `src/drift/checkers/tool-config-sync.ts` to flag a stale Code Graph block against the shipped template would close this automatically and is worth a follow-up — that checker already compares tool configs to each other.

## Verification

- `npm run build` clean, including DTS and `.wasm`/schema asset copy
- `npx vitest run` 369/369 passing (four consecutive full runs)
- `npm pack --dry-run`: `mex-agent-0.7.1.tgz`, 38 files, 1.1 MB packed / 8.3 MB unpacked
- Confirmed `templates/AGENTS.md`, `templates/.tool-configs/*`, `dist/cli.js`, and `dist/schema.sql` are all in the tarball, and that the shipped templates carry the new guidance text

One intermittent full-suite failure was observed twice earlier in the session and could not be reproduced across four subsequent runs; CI on #119 passed on both Node 22 and 24. `test/cli.test.ts` shells out to `npm run build` from inside the suite, which is a plausible race against parallel tests reading `dist/`. Worth a separate look; not treated as a blocker here.

## Not included

#120 (README results framing, CODEOWNERS, eval fixture) is deliberately held back for a later release.
