### PR TITLE
 Blame the tool config that moved, not the first in the list

### DIFF
--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -49,6 +49,17 @@ function isScaffoldCopy(content: string): boolean {
 	return SCAFFOLD_MARKER.test(content) || content.includes(LEGACY_MARKER);
 }
 
+/** One copy differs from what the others agree on. */
+function drift(path: string, reference: string): DriftIssue {
+	return {
+		code: "TOOL_CONFIG_DRIFT",
+		severity: "warning",
+		file: path,
+		line: null,
+		message: `Tool config ${path} has drifted from ${reference}. Re-copy from .tool-configs/ or edit both to match.`,
+	};
+}
+
 /** Check that all installed tool config files hold identical content. */
 export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 	const present: Array<{ path: string; content: string }> = [];
@@ -67,17 +78,52 @@ export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 	// Nothing to compare until at least two tool configs are installed.
 	if (present.length < 2) return [];
 
-	const reference = present[0];
-	const issues: DriftIssue[] = [];
-	for (let i = 1; i < present.length; i++) {
-		if (present[i].content !== reference.content) {
-			issues.push({
+	// Group the copies by content, keeping TOOL_CONFIG_FILES order within and
+	// between groups. Identical copies collapse into one group; each edit that
+	// was not propagated forms another.
+	const groups = new Map<string, string[]>();
+	for (const { path, content } of present) {
+		const group = groups.get(content);
+		if (group) group.push(path);
+		else groups.set(content, [path]);
+	}
+	if (groups.size === 1) return [];
+
+	const ordered = [...groups.values()];
+
+	// With exactly two copies there is no majority to appeal to and no way to
+	// tell which one moved, so keep reporting the pair as before.
+	if (present.length === 2) {
+		return [drift(present[1].path, present[0].path)];
+	}
+
+	// The largest group is what the copies are supposed to say: an edit made in
+	// one place leaves the others agreeing. Blaming the first file in list order
+	// instead pins every warning on the wrong file whenever the edited copy
+	// happens to sort first. See https://github.com/mex-memory/mex/issues/127
+	const largest = ordered.reduce((a, b) => (b.length > a.length ? b : a));
+	const tied = ordered.filter((g) => g.length === largest.length).length > 1;
+
+	// No majority means no honest culprit -- say they diverged and stop there,
+	// rather than picking a group to blame.
+	if (tied) {
+		const summary = ordered.map((g) => `[${g.join(", ")}]`).join(" vs ");
+		return [
+			{
 				code: "TOOL_CONFIG_DRIFT",
 				severity: "warning",
-				file: present[i].path,
+				file: ordered[0][0],
 				line: null,
-				message: `Tool config ${present[i].path} has drifted from ${reference.path}. Re-copy from .tool-configs/ or edit both to match.`,
-			});
+				message: `Tool configs have diverged into ${ordered.length} groups with no majority: ${summary}. Decide which is correct and re-copy it over the others.`,
+			},
+		];
+	}
+
+	const issues: DriftIssue[] = [];
+	for (const group of ordered) {
+		if (group === largest) continue;
+		for (const path of group) {
+			issues.push(drift(path, largest[0]));
 		}
 	}
 	return issues;

--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -114,7 +114,7 @@ export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 				severity: "warning",
 				file: ordered[0][0],
 				line: null,
-				message: `Tool configs have diverged into ${ordered.length} groups with no majority: ${summary}. Decide which is correct and re-copy it over the others.`,
+				message: `Tool configs have diverged into ${ordered.length} groups with no majority, so none can be identified as the edited one: ${summary}.`,
 			},
 		];
 	}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -132,7 +132,7 @@ function remediationFor(code: DriftIssue["code"]): string | null {
     case "UNDOCUMENTED_SCRIPT":
       return "Document the script in AGENTS.md, SETUP.md, or context/setup.md.";
     case "TOOL_CONFIG_DRIFT":
-      return "Re-copy the flagged file from the version the other tool configs agree on.";
+      return "Re-copy the correct version over the tool configs that disagree with it.";
     case "TODO_FIXME":
       return "Resolve the TODO/FIXME or remove the marker from the scaffold.";
     case "BROKEN_LINK":

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -132,7 +132,7 @@ function remediationFor(code: DriftIssue["code"]): string | null {
     case "UNDOCUMENTED_SCRIPT":
       return "Document the script in AGENTS.md, SETUP.md, or context/setup.md.";
     case "TOOL_CONFIG_DRIFT":
-      return "Copy the intended tool config text across installed agent config files.";
+      return "Re-copy the flagged file from the version the other tool configs agree on.";
     case "TODO_FIXME":
       return "Resolve the TODO/FIXME or remove the marker from the scaffold.";
     case "BROKEN_LINK":

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -665,6 +665,35 @@ describe("checkToolConfigSync", () => {
     expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
   });
 
+  it("blames the edited copy even when it comes first in the file list", () => {
+    // CLAUDE.md heads TOOL_CONFIG_FILES, so using it as the baseline pinned a
+    // warning on all four untouched files instead. https://github.com/mex-memory/mex/issues/127
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}v2 edited\n`);
+    writeFileSync(join(tmpDir, "AGENTS.md"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, ".windsurfrules"), `${marker}v1\n`);
+    mkdirSync(join(tmpDir, ".github"), { recursive: true });
+    writeFileSync(join(tmpDir, ".github/copilot-instructions.md"), `${marker}v1\n`);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].file).toBe("CLAUDE.md");
+    expect(issues[0].message).toContain("AGENTS.md");
+  });
+
+  it("names no culprit when the copies split evenly", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, "AGENTS.md"), `${marker}v1\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}v2\n`);
+    writeFileSync(join(tmpDir, ".windsurfrules"), `${marker}v2\n`);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("TOOL_CONFIG_DRIFT");
+    expect(issues[0].message).toContain("no majority");
+    expect(issues[0].message).toContain("[CLAUDE.md, AGENTS.md]");
+    expect(issues[0].message).toContain("[.cursorrules, .windsurfrules]");
+    expect(issues[0].message).not.toContain("has drifted from");
+  });
+
   it("does not treat a file that merely quotes the sentinel as a copy", () => {
     // Documentation about mex is not a managed copy of it.
     const quoting = "# Notes\nCopies carry `<!-- mex-tool-config -->` after the frontmatter.\n";

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -694,6 +694,15 @@ describe("checkToolConfigSync", () => {
     expect(issues[0].message).not.toContain("has drifted from");
   });
 
+  it("names every group when no two copies agree", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}a\n`);
+    writeFileSync(join(tmpDir, "AGENTS.md"), `${marker}b\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}c\n`);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain("3 groups with no majority");
+  });
+
   it("does not treat a file that merely quotes the sentinel as a copy", () => {
     // Documentation about mex is not a managed copy of it.
     const quoting = "# Notes\nCopies carry `<!-- mex-tool-config -->` after the frontmatter.\n";


### PR DESCRIPTION
## What

`checkToolConfigSync` picked `present[0]` as the comparison baseline, and `present` is filled in `TOOL_CONFIG_FILES` order — so `CLAUDE.md` took the baseline slot whenever it existed, regardless of whether it was the file that moved. Every warning then pointed at the wrong file.

This groups the copies by content and treats the largest group as the baseline. An edit made in one place leaves the others agreeing, so the minority is what moved, wherever it sits in the list. An even split has no majority and no honest culprit, so it reports a single issue naming the groups instead of picking one to blame. Two installed copies keep the existing pairwise message — there is no majority to appeal to there either.

The fix hint in `reporter.ts` is keyed on the issue code, so it has to read correctly for both shapes. The old wording ("Copy the intended tool config text across installed agent config files") read as *propagate the accidental edit into all five*; the replacement names the action without asserting a baseline that does not exist in the tie case.

Trade-off: `DriftIssue` requires a `file`, so the no-majority issue is anchored on the first config and prints under that filename even though the message says none can be identified. The wording carries the meaning; the heading cannot.

Note on scoring: affected repos will see their drift score rise, because three of those four warnings were false. That is the opposite of #125's concern — no signal is lost here, duplicates are removed and the real warning is kept.

## Why

Closes #127

With five configs installed and `CLAUDE.md` edited, `mex check` reported four warnings, none of them naming the file that actually changed, and a message that inverted the blame — `AGENTS.md has drifted from CLAUDE.md`. Combined with the old fix hint, the advice was to copy the accidental edit across all five rather than revert it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

## How to test

1. Create a project with five tool configs installed, all copied from `templates/.tool-configs/CLAUDE.md`.
2. Append a line to `CLAUDE.md` only, leaving `AGENTS.md`, `.cursorrules`, `.windsurfrules` and `.github/copilot-instructions.md` untouched.
3. Run `mex check`.

On `main`: four `TOOL_CONFIG_DRIFT` warnings naming the four untouched files, none naming `CLAUDE.md`.

With this change: one warning, `Tool config CLAUDE.md has drifted from AGENTS.md`, with the hint `Re-copy the correct version over the tool configs that disagree with it.`

For the no-majority path, set `CLAUDE.md`/`AGENTS.md` to one version and `.cursorrules`/`.windsurfrules` to another, then run `mex check`. Expect a single warning reporting the two groups and naming no culprit.

## Checklist

- [x] Tests pass (`npm test`)
- [x] No breaking changes (or documented below)
- [x] Tested locally with a real project

Notes on the above:

- `npm test` is 389 passing locally. Three failures in `test/config.test.ts` and `test/cli.test.ts` are pre-existing on `main`, reproduce on an unmodified checkout, and are Windows-only — CI is green on Node 22 and 24. Unrelated to this change; worth a separate issue.
- No API change. Behaviour changes by design: warning counts drop for repos hitting this bug, one message string is reworded, and the `TOOL_CONFIG_DRIFT` fix hint is reworded. Nothing parses either string.
- Verified end-to-end through the built `mex check` binary against a fixture using this repo's own scaffold and real shipped template bytes, since the hint lives in the reporter and unit tests on `DriftIssue` do not cover that seam. Also checked 1/1/1, 2v1 with the minority first and last, 3v2, 2v1v1, and both all-identical cases, with output stable across 20 runs.

## Code-graph changes

<!-- Not a code-graph change. -->

- [ ] This PR targets `main`
- [ ] A linked issue agrees on the bounded extractor/resolver scope
- [ ] The change follows the frozen `LanguageExtractor` or `FrameworkResolver` interface
- [ ] A focused fixture and assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered
- [ ] No graph identity, reconciliation, schema, or drift-semantics changes are included, or a `core / discuss-first` issue is linked above