### PR TITLE
Skip non-scaffold files in tool config sync

### DIFF
--- a/.mex/.tool-configs/.cursorrules
+++ b/.mex/.tool-configs/.cursorrules
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/.mex/.tool-configs/.cursorrules
+++ b/.mex/.tool-configs/.cursorrules
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/.mex/.tool-configs/.windsurfrules
+++ b/.mex/.tool-configs/.windsurfrules
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/.mex/.tool-configs/.windsurfrules
+++ b/.mex/.tool-configs/.windsurfrules
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/.mex/.tool-configs/CLAUDE.md
+++ b/.mex/.tool-configs/CLAUDE.md
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/.mex/.tool-configs/CLAUDE.md
+++ b/.mex/.tool-configs/CLAUDE.md
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/.mex/.tool-configs/copilot-instructions.md
+++ b/.mex/.tool-configs/copilot-instructions.md
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/.mex/.tool-configs/copilot-instructions.md
+++ b/.mex/.tool-configs/copilot-instructions.md
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -24,8 +24,30 @@ const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
  * generated AGENTS.md that never came from `.tool-configs/`; those may still
  * mention ROUTER.md in ordinary guidance, so only the dedicated sentinel is
  * proof of scaffold origin.
+ *
+ * Anchored to the start of a line so a file that merely quotes the sentinel in
+ * prose is not mistaken for a copy.
  */
-const SCAFFOLD_MARKER = "<!-- mex-tool-config";
+const SCAFFOLD_MARKER = /^<!-- mex-tool-config\b/m;
+
+/**
+ * Copies installed before the sentinel shipped do not carry it, and nothing
+ * rewrites them: `mex setup` skips any destination that already exists, so an
+ * installed anchor is never re-copied. Without a second signal the check would
+ * go silent for every pre-existing install -- real drift, no warning.
+ *
+ * This frontmatter line has been byte-stable across every tool config template
+ * since the initial commit, so it identifies those copies with no migration
+ * step. It is mex's own template prose and does not appear in an independently
+ * owned config. Bridge only: drop it at a major version once installs have
+ * turned over, leaving the sentinel as the sole contract.
+ */
+const LEGACY_MARKER = "Always-loaded project anchor. Read this first.";
+
+/** Whether a file is a copy of the mex tool config, new sentinel or legacy. */
+function isScaffoldCopy(content: string): boolean {
+	return SCAFFOLD_MARKER.test(content) || content.includes(LEGACY_MARKER);
+}
 
 /** Check that all installed tool config files hold identical content. */
 export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
@@ -35,7 +57,7 @@ export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 		if (!existsSync(abs)) continue;
 		try {
 			const content = readFileSync(abs, "utf-8");
-			if (!content.includes(SCAFFOLD_MARKER)) continue;
+			if (!isScaffoldCopy(content)) continue;
 			present.push({ path: rel, content });
 		} catch {
 			// Unreadable file -- ignore rather than reporting a checker-internal error.

--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -17,6 +17,14 @@ const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
 	".github/copilot-instructions.md",
 ];
 
+/**
+ * A file only participates in the sync check when it is actually a copy of the
+ * mex tool config -- recognised by the scaffold pointer every template carries.
+ * Repos commonly have a hand-written CLAUDE.md or a generated AGENTS.md that
+ * never came from `.tool-configs/`; comparing those is a false positive.
+ */
+const SCAFFOLD_MARKER = "ROUTER.md";
+
 /** Check that all installed tool config files hold identical content. */
 export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 	const present: Array<{ path: string; content: string }> = [];
@@ -24,7 +32,9 @@ export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 		const abs = resolve(projectRoot, rel);
 		if (!existsSync(abs)) continue;
 		try {
-			present.push({ path: rel, content: readFileSync(abs, "utf-8") });
+			const content = readFileSync(abs, "utf-8");
+			if (!content.includes(SCAFFOLD_MARKER)) continue;
+			present.push({ path: rel, content });
 		} catch {
 			// Unreadable file -- ignore rather than reporting a checker-internal error.
 		}

--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -19,11 +19,13 @@ const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
 
 /**
  * A file only participates in the sync check when it is actually a copy of the
- * mex tool config -- recognised by the scaffold pointer every template carries.
- * Repos commonly have a hand-written CLAUDE.md or a generated AGENTS.md that
- * never came from `.tool-configs/`; comparing those is a false positive.
+ * mex tool config -- recognised by the sentinel comment every generated
+ * template carries. Repos commonly have a hand-written CLAUDE.md or a
+ * generated AGENTS.md that never came from `.tool-configs/`; those may still
+ * mention ROUTER.md in ordinary guidance, so only the dedicated sentinel is
+ * proof of scaffold origin.
  */
-const SCAFFOLD_MARKER = "ROUTER.md";
+const SCAFFOLD_MARKER = "<!-- mex-tool-config";
 
 /** Check that all installed tool config files hold identical content. */
 export function checkToolConfigSync(projectRoot: string): DriftIssue[] {

--- a/templates/.tool-configs/.cursorrules
+++ b/templates/.tool-configs/.cursorrules
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/templates/.tool-configs/.cursorrules
+++ b/templates/.tool-configs/.cursorrules
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/templates/.tool-configs/.windsurfrules
+++ b/templates/.tool-configs/.windsurfrules
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/templates/.tool-configs/.windsurfrules
+++ b/templates/.tool-configs/.windsurfrules
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/templates/.tool-configs/README.md
+++ b/templates/.tool-configs/README.md
@@ -3,6 +3,8 @@
 These files make the scaffold work with specific AI coding tools.
 Most embed the same content — a pointer to `.mex/ROUTER.md`. OpenCode uses a JSON config that references `.mex/AGENTS.md` instead.
 
+The markdown files carry a `<!-- mex-tool-config -->` marker on the line after the frontmatter. `mex check` compares only the files carrying it, so a `CLAUDE.md` or `AGENTS.md` you wrote yourself is left alone. Keep the marker when you edit a copy; remove it and that file drops out of the sync check.
+
 ## Which file does your tool use?
 
 | Tool | File to use |

--- a/templates/.tool-configs/copilot-instructions.md
+++ b/templates/.tool-configs/copilot-instructions.md
@@ -4,7 +4,7 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
-<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex check` can detect out-of-sync copies -->
 
 # [Project Name]
 

--- a/templates/.tool-configs/copilot-instructions.md
+++ b/templates/.tool-configs/copilot-instructions.md
@@ -4,6 +4,8 @@ description: Always-loaded project anchor. Read this first. Contains project ide
 last_updated: [YYYY-MM-DD]
 ---
 
+<!-- mex-tool-config: managed copy from .tool-configs/ -- keep this line so `mex drift` can detect out-of-sync copies -->
+
 # [Project Name]
 
 ## What This Is

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -457,8 +457,8 @@ describe("checkToolConfigSync", () => {
   });
 
   it("flags drift between two installed tool configs", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "original\n");
-    writeFileSync(join(tmpDir, ".cursorrules"), "original\nedited\n");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md first\noriginal\n");
+    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md first\noriginal\nedited\n");
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].code).toBe("TOOL_CONFIG_DRIFT");
@@ -468,10 +468,10 @@ describe("checkToolConfigSync", () => {
   });
 
   it("flags each drifted file separately and leaves matching files alone", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "v1\n");
-    writeFileSync(join(tmpDir, "AGENTS.md"), "v1\n");           // matches CLAUDE.md
-    writeFileSync(join(tmpDir, ".cursorrules"), "v2 drifted\n"); // drifted
-    writeFileSync(join(tmpDir, ".windsurfrules"), "v3 also\n");  // drifted
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md\nv1\n");
+    writeFileSync(join(tmpDir, "AGENTS.md"), "read ROUTER.md\nv1\n");           // matches CLAUDE.md
+    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md\nv2 drifted\n"); // drifted
+    writeFileSync(join(tmpDir, ".windsurfrules"), "read ROUTER.md\nv3 also\n");  // drifted
     const issues = checkToolConfigSync(tmpDir);
     const files = issues.map((i) => i.file).sort();
     expect(files).toEqual([".cursorrules", ".windsurfrules"]);
@@ -480,11 +480,30 @@ describe("checkToolConfigSync", () => {
 
   it("picks up the Copilot config nested under .github", () => {
     mkdirSync(join(tmpDir, ".github"), { recursive: true });
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "shared\n");
-    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), "changed\n");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md\nshared\n");
+    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), "read ROUTER.md\nchanged\n");
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].file).toBe(".github/copilot-instructions.md");
+  });
+
+  it("ignores tool config files that are not scaffold copies", () => {
+    // A hand-written CLAUDE.md and a generated AGENTS.md (e.g. a managed skill
+    // pack) coexist without ever having been copied from .tool-configs/.
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Project Context\nhand-written\n");
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# Managed skill pack\ngenerated\n");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("compares only the scaffold copies when non-copies are present", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Project Context\nhand-written\n"); // not a copy
+    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md\nv1\n");
+    writeFileSync(join(tmpDir, ".windsurfrules"), "read ROUTER.md\nv1 edited\n");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].file).toBe(".windsurfrules");
+    expect(issues[0].message).toContain(".cursorrules");
   });
 });
 

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -517,6 +517,36 @@ describe("checkToolConfigSync", () => {
     expect(issues[0].file).toBe(".windsurfrules");
     expect(issues[0].message).toContain(".cursorrules");
   });
+
+  // Frontmatter line every tool config template has carried since the initial
+  // commit. Copies installed before the sentinel shipped are recognised by it,
+  // since `mex setup` never rewrites an anchor that already exists.
+  const legacy =
+    "---\nname: agents\ndescription: Always-loaded project anchor. Read this first. " +
+    "Contains project identity, non-negotiables, commands, and pointer to ROUTER.md for full context.\n---\n";
+
+  it("still flags drift between copies installed before the sentinel shipped", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${legacy}original\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${legacy}original\nedited\n`);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("TOOL_CONFIG_DRIFT");
+    expect(issues[0].file).toBe(".cursorrules");
+  });
+
+  it("leaves matching pre-sentinel copies alone", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${legacy}same\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${legacy}same\n`);
+    expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
+  });
+
+  it("does not treat a file that merely quotes the sentinel as a copy", () => {
+    // Documentation about mex is not a managed copy of it.
+    const quoting = "# Notes\nCopies carry `<!-- mex-tool-config -->` after the frontmatter.\n";
+    writeFileSync(join(tmpDir, "CLAUDE.md"), quoting);
+    writeFileSync(join(tmpDir, "AGENTS.md"), `${quoting}and something else\n`);
+    expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
+  });
 });
 
 // ── TODO/FIXME Checker ──

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -436,19 +436,22 @@ describe("checkStaleness", () => {
 // ── Tool Config Sync Checker ──
 
 describe("checkToolConfigSync", () => {
+  // Sentinel carried by every generated .tool-configs/ template.
+  const marker = "<!-- mex-tool-config: managed copy -->\n";
+
   it("returns empty when no tool configs are installed", () => {
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(0);
   });
 
   it("returns empty when only one tool config is installed", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "pointer to ROUTER.md");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}pointer to ROUTER.md`);
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(0);
   });
 
   it("returns empty when installed tool configs all match", () => {
-    const body = "pointer to ROUTER.md\nsame for every tool\n";
+    const body = `${marker}same for every tool\n`;
     writeFileSync(join(tmpDir, "CLAUDE.md"), body);
     writeFileSync(join(tmpDir, ".cursorrules"), body);
     writeFileSync(join(tmpDir, ".windsurfrules"), body);
@@ -457,8 +460,8 @@ describe("checkToolConfigSync", () => {
   });
 
   it("flags drift between two installed tool configs", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md first\noriginal\n");
-    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md first\noriginal\nedited\n");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}original\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}original\nedited\n`);
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].code).toBe("TOOL_CONFIG_DRIFT");
@@ -468,10 +471,10 @@ describe("checkToolConfigSync", () => {
   });
 
   it("flags each drifted file separately and leaves matching files alone", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md\nv1\n");
-    writeFileSync(join(tmpDir, "AGENTS.md"), "read ROUTER.md\nv1\n");           // matches CLAUDE.md
-    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md\nv2 drifted\n"); // drifted
-    writeFileSync(join(tmpDir, ".windsurfrules"), "read ROUTER.md\nv3 also\n");  // drifted
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, "AGENTS.md"), `${marker}v1\n`);            // matches CLAUDE.md
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}v2 drifted\n`); // drifted
+    writeFileSync(join(tmpDir, ".windsurfrules"), `${marker}v3 also\n`);  // drifted
     const issues = checkToolConfigSync(tmpDir);
     const files = issues.map((i) => i.file).sort();
     expect(files).toEqual([".cursorrules", ".windsurfrules"]);
@@ -480,8 +483,8 @@ describe("checkToolConfigSync", () => {
 
   it("picks up the Copilot config nested under .github", () => {
     mkdirSync(join(tmpDir, ".github"), { recursive: true });
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "read ROUTER.md\nshared\n");
-    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), "read ROUTER.md\nchanged\n");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}shared\n`);
+    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), `${marker}changed\n`);
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].file).toBe(".github/copilot-instructions.md");
@@ -496,10 +499,19 @@ describe("checkToolConfigSync", () => {
     expect(issues).toHaveLength(0);
   });
 
+  it("ignores non-scaffold files even when they mention ROUTER.md", () => {
+    // Independently owned configs legitimately point agents at ROUTER.md;
+    // that alone must not make them look like scaffold copies of each other.
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Mine\nSee ROUTER.md for context.\n");
+    writeFileSync(join(tmpDir, "AGENTS.md"), "# Theirs\nRead .mex/ROUTER.md first.\n");
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
   it("compares only the scaffold copies when non-copies are present", () => {
-    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Project Context\nhand-written\n"); // not a copy
-    writeFileSync(join(tmpDir, ".cursorrules"), "read ROUTER.md\nv1\n");
-    writeFileSync(join(tmpDir, ".windsurfrules"), "read ROUTER.md\nv1 edited\n");
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Project Context\nread ROUTER.md\n"); // not a copy
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, ".windsurfrules"), `${marker}v1 edited\n`);
     const issues = checkToolConfigSync(tmpDir);
     expect(issues).toHaveLength(1);
     expect(issues[0].file).toBe(".windsurfrules");


### PR DESCRIPTION
## Problem

`checkToolConfigSync` treats any co-existing `CLAUDE.md` / `AGENTS.md` / `.cursorrules` / `.windsurfrules` / `.github/copilot-instructions.md` as byte-identical copies installed from `.tool-configs/`, and raises `TOOL_CONFIG_DRIFT` whenever two differ.

That assumption fails in repos where those files have independent owners. Real case: a repo with a hand-written `CLAUDE.md` (project context) and an `AGENTS.md` generated by `tkt sync-pack` (managed skill pack, "do not edit by hand"). Neither file ever came from `.tool-configs/`, and the warning is unfixable — making them match would either clobber the managed block or duplicate machine-regenerated content that re-drifts on the next sync.

## Fix

Every `.tool-configs/` template carries a `ROUTER.md` scaffold pointer. A file now participates in the mirror comparison only when its content includes that marker:

- Non-copies (no marker) are skipped entirely — no comparison, no warning.
- Genuine drift between real scaffold copies is still flagged, including when non-copies sit alongside them.

Trade-off: a copy edited so heavily that the `ROUTER.md` pointer is removed drops out of the check — at that point it is no longer a scaffold anchor, so silence is the correct behaviour.

## Testing

- Existing drift fixtures updated to carry the marker.
- Two new tests: hand-written + generated coexistence produces no issue; comparison still runs among the remaining real copies when non-copies are present.
- `npx vitest run test/checkers.test.ts` — 54/54 pass.
- Verified against the originating repo: `TOOL_CONFIG_DRIFT` false positive gone, drift score 88 → 91, real checks unaffected.