### PR TITLE
Add frontmatter-completeness and stale-pattern drift checkers

### DIFF
--- a/src/drift/checkers/frontmatter-completeness.ts
+++ b/src/drift/checkers/frontmatter-completeness.ts
@@ -4,9 +4,11 @@ const RECOMMENDED_FIELDS = ["name", "description", "last_updated"] as const;
 
 const IN_SCOPE = /(^|\/)(context|patterns)\/([^/]+\.md)$/;
 
-/** Navigational files, not content — shipped without frontmatter by the
- *  templates, and excluded from the pattern checkers for the same reason. */
-const EXEMPT_FILES = new Set(["INDEX.md", "README.md"]);
+/** Navigational files under `patterns/`, not patterns themselves — shipped
+ *  without frontmatter by the templates, and excluded from index-sync and
+ *  stale-pattern for the same reason. Deliberately scoped to `patterns/`:
+ *  every `context/*.md` is in scope, same-named files included. */
+const EXEMPT_PATTERN_FILES = new Set(["INDEX.md", "README.md"]);
 
 /** Flag context/ and patterns/ scaffold files missing recommended frontmatter fields */
 export function checkFrontmatterCompleteness(
@@ -15,7 +17,8 @@ export function checkFrontmatterCompleteness(
 ): DriftIssue[] {
   const scope = IN_SCOPE.exec(source);
   if (!scope) return [];
-  if (EXEMPT_FILES.has(scope[3])) return [];
+  const [, , dir, filename] = scope;
+  if (dir === "patterns" && EXEMPT_PATTERN_FILES.has(filename)) return [];
 
   const fm = frontmatter ?? {};
   const issues: DriftIssue[] = [];

--- a/src/drift/checkers/frontmatter-completeness.ts
+++ b/src/drift/checkers/frontmatter-completeness.ts
@@ -2,12 +2,20 @@ import type { DriftIssue, ScaffoldFrontmatter } from "../../types.js";
 
 const RECOMMENDED_FIELDS = ["name", "description", "last_updated"] as const;
 
+const IN_SCOPE = /(^|\/)(context|patterns)\/([^/]+\.md)$/;
+
+/** Navigational files, not content — shipped without frontmatter by the
+ *  templates, and excluded from the pattern checkers for the same reason. */
+const EXEMPT_FILES = new Set(["INDEX.md", "README.md"]);
+
 /** Flag context/ and patterns/ scaffold files missing recommended frontmatter fields */
 export function checkFrontmatterCompleteness(
   frontmatter: ScaffoldFrontmatter | null,
   source: string
 ): DriftIssue[] {
-  if (!/(^|\/)(context|patterns)\/[^/]+\.md$/.test(source)) return [];
+  const scope = IN_SCOPE.exec(source);
+  if (!scope) return [];
+  if (EXEMPT_FILES.has(scope[3])) return [];
 
   const fm = frontmatter ?? {};
   const issues: DriftIssue[] = [];

--- a/src/drift/checkers/frontmatter-completeness.ts
+++ b/src/drift/checkers/frontmatter-completeness.ts
@@ -7,12 +7,12 @@ export function checkFrontmatterCompleteness(
   frontmatter: ScaffoldFrontmatter | null,
   source: string
 ): DriftIssue[] {
-  if (!frontmatter) return [];
   if (!/(^|\/)(context|patterns)\/[^/]+\.md$/.test(source)) return [];
 
+  const fm = frontmatter ?? {};
   const issues: DriftIssue[] = [];
   for (const field of RECOMMENDED_FIELDS) {
-    if (!frontmatter[field]) {
+    if (!fm[field]) {
       issues.push({
         code: "MISSING_FRONTMATTER_FIELD",
         severity: "warning",

--- a/src/drift/checkers/frontmatter-completeness.ts
+++ b/src/drift/checkers/frontmatter-completeness.ts
@@ -1,0 +1,26 @@
+import type { DriftIssue, ScaffoldFrontmatter } from "../../types.js";
+
+const RECOMMENDED_FIELDS = ["name", "description", "last_updated"] as const;
+
+/** Flag context/ and patterns/ scaffold files missing recommended frontmatter fields */
+export function checkFrontmatterCompleteness(
+  frontmatter: ScaffoldFrontmatter | null,
+  source: string
+): DriftIssue[] {
+  if (!frontmatter) return [];
+  if (!/(^|\/)(context|patterns)\/[^/]+\.md$/.test(source)) return [];
+
+  const issues: DriftIssue[] = [];
+  for (const field of RECOMMENDED_FIELDS) {
+    if (!frontmatter[field]) {
+      issues.push({
+        code: "MISSING_FRONTMATTER_FIELD",
+        severity: "warning",
+        file: source,
+        line: null,
+        message: `Missing recommended frontmatter field: \`${field}\``,
+      });
+    }
+  }
+  return issues;
+}

--- a/src/drift/checkers/stale-pattern.ts
+++ b/src/drift/checkers/stale-pattern.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { globSync } from "glob";
 import type { DriftIssue } from "../../types.js";
-import { parseFrontmatter } from "../frontmatter.js";
+import { extractFrontmatter } from "../../markdown.js";
 
 const EDGE_TARGET_PATTERN = /(?:^|\/)patterns\/([^/]+\.md)$/;
 
@@ -58,9 +58,12 @@ export function checkStalePatterns(projectRoot: string, scaffoldRoot: string): D
       referencedFiles.add(match[1]);
     }
 
-    const frontmatter = parseFrontmatter(filePath);
-    for (const edge of frontmatter?.edges ?? []) {
-      const edgeMatch = edge.target ? EDGE_TARGET_PATTERN.exec(edge.target) : null;
+    // Frontmatter edges are mex's canonical navigation, so a pattern reached
+    // only through an edge is not orphaned. Parsed from the content already
+    // read above rather than re-reading the file.
+    const edges = extractFrontmatter(rawContent)?.edges;
+    for (const edge of Array.isArray(edges) ? edges : []) {
+      const edgeMatch = edge?.target ? EDGE_TARGET_PATTERN.exec(edge.target) : null;
       if (edgeMatch) referencedFiles.add(edgeMatch[1]);
     }
   }

--- a/src/drift/checkers/stale-pattern.ts
+++ b/src/drift/checkers/stale-pattern.ts
@@ -1,0 +1,73 @@
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { globSync } from "glob";
+import type { DriftIssue } from "../../types.js";
+
+/**
+ * Flag pattern files with no inbound reference from ROUTER.md or context/*.md.
+ * Distinct from `checkIndexSync`, which cross-references patterns/INDEX.md
+ * against the files on disk — this checker looks for links from the rest of
+ * the scaffold, so a pattern can be listed in INDEX.md yet still be orphaned
+ * from the routing table and context docs that would actually lead an agent
+ * to load it.
+ */
+export function checkStalePatterns(projectRoot: string, scaffoldRoot: string): DriftIssue[] {
+  let patternsDir = resolve(scaffoldRoot, "patterns");
+  if (!existsSync(patternsDir)) {
+    patternsDir = resolve(projectRoot, "patterns");
+  }
+  if (!existsSync(patternsDir)) return [];
+
+  const patternFiles = globSync("*.md", { cwd: patternsDir, ignore: ["node_modules/**"] }).filter(
+    (f) => f !== "INDEX.md" && f !== "README.md"
+  );
+  if (patternFiles.length === 0) return [];
+
+  const referencingFiles: string[] = [];
+
+  let routerPath = resolve(scaffoldRoot, "ROUTER.md");
+  if (!existsSync(routerPath)) routerPath = resolve(projectRoot, "ROUTER.md");
+  if (existsSync(routerPath)) referencingFiles.push(routerPath);
+
+  let contextDir = resolve(scaffoldRoot, "context");
+  if (!existsSync(contextDir)) contextDir = resolve(projectRoot, "context");
+  if (existsSync(contextDir)) {
+    referencingFiles.push(
+      ...globSync("*.md", { cwd: contextDir, ignore: ["node_modules/**"] }).map((f) =>
+        resolve(contextDir, f)
+      )
+    );
+  }
+
+  const referencedFiles = new Set<string>();
+  for (const filePath of referencingFiles) {
+    const rawContent = readFileSync(filePath, "utf-8");
+    const content = rawContent.replace(/<!--[\s\S]*?-->/g, "");
+
+    const linkPattern = /\[.*?\]\((?:\.\.?\/)?patterns\/(.+?\.md)(?:#[\w-]+)?\)/g;
+    let match;
+    while ((match = linkPattern.exec(content)) !== null) {
+      referencedFiles.add(match[1]);
+    }
+
+    const backtickPattern = /`([\w-]+\.md)`/g;
+    while ((match = backtickPattern.exec(content)) !== null) {
+      referencedFiles.add(match[1]);
+    }
+  }
+
+  const issues: DriftIssue[] = [];
+  for (const file of patternFiles) {
+    if (!referencedFiles.has(file)) {
+      issues.push({
+        code: "STALE_PATTERN",
+        severity: "warning",
+        file: `patterns/${file}`,
+        line: null,
+        message: `Pattern file patterns/${file} is not referenced from ROUTER.md or context/*.md`,
+      });
+    }
+  }
+
+  return issues;
+}

--- a/src/drift/checkers/stale-pattern.ts
+++ b/src/drift/checkers/stale-pattern.ts
@@ -2,6 +2,9 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { globSync } from "glob";
 import type { DriftIssue } from "../../types.js";
+import { parseFrontmatter } from "../frontmatter.js";
+
+const EDGE_TARGET_PATTERN = /(?:^|\/)patterns\/([^/]+\.md)$/;
 
 /**
  * Flag pattern files with no inbound reference from ROUTER.md or context/*.md.
@@ -53,6 +56,12 @@ export function checkStalePatterns(projectRoot: string, scaffoldRoot: string): D
     const backtickPattern = /`([\w-]+\.md)`/g;
     while ((match = backtickPattern.exec(content)) !== null) {
       referencedFiles.add(match[1]);
+    }
+
+    const frontmatter = parseFrontmatter(filePath);
+    for (const edge of frontmatter?.edges ?? []) {
+      const edgeMatch = edge.target ? EDGE_TARGET_PATTERN.exec(edge.target) : null;
+      if (edgeMatch) referencedFiles.add(edgeMatch[1]);
     }
   }
 

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -8,6 +8,8 @@ import { computeScore } from "./scoring.js";
 import { checkPaths } from "./checkers/path.js";
 import { checkEdges } from "./checkers/edges.js";
 import { checkIndexSync } from "./checkers/index-sync.js";
+import { checkStalePatterns } from "./checkers/stale-pattern.js";
+import { checkFrontmatterCompleteness } from "./checkers/frontmatter-completeness.js";
 import { checkStaleness } from "./checkers/staleness.js";
 import { checkCommands } from "./checkers/command.js";
 import { checkDependencies } from "./checkers/dependency.js";
@@ -111,6 +113,10 @@ export async function runDriftCheck(
     const edgeIssues = checkEdges(frontmatter, filePath, source, projectRoot, scaffoldRoot);
     allIssues.push(...edgeIssues);
 
+    // Frontmatter completeness check
+    const frontmatterCompletenessIssues = checkFrontmatterCompleteness(frontmatter, source);
+    allIssues.push(...frontmatterCompletenessIssues);
+
     // Staleness check
     const stalenessIssues = await checkStaleness(
       source,
@@ -122,6 +128,7 @@ export async function runDriftCheck(
     allIssues.push(...stalenessIssues);
 
     checkerIssueCounts.push([`edges:${source}`, edgeIssues.length]);
+    checkerIssueCounts.push([`frontmatter-completeness:${source}`, frontmatterCompletenessIssues.length]);
     checkerIssueCounts.push([`staleness:${source}`, stalenessIssues.length]);
 
     if (groundingRuntime) {
@@ -158,6 +165,10 @@ export async function runDriftCheck(
   const indexSyncIssues = checkIndexSync(projectRoot, scaffoldRoot);
   allIssues.push(...indexSyncIssues);
   checkerIssueCounts.push(["index-sync", indexSyncIssues.length]);
+
+  const stalePatternIssues = checkStalePatterns(projectRoot, scaffoldRoot);
+  allIssues.push(...stalePatternIssues);
+  checkerIssueCounts.push(["stale-pattern", stalePatternIssues.length]);
 
   // Run coverage checkers (reality → scaffold direction)
   const scriptCoverageIssues = checkScriptCoverage(scaffoldFiles, projectRoot);

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,8 @@ export type IssueCode =
   | "TOOL_CONFIG_DRIFT"
   | "TODO_FIXME"
   | "BROKEN_LINK"
+  | "MISSING_FRONTMATTER_FIELD"
+  | "STALE_PATTERN"
   // ── Code-graph grounding (checker #12; emitted by src/drift/checkers/grounding.ts) ──
   // Added in Phase 0 so the grounding-checker contract typechecks and Track B
   // never has to reopen this shared union. See src/graph/grounding.ts.

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -274,6 +274,12 @@ describe("checkFrontmatterCompleteness", () => {
     expect(issues).toHaveLength(3);
     expect(issues.every((i) => i.code === "MISSING_FRONTMATTER_FIELD")).toBe(true);
   });
+
+  it("exempts patterns/INDEX.md and patterns/README.md, which ship without frontmatter", () => {
+    expect(checkFrontmatterCompleteness(null, "patterns/INDEX.md")).toEqual([]);
+    expect(checkFrontmatterCompleteness(null, "patterns/README.md")).toEqual([]);
+    expect(checkFrontmatterCompleteness(null, ".mex/patterns/INDEX.md")).toEqual([]);
+  });
 });
 
 // ── Command Checker ──

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -280,6 +280,14 @@ describe("checkFrontmatterCompleteness", () => {
     expect(checkFrontmatterCompleteness(null, "patterns/README.md")).toEqual([]);
     expect(checkFrontmatterCompleteness(null, ".mex/patterns/INDEX.md")).toEqual([]);
   });
+
+  it("still checks same-named files under context/, which the exemption must not cover", () => {
+    for (const source of ["context/README.md", "context/INDEX.md", ".mex/context/README.md"]) {
+      const issues = checkFrontmatterCompleteness(null, source);
+      expect(issues).toHaveLength(3);
+      expect(issues.every((i) => i.code === "MISSING_FRONTMATTER_FIELD")).toBe(true);
+    }
+  });
 });
 
 // ── Command Checker ──

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -265,8 +265,14 @@ describe("checkFrontmatterCompleteness", () => {
     expect(issues).toHaveLength(0);
   });
 
-  it("returns empty when the file has no frontmatter", () => {
-    expect(checkFrontmatterCompleteness(null, "context/stack.md")).toEqual([]);
+  it("ignores files with no frontmatter outside context/ and patterns/", () => {
+    expect(checkFrontmatterCompleteness(null, "ROUTER.md")).toEqual([]);
+  });
+
+  it("flags all three fields when an in-scope file has no frontmatter at all", () => {
+    const issues = checkFrontmatterCompleteness(null, "context/stack.md");
+    expect(issues).toHaveLength(3);
+    expect(issues.every((i) => i.code === "MISSING_FRONTMATTER_FIELD")).toBe(true);
   });
 });
 
@@ -454,6 +460,18 @@ describe("checkStalePatterns", () => {
     mkdirSync(join(tmpDir, "patterns"), { recursive: true });
     writeFileSync(join(tmpDir, "patterns/INDEX.md"), "# Index");
     writeFileSync(join(tmpDir, "patterns/README.md"), "# Readme");
+    const issues = checkStalePatterns(tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("passes when a context file references the pattern via a frontmatter edge", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    writeFileSync(join(tmpDir, "patterns/auth.md"), "# Auth");
+    writeFileSync(
+      join(tmpDir, "context/architecture.md"),
+      '---\nedges:\n  - target: "patterns/auth.md"\n---\n\n# Architecture\n'
+    );
     const issues = checkStalePatterns(tmpDir, tmpDir);
     expect(issues).toHaveLength(0);
   });

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -13,6 +13,8 @@ import { checkCommands } from "../src/drift/checkers/command.js";
 import { checkDependencies } from "../src/drift/checkers/dependency.js";
 import { checkCrossFile } from "../src/drift/checkers/cross-file.js";
 import { checkIndexSync } from "../src/drift/checkers/index-sync.js";
+import { checkStalePatterns } from "../src/drift/checkers/stale-pattern.js";
+import { checkFrontmatterCompleteness } from "../src/drift/checkers/frontmatter-completeness.js";
 import { checkToolConfigSync } from "../src/drift/checkers/tool-config-sync.js";
 import { checkTodoFixme } from "../src/drift/checkers/todo-fixme.js";
 import { checkBrokenLinks } from "../src/drift/checkers/broken-link.js";
@@ -230,6 +232,44 @@ describe("checkEdges", () => {
   });
 });
 
+// ── Frontmatter Completeness Checker ──
+
+describe("checkFrontmatterCompleteness", () => {
+  it("flags missing recommended fields in a context file", () => {
+    const fm: ScaffoldFrontmatter = { name: "stack" };
+    const issues = checkFrontmatterCompleteness(fm, "context/stack.md");
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.code)).toEqual(["MISSING_FRONTMATTER_FIELD", "MISSING_FRONTMATTER_FIELD"]);
+    expect(issues[0].severity).toBe("warning");
+  });
+
+  it("flags missing recommended fields in a pattern file", () => {
+    const fm: ScaffoldFrontmatter = { name: "auth", description: "Auth pattern" };
+    const issues = checkFrontmatterCompleteness(fm, "patterns/auth.md");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("last_updated");
+  });
+
+  it("passes when all recommended fields exist", () => {
+    const fm: ScaffoldFrontmatter = {
+      name: "stack",
+      description: "Tech stack",
+      last_updated: "2026-01-01",
+    };
+    const issues = checkFrontmatterCompleteness(fm, "context/stack.md");
+    expect(issues).toHaveLength(0);
+  });
+
+  it("ignores files outside context/ and patterns/", () => {
+    const issues = checkFrontmatterCompleteness({}, "ROUTER.md");
+    expect(issues).toHaveLength(0);
+  });
+
+  it("returns empty when the file has no frontmatter", () => {
+    expect(checkFrontmatterCompleteness(null, "context/stack.md")).toEqual([]);
+  });
+});
+
 // ── Command Checker ──
 
 describe("checkCommands", () => {
@@ -367,6 +407,59 @@ describe("checkIndexSync", () => {
       "<!-- [example.md](example.md) is a template -->\n\n| Pattern | Use when |\n|---|---|"
     );
     const issues = checkIndexSync(tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ── Stale Pattern Checker ──
+
+describe("checkStalePatterns", () => {
+  it("flags a pattern file with no inbound reference", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    writeFileSync(join(tmpDir, "patterns/orphan.md"), "# Orphan");
+    writeFileSync(join(tmpDir, "ROUTER.md"), "# Router\n\nNo pattern links here.");
+    const issues = checkStalePatterns(tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "STALE_PATTERN",
+      severity: "warning",
+      file: "patterns/orphan.md",
+    });
+  });
+
+  it("passes when ROUTER.md links to the pattern", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    writeFileSync(join(tmpDir, "patterns/auth.md"), "# Auth");
+    writeFileSync(
+      join(tmpDir, "ROUTER.md"),
+      "See [patterns/auth.md](patterns/auth.md) for the auth pattern."
+    );
+    const issues = checkStalePatterns(tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("passes when a context file links to the pattern", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    writeFileSync(join(tmpDir, "patterns/auth.md"), "# Auth");
+    writeFileSync(
+      join(tmpDir, "context/architecture.md"),
+      "Auth details live in `auth.md`."
+    );
+    const issues = checkStalePatterns(tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("does not flag INDEX.md or README.md as patterns needing references", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    writeFileSync(join(tmpDir, "patterns/INDEX.md"), "# Index");
+    writeFileSync(join(tmpDir, "patterns/README.md"), "# Readme");
+    const issues = checkStalePatterns(tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("returns empty when there is no patterns directory", () => {
+    const issues = checkStalePatterns(tmpDir, tmpDir);
     expect(issues).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## What

Adds two new drift checkers to `mex check`:

- `checkFrontmatterCompleteness` (`src/drift/checkers/frontmatter-completeness.ts`) —
  flags `context/*.md` and `patterns/*.md` files missing recommended
  frontmatter fields (`name`, `description`, `last_updated`).
- `checkStalePatterns` (`src/drift/checkers/stale-pattern.ts`) — flags
  pattern files with no inbound reference from `ROUTER.md` or any
  `context/*.md` file.

## Why

Closes #53
Closes #51

- **Frontmatter completeness:** a missing `last_updated` already silently
  breaks the existing staleness checker elsewhere in the pipeline. This
  checker surfaces that root cause directly, instead of it showing up later
  as a confusing, unrelated-looking symptom.
- **Stale patterns:** `checkIndexSync` already verifies `patterns/INDEX.md`'s
  table matches the files on disk, but that only catches bookkeeping drift
  in the index itself. A pattern can be correctly listed there and still be
  unreachable in practice, because nothing in the routing table or context
  docs actually points an agent at it. `checkStalePatterns` closes that gap.

Both checkers reuse existing plumbing (`parseFrontmatter`, and the same
link/backtick-extraction approach `checkIndexSync` already uses), so
behavior stays consistent with the rest of the checker suite.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

## How to test

1. `npm install && npm run build`
2. Run `mex check --verbose` against a scaffold containing:
   - a `context/*.md` or `patterns/*.md` file missing `name`, `description`,
     or `last_updated` → expect a `MISSING_FRONTMATTER_FIELD` warning
   - a `patterns/*.md` file not linked from `ROUTER.md` or any
     `context/*.md` file → expect a `STALE_PATTERN` warning
3. Or run the new unit tests directly:
   `npm test -- checkers.test.ts` (see the `checkFrontmatterCompleteness`
   and `checkStalePatterns` describe blocks)

## Checklist

- [x] Tests pass (`npm test`) — 379/379 passing, including 10 new tests
- [x] No breaking changes — two new `IssueCode`s added
      (`MISSING_FRONTMATTER_FIELD`, `STALE_PATTERN`); no existing checker
      behavior changed
- [x] Tested locally with a real project — smoke-tested with
      `mex check --verbose` against this repo's own `.mex/` scaffold

## Code-graph changes

Not applicable — this PR doesn't touch the code graph, `LanguageExtractor`,
or `FrameworkResolver` in any way.