### PR TITLE
feat(graph): source-backed retrieval and v0.7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,17 @@ jobs:
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run typecheck
       - run: npm run test
+      - name: Run evaluator tests
+        if: matrix.node-version == 22
+        run: npm run eval:test
       - run: npm run build
       - name: Smoke test packed graph CLI
         if: matrix.node-version == 22

--- a/.mex/.tool-configs/.cursorrules
+++ b/.mex/.tool-configs/.cursorrules
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/.mex/.tool-configs/.windsurfrules
+++ b/.mex/.tool-configs/.windsurfrules
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/.mex/.tool-configs/CLAUDE.md
+++ b/.mex/.tool-configs/CLAUDE.md
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/.mex/.tool-configs/copilot-instructions.md
+++ b/.mex/.tool-configs/copilot-instructions.md
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-20
+
+### Added
+- Compiler-backed TypeScript extraction now resolves calls, imports, inheritance, containment, and callback flow with stable declaration identities, while retaining bounded Tree-sitter support for TypeScript, JavaScript, Python, and Rust.
+- Source-chunk search, parser-health metadata, graph-integrity reporting, and deterministic native holdouts for Hono, TypeScript's compiler subtree, MEX, and mixed-language fixtures.
+- Evidence-aware JSONL protocol v3 records for source ranges, directed execution flows, summaries, omissions, and trustworthy fallback guidance.
+
+### Changed
+- `mex graph scope` now defaults to bounded source-backed retrieval instead of a minimal manifest, prioritizing the most relevant declarations and real high-confidence execution paths in the first response.
+- Scope budgets adapt to repository size, enforce file/node/flow/source ceilings, and distinguish mandatory evidence from optional truncation.
+- TypeScript 5.9.3 is now an exact runtime dependency because graph construction uses the compiler API.
+- CI verifies Node.js 22 and 24, runs the evaluator tests on Node 22, and uses Node 24-based GitHub Actions.
+- Tool-config sync ignores unmarked user-authored files and reports the actual managed config that moved.
+
+### Fixed
+- Stale or unreadable source files can no longer silently erase trusted graph state; changed-file failures abort publication and preserve the last good graph.
+- Callback synthesis no longer maps extra arguments onto a non-rest final parameter, and rest callbacks are linked only when the corresponding indexed element is invoked.
+- Retrieval now preserves compiler-proven cross-file flows, source-aligned declarations, whole primary answers, and fair source allocation without manufacturing relationships or exceeding the output ledger.
+- Deterministic identity, duplicate/dangling-edge, FTS, confidence, parser-loss, and production-to-test integrity checks fail closed in the evaluation harness.
+- Headless comparison runs now enforce exact command permissions, subject/bundle identity, rate-limit-safe resume semantics, and blind answer grading.
+
+### Performance
+- In a descriptive 24-session, 12-task Claude Sonnet pilot against a files-only baseline, the candidate answered 7/12 tasks correctly versus 6/12 while reducing new tokens by 54.5%, processed tokens by 72.5%, estimated cost by 56.6%, and mean latency by 22.9%.
+- First responses returned 22/23 required source spans, all required Hono flows, and graph evidence for all 12 tasks. The pilot used one repetition per task and did not include the released `main` implementation as an arm.
+
+### Compatibility
+- Node.js 22.5 or newer remains required.
+- Existing schema-v1 `.mex/graph.db` files require a one-time `mex graph` rebuild; the Markdown scaffold itself does not need to be reset.
+- The richer graph currently uses more disk than 0.7.1. Incremental/no-op rebuild and storage optimization are deferred to a follow-up release.
+
 ## [0.7.1] - 2026-08-05
 
 ### Changed

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,7 +2,7 @@
 
 ## Runtime requirement
 
-mex 0.7.0 requires Node.js 22.5 or newer. The code graph uses the built-in `node:sqlite` module; older Node releases are unsupported. Users who cannot upgrade Node can remain on mex v0.6.3, which supports Node.js 20 or newer.
+mex 0.7.x requires Node.js 22.5 or newer. The code graph uses the built-in `node:sqlite` module; older Node releases are unsupported. Users who cannot upgrade Node can remain on mex v0.6.3, which supports Node.js 20 or newer.
 
 This document defines `mex-agent`'s public contract: what's stable, what isn't,
 and what counts as a breaking change. It is intended for embedders — tools that
@@ -23,17 +23,17 @@ import { /* … */ } from "mex-agent";
 Concretely, that's everything re-exported from
 [`src/index.ts`](./src/index.ts):
 
-- **Functions** — `findConfig`, `createConfig`, `appendEvent`, `readEvents`,
-  `eventLogPath`, `runDriftCheck`, `parseFrontmatter`, `checkHeartbeat`,
-  `runHeartbeat`.
+- **Functions** — `findConfig`, `createConfig`, `getScaffoldIdentity`,
+  `appendEvent`, `readEvents`, `eventLogPath`, `runDriftCheck`,
+  `parseFrontmatter`, `checkHeartbeat`, `runHeartbeat`.
 - **Runtime constants** — `EVENT_KINDS`, `DEFAULT_STALENESS_THRESHOLDS`,
   `DEFAULT_SCAFFOLD_PATTERNS`, `DEFAULT_HEARTBEAT_PATTERNS`.
 - **Types** — `MexConfig`, `CreateConfigInput`, `EventEntry`, `EventKind`,
   `LogOpts`, `DriftReport`, `DriftIssue`, `RunDriftCheckOpts`,
   `HeartbeatResult`, `HeartbeatOpts`, `CheckHeartbeatOpts`,
   `StalenessThresholds`, `WatchConfig`, `HeartbeatConfig`, `AiTool`,
-  `IssueCode`, `Severity`, `ScaffoldFrontmatter`, `FrontmatterEdge`, `Claim`,
-  `ClaimKind`.
+  `ScaffoldIdentity`, `IssueCode`, `Severity`, `ScaffoldFrontmatter`,
+  `FrontmatterEdge`, `Claim`, `ClaimKind`.
 
 The CI smoke test at [`test/public-api.test.ts`](./test/public-api.test.ts)
 asserts the existence and basic shape of these exports. Any change that breaks

--- a/README.es.md
+++ b/README.es.md
@@ -18,7 +18,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/mex-memory/mex/actions/workflows/ci.yml/badge.svg)](https://github.com/mex-memory/mex/actions/workflows/ci.yml)
 [![Node.js >=22.5](https://img.shields.io/badge/node-%3E%3D22.5-339933)](package.json)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6)](package.json)
 [![Agent memory](https://img.shields.io/badge/agent%20memory-compatible-6f8cff)](#modo-de-memoria-del-agente)
 [![MCP](https://img.shields.io/badge/MCP-compatible-6f8cff)](#servidor-mcp)
 
@@ -30,7 +30,7 @@ mex crea un mapa de tu código, convierte lo que aprenden los agentes en Markdow
 
 Cada sesión de programación comienza con el contexto arquitectónico relevante, no con otro escaneo completo del repositorio.
 
-> **Nuevo en v0.7.0:** grafos de código locales y deterministas, conocimiento vinculado a símbolos, recuperación compacta para agentes y compatibilidad con Python y Rust además de TypeScript y JavaScript.
+> **Nuevo en v0.7.2:** recuperación del grafo con código fuente en una sola llamada, flujos de TypeScript resueltos por el compilador, evidencia determinista y límites estrictos de salida.
 
 💬 **Únete a la comunidad de mex en Discord** — comenta ideas, obtén ayuda, comparte tus opiniones y contribuye al proyecto.
 
@@ -170,9 +170,9 @@ El grafo también funciona como capa de recuperación compacta:
 mex graph scope "seguir el flujo de autenticación"
 ```
 
-En lugar de devolver grandes bloques de código, mex produce un vecindario puntuado de símbolos relevantes con un límite estricto de tokens estimados. La respuesta predeterminada contiene firmas compactas, relaciones, IDs de nodo y motivos de selección.
+En lugar de devolver todo el repositorio, mex prioriza las declaraciones y los flujos de ejecución reales con mayor probabilidad de responder a la tarea, bajo un límite estricto de tokens estimados. La respuesta predeterminada incluye código fuente mediante registros JSONL deterministas `meta`, `source`, `flow` y `summary`.
 
-El agente expande únicamente los símbolos necesarios:
+El código fuente devuelto ya se considera leído. Si el resumen indica `ok`, el agente puede responder directamente aunque se haya truncado contexto opcional de menor prioridad. La expansión exacta sigue disponible cuando falta una declaración o el resumen recomienda continuar:
 
 ```bash
 mex graph get <node-id>
@@ -191,20 +191,19 @@ Los comandos para agentes usan envolturas JSONL deterministas para separar metad
 
 ## Resultados
 
-En el benchmark del repositorio de mex:
+Un piloto de 24 sesiones comparó el candidato 0.7.2 con búsquedas solo de archivos en 12 tareas de Hono y MEX:
 
 | Medición | Resultado |
 |---|---:|
-| Corpus completo ÷ alcance del grafo | **916.38×** |
-| Salida de los 3 primeros resultados de grep ÷ alcance | **10.74×** |
-| Recuperación de símbolos esperados | **100%** |
-| Tareas completadas con contexto mínimo | **5/5** |
-| Tareas mínimas que necesitaron Read/Grep | **0/5** |
-| Tareas con fuente incluida que necesitaron Read/Grep | **4/5** |
+| Respuestas correctas en revisión ciega | **7/12 candidato frente a 6/12 archivos** |
+| Cambio en tokens nuevos | **-54,5 %** |
+| Cambio en tokens procesados | **-72,5 %** |
+| Cambio en coste estimado | **-56,6 %** |
+| Cambio en latencia media | **-22,9 %** |
+| Fragmentos de código requeridos devueltos | **22/23 (95,7 %)** |
+| Flujos requeridos de Hono devueltos | **6/6 (100 %)** |
 
-El repositorio medido contenía 252 archivos de corpus, unos 733 605 tokens estimados, 154 archivos indexados, 1867 nodos y 2892 relaciones. El grafo tardó aproximadamente 7,2 segundos en construirse.
-
-Son resultados orientativos de un repositorio, seis tareas de recuperación automatizadas y cinco tareas con agentes reales. Demuestran una recuperación compacta, no un ahorro universal de tokens de extremo a extremo frente a no utilizar un grafo.
+Cada tarea se ejecutó una vez por variante con Claude Sonnet. Son resultados descriptivos de una muestra pequeña frente a una línea base que solo busca archivos; no comparan con `main` publicado ni prueban un ahorro universal de tokens. Consulta el [informe del benchmark](evaluate/RESULTS.md) para ver la metodología y las limitaciones.
 
 Consulta los [resultados del benchmark](evaluate/RESULTS.md) y el [sistema de evaluación](evaluate/README.md) para ver la metodología, los datos, las limitaciones y los comandos de reproducción.
 
@@ -296,7 +295,7 @@ El paquete MCP todavía no está publicado. Para desarrollo local:
 npm run build --workspace mex-mcp
 ```
 
-La publicación principal de v0.7.0 sigue siendo la CLI `mex-agent`.
+La publicación principal de v0.7.2 sigue siendo la CLI `mex-agent`.
 
 ## Modo de memoria del agente
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/mex-memory/mex/actions/workflows/ci.yml/badge.svg)](https://github.com/mex-memory/mex/actions/workflows/ci.yml)
 [![Node.js >=22.5](https://img.shields.io/badge/node-%3E%3D22.5-339933)](package.json)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6)](package.json)
 [![Agent memory](https://img.shields.io/badge/agent%20memory-compatible-6f8cff)](#agent-memory-mode)
 [![MCP](https://img.shields.io/badge/MCP-compatible-6f8cff)](#mcp-server)
 
@@ -30,7 +30,7 @@ mex maps your code, turns what agents learn into structured Markdown, and keeps 
 
 Every coding session starts with relevant architectural context instead of another full-repository scan.
 
-> **New in v0.7.0:** deterministic local code graphs, symbol-grounded knowledge, compact agent retrieval, and Python/Rust support alongside TypeScript and JavaScript.
+> **New in v0.7.2:** source-backed one-call graph retrieval with compiler-resolved TypeScript flows, deterministic evidence, and hard output budgets.
 
 💬 **Join the mex community on Discord** — discuss ideas, get help, share feedback, and contribute to the project.
 
@@ -170,9 +170,9 @@ The graph is also a compact agent-retrieval layer:
 mex graph scope "trace the authentication flow"
 ```
 
-Instead of returning a large source dump, mex produces a scored neighborhood of relevant symbols under a hard estimated-token budget. The default response contains compact signatures, relationships, node IDs, and selection reasons.
+Instead of returning a repository-sized source dump, mex prioritizes the declarations and real execution flows most likely to answer the task under a hard estimated-token budget. The default response is source-backed and uses deterministic `meta`, `source`, `flow`, and `summary` JSONL records.
 
-Agents can then expand only the symbols they need:
+Returned source is already read. When the summary is `ok`, an agent can answer directly even if lower-priority optional context was truncated. Exact expansion remains available when a declaration is missing or the summary recommends a follow-up:
 
 ```bash
 mex graph get <node-id>
@@ -191,27 +191,19 @@ Agent-facing graph commands use deterministic JSONL envelopes so tools can relia
 
 ## Results
 
-On the mex repository benchmark:
+A 24-session pilot compared the 0.7.2 candidate with files-only search across 12 Hono and MEX tasks:
 
 | Measurement | Result |
 |---|---:|
-| Full repository corpus ÷ graph scope | **916.38×** |
-| Grep top-3 output ÷ graph scope | **10.74×** |
-| Expected-symbol recall | **100%** |
-| Minimal-context agent tasks completed | **5/5** |
-| Minimal-context tasks requiring fallback Read/Grep | **0/5** |
-| Inline-source tasks requiring fallback Read/Grep | **4/5** |
+| Blind-correct answers | **7/12 candidate vs 6/12 files** |
+| New-token change | **-54.5%** |
+| Processed-token change | **-72.5%** |
+| Estimated-cost change | **-56.6%** |
+| Mean-latency change | **-22.9%** |
+| Required source spans returned | **22/23 (95.7%)** |
+| Required Hono flows returned | **6/6 (100%)** |
 
-The measured repository contained:
-
-- 252 corpus files
-- approximately 733,605 estimated tokens
-- 154 graph-indexed source files
-- 1,867 code nodes
-- 2,892 relationships
-- approximately 7.2 seconds to build the graph
-
-These are directional results from one repository, six scripted retrieval tasks, and five real-agent tasks. They demonstrate compact retrieval behavior, not a universal end-to-end graph-versus-no-graph token-savings claim.
+Each task ran once per arm with Claude Sonnet. These are descriptive small-N results against a files-only baseline, not a released-`main` comparison or a universal token-savings claim. See the [benchmark report](evaluate/RESULTS.md) for methodology and limitations.
 
 See the [benchmark results](evaluate/RESULTS.md) and [evaluation harness](evaluate/README.md) for the methodology, raw results, caveats, and reproduction commands.
 
@@ -307,7 +299,7 @@ The MCP package is not published yet. For local development, build it with:
 npm run build --workspace mex-mcp
 ```
 
-The primary v0.7.0 release remains the `mex-agent` CLI.
+The primary v0.7.2 release remains the `mex-agent` CLI.
 
 ## Agent memory mode
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -18,7 +18,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/mex-memory/mex/actions/workflows/ci.yml/badge.svg)](https://github.com/mex-memory/mex/actions/workflows/ci.yml)
 [![Node.js >=22.5](https://img.shields.io/badge/node-%3E%3D22.5-339933)](package.json)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6)](package.json)
 [![Agent memory](https://img.shields.io/badge/agent%20memory-compatible-6f8cff)](#modo-de-memória-do-agente)
 [![MCP](https://img.shields.io/badge/MCP-compatible-6f8cff)](#servidor-mcp)
 
@@ -30,7 +30,7 @@ mex mapeia seu código, transforma o que os agentes aprendem em Markdown estrutu
 
 Cada sessão de programação começa com o contexto arquitetural relevante, e não com mais uma varredura completa do repositório.
 
-> **Novidade na v0.7.0:** grafos de código locais e determinísticos, conhecimento vinculado a símbolos, recuperação compacta para agentes e suporte a Python e Rust além de TypeScript e JavaScript.
+> **Novidade na v0.7.2:** recuperação do grafo com código-fonte em uma única chamada, fluxos de TypeScript resolvidos pelo compilador, evidência determinística e limites rígidos de saída.
 
 💬 **Entre na comunidade do mex no Discord** — discuta ideias, peça ajuda, compartilhe feedback e contribua com o projeto.
 
@@ -170,9 +170,9 @@ O grafo também funciona como uma camada compacta de recuperação:
 mex graph scope "rastrear o fluxo de autenticação"
 ```
 
-Em vez de retornar grandes blocos de código, mex produz uma vizinhança pontuada de símbolos relevantes sob um limite rígido de tokens estimados. A resposta padrão contém assinaturas compactas, relações, IDs de nós e motivos de seleção.
+Em vez de retornar todo o repositório, o mex prioriza as declarações e os fluxos de execução reais mais prováveis de responder à tarefa, sob um limite rígido de tokens estimados. A resposta padrão inclui código-fonte em registros JSONL determinísticos `meta`, `source`, `flow` e `summary`.
 
-O agente expande somente os símbolos necessários:
+O código-fonte retornado já deve ser considerado lido. Quando o resumo é `ok`, o agente pode responder diretamente mesmo que contexto opcional de menor prioridade tenha sido truncado. A expansão exata continua disponível quando falta uma declaração ou o resumo recomenda uma próxima etapa:
 
 ```bash
 mex graph get <node-id>
@@ -191,20 +191,19 @@ Os comandos voltados a agentes usam envelopes JSONL determinísticos para separa
 
 ## Resultados
 
-No benchmark do repositório do mex:
+Um piloto de 24 sessões comparou o candidato 0.7.2 com busca apenas em arquivos em 12 tarefas de Hono e MEX:
 
 | Medição | Resultado |
 |---|---:|
-| Corpus completo ÷ escopo do grafo | **916,38×** |
-| Saída dos 3 primeiros resultados do grep ÷ escopo | **10,74×** |
-| Recuperação dos símbolos esperados | **100%** |
-| Tarefas concluídas com contexto mínimo | **5/5** |
-| Tarefas mínimas que exigiram Read/Grep | **0/5** |
-| Tarefas com fonte embutida que exigiram Read/Grep | **4/5** |
+| Respostas corretas em revisão cega | **7/12 candidato contra 6/12 arquivos** |
+| Mudança em novos tokens | **-54,5%** |
+| Mudança em tokens processados | **-72,5%** |
+| Mudança no custo estimado | **-56,6%** |
+| Mudança na latência média | **-22,9%** |
+| Trechos de código obrigatórios retornados | **22/23 (95,7%)** |
+| Fluxos obrigatórios do Hono retornados | **6/6 (100%)** |
 
-O repositório medido continha 252 arquivos de corpus, cerca de 733.605 tokens estimados, 154 arquivos indexados, 1.867 nós e 2.892 relações. O grafo levou aproximadamente 7,2 segundos para ser construído.
-
-São resultados direcionais de um repositório, seis tarefas automatizadas de recuperação e cinco tarefas com agentes reais. Eles demonstram recuperação compacta, não uma economia universal de tokens de ponta a ponta em comparação com não usar um grafo.
+Cada tarefa foi executada uma vez por variante com Claude Sonnet. São resultados descritivos de uma amostra pequena contra uma linha de base que pesquisa apenas arquivos; não comparam com o `main` publicado nem provam economia universal de tokens. Consulte o [relatório do benchmark](evaluate/RESULTS.md) para metodologia e limitações.
 
 Consulte os [resultados do benchmark](evaluate/RESULTS.md) e o [sistema de avaliação](evaluate/README.md) para metodologia, dados, limitações e comandos de reprodução.
 
@@ -296,7 +295,7 @@ O pacote MCP ainda não foi publicado. Para desenvolvimento local:
 npm run build --workspace mex-mcp
 ```
 
-O lançamento principal da v0.7.0 continua sendo a CLI `mex-agent`.
+O lançamento principal da v0.7.2 continua sendo a CLI `mex-agent`.
 
 ## Modo de memória do agente
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/mex-memory/mex/actions/workflows/ci.yml/badge.svg)](https://github.com/mex-memory/mex/actions/workflows/ci.yml)
 [![Node.js >=22.5](https://img.shields.io/badge/node-%3E%3D22.5-339933)](package.json)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6)](package.json)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6)](package.json)
 [![Agent memory](https://img.shields.io/badge/agent%20memory-compatible-6f8cff)](#代理记忆模式)
 [![MCP](https://img.shields.io/badge/MCP-compatible-6f8cff)](#mcp-服务器)
 
@@ -30,7 +30,7 @@ mex 为代码建立地图，把代理学到的知识整理成结构化 Markdown�
 
 每次编程会话都从相关的架构上下文开始，而不是重新扫描整个仓库。
 
-> **v0.7.0 新功能：** 确定性的本地代码图谱、符号级知识锚定、面向代理的紧凑检索，以及在 TypeScript 和 JavaScript 之外新增的 Python 与 Rust 支持。
+> **v0.7.2 新功能：** 一次调用即可获得带源码的图谱检索、由编译器解析的 TypeScript 执行流、确定性证据以及严格的输出预算。
 
 💬 **加入 mex Discord 社区** — 讨论想法、获取帮助、分享反馈并参与项目贡献。
 
@@ -170,9 +170,9 @@ grounds_to:
 mex graph scope "追踪身份验证流程"
 ```
 
-mex 不会返回大段源代码，而是在严格的估算 token 预算内给出经过评分的相关符号邻域。默认结果包含紧凑签名、关系、节点 ID 和选择理由。
+mex 不会返回整个仓库，而是在严格的估算 token 预算内优先返回最可能回答任务的声明和真实执行流。默认响应包含源码，并使用确定性的 `meta`、`source`、`flow` 和 `summary` JSONL 记录。
 
-代理随后只需展开真正需要的符号：
+返回的源码应视为已经阅读。当摘要状态为 `ok` 时，即使低优先级的可选上下文被截断，代理也可以直接作答。仅在缺少某个声明或摘要建议继续时才需要精确展开：
 
 ```bash
 mex graph get <node-id>
@@ -191,27 +191,19 @@ mex impact requireSession
 
 ## 测试结果
 
-在 mex 仓库基准测试中：
+一项包含 24 个会话的试验，在 12 个 Hono 和 MEX 任务上比较了 0.7.2 候选版本与仅文件搜索：
 
 | 指标 | 结果 |
 |---|---:|
-| 完整仓库语料 ÷ 图谱 scope | **916.38×** |
-| grep 前 3 条输出 ÷ 图谱 scope | **10.74×** |
-| 预期符号召回率 | **100%** |
-| 最小上下文模式完成的代理任务 | **5/5** |
-| 最小上下文模式需要回退到 Read/Grep 的任务 | **0/5** |
-| 内联源代码模式需要回退到 Read/Grep 的任务 | **4/5** |
+| 盲审正确答案 | **候选版本 7/12，对照组 6/12** |
+| 新增 token 变化 | **-54.5%** |
+| 处理 token 变化 | **-72.5%** |
+| 估算成本变化 | **-56.6%** |
+| 平均延迟变化 | **-22.9%** |
+| 返回的必需源码区间 | **22/23（95.7%）** |
+| 返回的 Hono 必需执行流 | **6/6（100%）** |
 
-被测仓库包含：
-
-- 252 个语料文件
-- 约 733,605 个估算 token
-- 154 个进入图谱索引的源文件
-- 1,867 个代码节点
-- 2,892 条关系
-- 构建图谱约需 7.2 秒
-
-这些是来自单个仓库、六个脚本化检索任务和五个真实代理任务的方向性结果。它们验证的是紧凑检索行为，而不是普遍适用的端到端“有图谱与无图谱”token 节省结论。
+每个任务都使用 Claude Sonnet 为每个方案运行一次。这是一项小样本描述性试验，对照组仅搜索文件；它既不是与已发布 `main` 的比较，也不能证明普遍的 token 节省。方法和限制详见[基准测试报告](evaluate/RESULTS.md)。
 
 请参阅[基准测试结果](evaluate/RESULTS.md)和[评估工具](evaluate/README.md)，了解方法、原始结果、局限及复现命令。
 
@@ -307,7 +299,7 @@ MCP 包尚未发布。本地开发时请运行：
 npm run build --workspace mex-mcp
 ```
 
-v0.7.0 的主要发布内容仍然是 `mex-agent` CLI。
+v0.7.2 的主要发布内容仍然是 `mex-agent` CLI。
 
 ## 代理记忆模式
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,92 +1,68 @@
-# mex 0.7.0 — Code-aware project memory
+# mex 0.7.2 — Source-backed graph retrieval
 
-mex 0.7.0 adds a deterministic code knowledge graph beneath the existing markdown scaffold. Memory can now ground itself to exact code nodes instead of relying only on file paths, so mex can tell an agent precisely which symbol changed and which surrounding code or scaffold memory is affected.
+mex 0.7.2 makes the code graph useful as a first-response retrieval system rather than only a compact symbol manifest. `mex graph scope` now returns the most relevant source declarations and real execution flows under a hard token budget, so an agent can often answer from one graph call instead of repeatedly expanding node IDs or reopening files.
 
-The graph is local, zero-AI infrastructure: tree-sitter extraction writes SQLite in `.mex/graph.db`, body hashes detect edits, and MinHash fingerprints reconcile confident renames and moves.
+## What changed
 
-## What is included
+- **Source-backed Scope by default.** Task queries return bounded `meta`, `source`, `flow`, and `summary` JSONL records. Primary declarations and trustworthy flows are admitted before optional context.
+- **Compiler-backed TypeScript graph.** The TypeScript compiler API adds resolved calls, imports, inheritance, containment, callback flow, and declaration-aware source regions. TypeScript 5.9.3 is therefore an exact runtime dependency.
+- **Evidence-aware retrieval.** Lexical search, source chunks, graph neighborhoods, compiler callsites, and declaration identity are fused without inventing edges. Displayed flows use stored edges with confidence at least 0.8 and remain bounded by hop, branch, work, and output-step limits.
+- **Honest status and budgets.** `ok`, `partial`, `degraded`, and `no-match` reflect whether mandatory answer evidence was returned. `truncated: true` may now mean only lower-priority optional evidence was omitted.
+- **Safer graph publication.** Parser/read failures preserve the previous graph, rebuilds are deterministic, and integrity checks cover extraction loss, duplicate or dangling rows, FTS drift, identity drift, invalid confidence, and suspicious production-to-test edges.
+- **Stronger evaluation.** Native Hono, TypeScript-compiler, MEX, and mixed-language holdouts validate files, exact source spans, flows, budgets, construction integrity, and deterministic rebuilds. Headless comparisons pin subject and command identity, constrain tools, support safe resume after provider limits, and blind-grade exact source declarations.
+- **Drift-check improvements.** This release also includes frontmatter completeness, stale-pattern checks, and safer tool-config synchronization from the latest `main` branch.
 
-- TypeScript, TSX, JavaScript, JSX, Python, and Rust extraction.
-- Cross-file calls, imports, inheritance, containment, and reference edges.
-- An Express reference resolver linking route registrations to handler nodes.
-- Grounding checker #12 for changed, moved, ambiguous, or removed code nodes.
-- Compact, scored task neighborhoods through `mex graph scope`, with deterministic ordering, explicit selection reasons, and hard estimated-token budgets.
-- Targeted source expansion through `mex graph get`, with source remaining opt-in for scope, query, and impact commands.
-- Setup-time grounding plus an idempotent migration path for existing scaffolds.
-- Durable re-grounding of frontmatter and inline anchors during `mex sync`.
-- A contributor-facing extractor test pattern in the source repository.
+## Agent workflow
 
-## New commands
+For an unfamiliar task, start with:
+
+```bash
+mex graph scope "trace the authentication flow"
+```
+
+Treat returned source as already read. If the summary is `ok`, answer from the returned evidence even when optional context was truncated. Use `mex graph get <node-id>` for an exact missing declaration, or follow `suggestedNextCommands` when the summary is `partial` or `degraded`. Fall back to Grep/Glob when the graph evidence does not clearly answer the task.
+
+Exact structural commands remain available:
+
+```bash
+mex graph query where-defined authenticate
+mex graph query who-calls requireSession
+mex graph query what-calls createServer
+mex impact requireSession
+```
+
+## Benchmark snapshot
+
+A descriptive pilot ran 12 tasks across Hono and MEX once with a files-only search arm and once with the 0.7.2 candidate: 24 valid Claude Sonnet sessions in total.
+
+| Metric | Files baseline | 0.7.2 candidate | Change |
+|---|---:|---:|---:|
+| Blind-correct answers | 6/12 | 7/12 | +1 answer |
+| New tokens | 393,637 | 179,179 | **-54.5%** |
+| Processed tokens | 3,348,865 | 920,544 | **-72.5%** |
+| Estimated cost | $3.6973 | $1.6061 | **-56.6%** |
+| Mean latency | 45.62 s | 35.17 s | **-22.9%** |
+
+Candidate first responses returned 22/23 required source spans, every required Hono flow, and graph evidence for all 12 tasks.
+
+This is a small, one-repetition pilot. It compares the candidate with files-only search, not with the released `main` graph implementation, and individual task results—especially Hono schema retries—were noisy.
+
+## Upgrade and compatibility
+
+mex 0.7.2 requires Node.js 22.5 or newer, unchanged from 0.7.1.
+
+```bash
+npm install -g mex-agent@0.7.2
+```
+
+Existing Markdown scaffolds remain valid. The graph schema has changed, so rebuild an existing graph once after upgrading:
 
 ```bash
 mex graph
-mex graph --json
-mex graph scope <task>
-mex graph get <node-id>
-mex graph ground
-mex graph query where-defined <symbol>
-mex graph query who-calls <symbol>
-mex graph query what-calls <symbol>
-mex impact <symbol-or-file>
 ```
 
-`mex graph scope`, `mex graph query`, `mex graph get`, and `mex impact` emit a framed JSONL protocol intended for coding agents to call during setup, repair, and implementation tasks. The default `minimal` detail returns compact structural facts and relationship counts. Use `--detail standard` for returned-node edges, `--detail source` for inline source, or `mex graph get <node-id>` to expand only the exact nodes needed.
+Existing projects do not automatically receive updated agent instructions. Copy the new `## Code Graph` section from `templates/AGENTS.md` if you want source-backed one-call guidance in an already-created scaffold.
 
-## Retrieval results
+## Known tradeoff
 
-The release harness measured `mex graph scope` against a grep top-3 baseline on six symbol tasks in this repository:
-
-- The median grep-top-3-to-scope output ratio was **10.74×** by the documented `ceil(chars/4)` estimate.
-- Expected-symbol recall remained **1.0**.
-- The former `runDriftCheck` over-expansion case improved from 32 source-bearing facts and 0.26× grep efficiency to 9 compact facts and 5.90× grep efficiency.
-
-In a five-task real-agent comparison, both `minimal` and `source` modes answered 5/5 correctly. `minimal` used targeted `graph get` calls and never fell back to Read/Grep; `source` needed Read/Grep fallback on four tasks. That is why `minimal` is the default.
-
-These measurements are intentionally narrow: one mid-size repository, six symbol tasks, five natural-language tasks, and one model. They compare graph output with a synthetic grep baseline and compare two graph detail modes; they do **not** measure end-to-end graph-versus-no-graph token savings.
-
-## Grounded scaffold memory
-
-Setup now authors grounding as it populates memory. It follows **read broad, ground tight**: read the relevant scope neighborhood, then ground only prose claims that depend on specific behavior. Broad architecture, stack, and convention files remain sparse; pattern and deep-domain files ground tightly.
-
-Behavioral assertions use frontmatter with both a node id and fingerprint:
-
-```yaml
-grounds_to:
-  - node: "function:a3f8...c21"
-    fingerprint: "mh:64:9f2a..."
-```
-
-Load-bearing symbol mentions use readable inline navigation anchors containing only the node id:
-
-```markdown
-[`calculateCheckoutTotal()`](mex://function:a3f8...c21)
-```
-
-An unchanged node is clean. A body edit produces a grounding warning with old/new source for sync. Sync repairs the prose when needed, refreshes the frontmatter fingerprint, and updates or removes stale anchors. A high-confidence rename is rebound automatically; an uncertain candidate is surfaced for agent adjudication. Broken inline navigation remains warning-only.
-
-## Installation and upgrades
-
-mex 0.7.0 requires Node.js 22.5 or newer because the graph uses Node's built-in SQLite module.
-
-```bash
-npx mex-agent@0.7.0 setup
-```
-
-Fresh `mex setup` runs build the graph before population, and the setup agent consumes it through the hydrated retrieval commands while authoring grounding.
-
-Existing populated scaffolds remain valid, but need a one-time pointer migration to participate in graph drift detection:
-
-```bash
-mex graph
-mex graph ground
-```
-
-`mex graph ground` preserves the existing prose and adds tight `grounds_to` entries plus load-bearing `mex://` anchors. It is safe to rerun. Scaffolds that have not migrated continue to behave as before under the original eleven checkers.
-
-## Graceful degradation
-
-The graph is additive. If no graph exists, a grammar is unavailable, or SQLite cannot load on a platform, mex skips graph grounding and continues running the rest of `mex check`. Unsupported-language files are skipped rather than crashing graph construction.
-
-## What comes next
-
-The 0.7.x series will broaden language and framework coverage through bounded extractor and resolver contributions, tune reconciliation and retrieval on larger repositories, and add a controlled graph-vs-no-graph agent benchmark.
+The compiler-backed graph stores substantially more nodes, edges, source chunks, import bindings, and integrity metadata than 0.7.1, so `.mex/graph.db` is larger. Build memory is not higher than the released baseline in paired Hono/TypeScript measurements, but storage and no-op/incremental rebuild performance remain follow-up work.

--- a/evaluate/README.md
+++ b/evaluate/README.md
@@ -79,7 +79,7 @@ Branch artifacts are produced with `git archive` into the ignored output directo
 worktree is not switched, reset, or overwritten. Existing `node_modules` may be shared read-only by
 the archived builds.
 
-### Strict task evidence
+### Source-grounded task evidence
 
 Every non-negative task uses exact evidence:
 
@@ -93,16 +93,18 @@ Every non-negative task uses exact evidence:
     {
       "symbol": "BudgetLedger",
       "kind": "class",
-      "path": "src/graph/agent-protocol.ts"
+      "path": "src/graph/agent-protocol.ts",
+      "startLine": 174,
+      "endLine": 213
     }
   ]
 }
 ```
 
-Preparation fails for missing files, stale declarations, duplicate task IDs, ambiguous declarations,
-empty fixtures, absolute paths, or paths escaping the subject repository. Matching is exact on
-symbol, graph kind, and normalized repository-relative path. A substring in `qualifiedName` or
-serialized JSON is not a match.
+Preparation fails for missing files, stale source spans, duplicate task IDs, ambiguous declarations,
+empty fixtures, absolute paths, or paths escaping the subject repository. Evidence identity is the
+exact symbol, normalized repository-relative path, and source span. Extractor node kind is retained
+as an advisory diagnostic but cannot make valid source evidence impossible.
 
 Supported task operations are:
 
@@ -119,7 +121,10 @@ make a run invalid rather than an empty successful result.
 
 The report includes:
 
-- exact evidence Recall@1, Recall@5, and Recall@10;
+- first-response top-five file hit rate and file MRR;
+- returned required source-span recall and directed-flow coverage;
+- graph-construction coverage, reported separately from retrieval misses;
+- source-identity Recall@1, Recall@5, and Recall@10 for covered graph evidence;
 - MRR with every miss scored as zero;
 - nDCG@10, Precision@5, irrelevant-result rate, and complete-evidence rate;
 - negative-query accuracy and prohibited-result hits;
@@ -191,6 +196,33 @@ npm run eval:compare -- --run \
   --repetitions 3
 ```
 
+For a tuning pilot that compares only repository files with the active candidate, select the same
+two arms during preparation and execution:
+
+```bash
+npm run eval:compare -- --prepare \
+  --suite evaluate/compare/suites/mex-graph.json \
+  --repo . \
+  --output .mex/eval-results/compare/mex-graph-two-arm \
+  --arms files,candidate
+
+npm run eval:compare -- --run \
+  --suite evaluate/compare/suites/mex-graph.json \
+  --repo . \
+  --output .mex/eval-results/compare/mex-graph-two-arm \
+  --arms files,candidate \
+  --agent claude \
+  --model <model-name> \
+  --policy forced-first \
+  --repetitions 1
+```
+
+The run manifest records the selected arms, and `--report` reads that selection automatically.
+Use a fresh output directory when changing the arm set. With the six-task MEX and Hono suites,
+one repetition of `files,candidate` is 12 sessions per suite, or 24 sessions total. This two-arm
+report computes the candidate-versus-files efficiency and correctness gate but remains a
+descriptive tuning pilot; the final release decision still uses all three arms.
+
 Or use the locally authenticated Codex CLI:
 
 ```bash
@@ -222,10 +254,19 @@ Report the policies separately; they answer different questions.
 
 Each session starts in a fresh neutral temporary directory. The subject repository is added as a
 readable directory, graph commands pass through a fixed wrapper into the prepared subject index,
-and the agent never inherits conversation state. Claude safe mode/no-session-persistence and Codex
-ephemeral/read-only modes are used. Policy validation distinguishes attempted, executed, failed,
-and denied tool calls and rejects raw SQLite, cross-arm binaries, shell composition, or an invalid
-forced-first sequence.
+and the agent never inherits conversation state. Claude uses empty user/project/local setting
+sources, one harness-owned Bash guard, and no session persistence; Codex uses ephemeral/read-only
+mode. Policy validation distinguishes attempted, executed, failed, and denied tool calls and rejects
+executed raw SQLite, cross-arm binaries, shell composition, or an invalid forced-first sequence.
+Run the evaluation as the sole graph writer for its subject repository: preparation and execution
+temporarily swap `.mex/graph.db` and restore the startup copy, so a concurrent external `mex graph`
+process is outside the supported execution model. Source, evaluator, CLI-bundle, snapshot, prepare,
+or active-manifest drift aborts the run instead of persisting a graded row.
+Claude runs in isolated `dontAsk` mode: both arms receive the same
+Read/Grep/Glob capabilities, while graph arms additionally pre-approve only their own fixed graph
+wrapper. The PreToolUse guard denies every other Bash command before Claude's built-in read-only
+auto-allow can run. A denied, read-only file-shell attempt is recorded separately and may recover through
+Read/Grep/Glob; an executed file-shell fallback or any unexplained denial invalidates the row.
 
 ### Token and prompt-cache accounting
 
@@ -243,6 +284,10 @@ and maps only established fields into:
   "reportedCostUsd": null,
   "newTokens": 0,
   "cacheUseRatio": 0,
+  "accountingValid": true,
+  "accountingReason": null,
+  "terminal": {},
+  "perMessage": {},
   "raw": []
 }
 ```
@@ -250,6 +295,12 @@ and maps only established fields into:
 Unavailable fields remain `null`. In particular, Codex does not currently expose a cache-write
 count in its JSONL usage event, so the adapter preserves `cacheWrite: null` while computing new
 tokens from uncached input plus output. Claude reports cache creation/write separately.
+
+Claude stream-json can repeat the same assistant message. The harness deduplicates usage by
+`message.id`, sums the unique messages, and accepts the terminal cumulative token totals only when
+terminal uncached input, cache-write, and cache-read values exactly agree with those unique-message
+totals. A mismatch remains available for correctness review and preserves both observations, but is
+marked accounting-invalid and excluded from every paired token decision.
 
 The primary comparison is paired within the same task and repetition:
 
@@ -264,17 +315,18 @@ Absolute uncached input, cache writes, cache reads, output, totals, cost, and ca
 visible per arm. Reports include distributions, totals, paired means, and deterministic bootstrap
 95% intervals. Missing fields never become zero-cost claims.
 
-Arm order is balanced across tasks and repetitions using all six three-arm permutations. This
-prevents one arm from always running after another has warmed a provider cache. Shared prompt text
-appears in the same prefix where the experiment permits, but the report does not assume cache reads
-cancel between arms.
+Arm order is balanced across tasks and repetitions using both two-arm orders or all six three-arm
+permutations. This prevents one arm from always running after another has warmed a provider cache.
+Shared prompt text appears in the same prefix where the experiment permits, but the report does not
+assume cache reads cancel between arms.
 
 ### Agent outcomes
 
 The agent report records:
 
 - exact structured answer symbols and evidence paths;
-- initial scope rank, Recall@5, MRR, and miss rate without dropping misses;
+- first-response file rank/hit rate, returned source-span recall, and directed-flow coverage;
+- per-arm graph-construction coverage, kept separate from retrieval misses;
 - scope calls, semantically distinct scope retries, graph follow-ups, file-search fallbacks, tool
   errors, denials, turns, latency, and tool-result characters;
 - complete absolute cache/token composition; and
@@ -295,8 +347,9 @@ npm run eval:test
 
 The tests use fake graph, Claude, and Codex processes. They cover nonzero exits, timeouts, malformed
 and empty JSONL, stale/ambiguous gold, exact identity matching, partial multi-symbol evidence,
-miss-preserving MRR, output and cache accounting, balanced repetitions, resume identity, stale
-manual reviews, graph loss metrics, index restoration, and policy violations.
+miss-preserving MRR, terminal-versus-unique-message cache accounting, balanced repetitions, resume identity, stale
+manual reviews, graph loss metrics, index restoration, the exact-wrapper Bash guard, denial recovery,
+and policy violations.
 
 ## Historical scripts
 

--- a/evaluate/RESULTS.md
+++ b/evaluate/RESULTS.md
@@ -1,92 +1,72 @@
 # Graph retrieval benchmark results
 
-Scripted harness run: 2026-07-25
+Evaluation date: 2026-08-19 to 2026-08-20
 
-Real-agent run: 2026-07-22
+Candidate: mex 0.7.2 source-backed Scope
 
-Subject: mex repository on the `code-graph-preview` line
+Harnesses: `evaluate/compare/` for headless agent comparison and `evaluate/graph/` for deterministic retrieval, source-span, flow, budget, and integrity checks.
 
-Harness: `evaluate/` (`npm run eval`, `npm run eval:e2e`, and
-`node evaluate/agent-e2e-model.mjs`)
+## Headless files-baseline comparison
 
-## Subject graph
+The pilot used 12 natural-language tasks: six against Hono and six against MEX. Each task ran once with each arm:
 
-| Metric | Value |
-|---|---:|
-| Files indexed | 154 |
-| Nodes | 1,867 |
-| Edges | 2,892 |
-| Graph build time | 7.2 s |
-| Harness corpus | 252 source files |
-| Harness corpus size | 733,605 estimated tokens |
+- **Files baseline:** ordinary Read/Grep/Glob-style repository search.
+- **Candidate:** exactly one forced-first `mex graph scope` request, followed by permitted file reads when necessary.
 
-The harness uses `ceil(chars/4)` as a deterministic, model-agnostic token
-estimate for retrieval output. It is not a tokenizer measurement.
+Arm order was balanced. All 24 Claude Sonnet sessions passed execution, permission, subject-identity, command-bundle, and token-accounting checks. Answers were anonymized and graded against source before arm identity was revealed.
 
-## Retrieval efficiency
+| Metric | Files baseline | Candidate | Candidate change |
+|---|---:|---:|---:|
+| Valid sessions | 12/12 | 12/12 | No invalid runs |
+| Blind-correct answers | 6/12 (50.0%) | 7/12 (58.3%) | **+1 answer** |
+| New tokens | 393,637 | 179,179 | **-54.5%** |
+| Processed tokens | 3,348,865 | 920,544 | **-72.5%** |
+| Estimated cost | $3.6973 | $1.6061 | **-56.6%** |
+| Mean latency per answer | 45.62 s | 35.17 s | **-22.9%** |
 
-`mex graph scope <task>` was compared with the top three files returned by the
-committed grep baseline.
+`New tokens` are uncached input plus cache writes and output. `Processed tokens` additionally include cache reads. The median paired new-token change across the 12 tasks was -47.0%.
 
-| Task | Grep top-3 tokens | Scope tokens | Returned facts | Grep/scope ratio |
-|---|---:|---:|---:|---:|
-| `computeScore` | 2,915 | 345 | 2 | 8.45× |
-| `runScan` | 11,023 | 782 | 6 | 14.10× |
-| `runGraphScope` | 9,714 | 820 | 6 | 11.85× |
-| `runImpact` | 9,714 | 821 | 6 | 11.83× |
-| `buildSyncBrief` | 4,786 | 496 | 3 | 9.65× |
-| `runDriftCheck` | 7,042 | 1,194 | 9 | 5.90× |
+## Retrieval quality
 
-| Aggregate | Result |
-|---|---:|
-| Median grep-top-3-to-scope ratio | **10.74×** |
-| Median whole-corpus-to-scope ratio | **916.38×** |
-| Expected-symbol recall | **1.0** |
-| `where-defined` found rate | **1.0** |
-| Exact-match rank | **1 for every task** |
+| Measure | Combined | Hono | MEX |
+|---|---:|---:|---:|
+| Required-file task hits in first response | 11/12 | 6/6 | 5/6 |
+| Required source spans returned | 22/23 | 14/14 | 8/9 |
+| Graph evidence coverage | 12/12 | 6/6 | 6/6 |
+| Required directed flows | — | 6/6 | N/A |
+| Mean distinct Scope queries per candidate run | 1.0 | 1.0 | 1.0 |
 
-Before compact, budgeted retrieval, the median grep-top-3-to-scope ratio was
-1.34×. The `runDriftCheck` case was an over-expansion outlier at 0.26× with 32
-source-bearing facts; it now returns 9 compact facts at 5.90×.
+Hono candidate correctness was 4/6 versus 3/6 for files. Its total new-token reduction was 7.4%, while the paired macro-median reduction was 10.0%; schema-retry-heavy tasks produced high variance. MEX correctness was tied at 3/6, with a 72.3% total new-token reduction.
 
-## Real-agent detail-mode comparison
+## Deterministic holdouts
 
-A headless Claude run used five natural-language tasks to compare the default
-two-stage `minimal` mode with one-shot inline `source` mode.
+Fresh native suites independently checked retrieval without a model:
 
-| Variant | Correct | Mean reported cost | Mean turns | Mean `graph get` calls | Mean Read/Grep fallback |
-|---|---:|---:|---:|---:|---:|
-| `minimal` | 5/5 | $0.20 | 4.4 | 2.2 | 0.0 |
-| `source` | 5/5 | $0.17 | 3.0 | 0.0 | 1.0 |
+| Suite | Runs | File@5 | Source-span recall | Graph coverage | Budget | Other ranked metrics |
+|---|---:|---:|---:|---:|---:|---|
+| TypeScript `src/compiler` | 6/6 | 1.0 | 1.0 | 1.0 | 1.0 | Source-first suite; fact R@5/MRR are not applicable |
+| Mixed TypeScript/Python/Rust synthetic | 9/9 | 1.0 | 1.0 | 1.0 | 1.0 | R@5 0.9167, MRR 0.875, nDCG@10 0.9095 |
 
-Both modes answered every task correctly. `minimal` never fell back to Read/Grep
-and instead followed precise `graph get` expansion handles. `source` used fewer
-turns but fell back on four of five tasks when the inline source did not cover the
-answer. This result supports `minimal` as the predictable default while keeping
-`--detail source` available.
+Both suites produced identical normalized graph hashes across two rebuilds. Integrity gates found no extraction/storage loss, duplicate or dangling graph rows, FTS drift, invalid confidence values, or suspicious production-to-test edges.
 
 ## Limits on interpretation
 
-- The sample is small: six symbol tasks and five natural-language tasks.
-- It covers one mid-size repository and one model.
-- Reported model cost is prompt-cache dominated and varied by roughly 35%;
-  correctness and fallback behavior are the stronger signals.
-- The retrieval ratio compares one graph response with a synthetic grep baseline.
-- The agent comparison tests two graph detail modes. It does not include a
-  no-graph arm and does not aggregate raw transcript tokens.
+- This was one repetition per task and one model. Per-task efficiency and correctness remain noisy.
+- The headless pilot compares the candidate with files-only search. It does **not** include the released `main` graph implementation as an arm.
+- TypeScript testing uses a sparse checkout of the real repository's complete `src/compiler` subtree, not the full TypeScript monorepo.
+- Classical fact R@5/MRR/nDCG are meaningful for fact-emitting suites. Source-first holdouts instead gate the required files, exact source spans, real graph evidence, flows when declared, and output budget.
+- The richer compiler-backed graph uses more disk than 0.7.1; storage and incremental/no-op build optimization are follow-up work.
 
-These results therefore validate retrieval compactness, recall, determinism, and
-agent navigation behavior. They do not establish an end-to-end
-graph-versus-no-graph token-savings claim.
+These results support the release claim that source-backed Scope can reduce agent context while preserving or slightly improving answer correctness in this pilot. They do not establish a universal token-savings percentage.
 
 ## Reproduce
 
 ```bash
+npm ci
 npm run build
-npm run eval
-npm run eval:e2e
-node evaluate/agent-e2e-model.mjs
+npm run eval:test
+node evaluate/graph/index.mjs --help
+node evaluate/compare/index.mjs --help
 ```
 
-The real-model runner requires the Claude CLI and incurs model usage. The first
-three commands are local and deterministic.
+Native suites are local and deterministic. Headless comparison requires the configured model CLI, consumes model quota, and should use a fresh output directory with the exact suite and subject revisions recorded in its prepare manifest.

--- a/evaluate/adapters/agents/claude.mjs
+++ b/evaluate/adapters/agents/claude.mjs
@@ -1,10 +1,64 @@
 import { parseStructuredAnswer } from "../../compare/lib/answer.mjs";
+import { BASH_GUARD_DENIAL } from "../../compare/lib/bash-guard.mjs";
 import { contentText, parseEventStream, toolMetrics, usageRecord } from "./shared.mjs";
+
+const CLAUDE_BASH_HOOK_NAME = "PreToolUse:Bash";
+
+function bashGuardLifecycle(events, toolCalls) {
+  const lifecycle = events.filter((event) => event?.type === "system"
+    && ["hook_started", "hook_response"].includes(event.subtype)
+    && event.hook_event === "PreToolUse"
+    && event.hook_name === CLAUDE_BASH_HOOK_NAME);
+  const unique = new Map();
+  let malformed = 0;
+  for (const event of lifecycle) {
+    if (typeof event.hook_id !== "string" || !event.hook_id) { malformed += 1; continue; }
+    unique.set(`${event.subtype}:${event.hook_id}`, event);
+  }
+  const starts = [...unique.values()].filter((event) => event.subtype === "hook_started");
+  const responses = [...unique.values()].filter((event) => event.subtype === "hook_response");
+  const startIds = new Set(starts.map((event) => event.hook_id));
+  const responseIds = new Set(responses.map((event) => event.hook_id));
+  const completeIds = [...startIds].filter((id) => responseIds.has(id));
+  const bashCalls = toolCalls.filter((call) => call.name === "Bash").length;
+  const violations = [];
+  if (malformed) violations.push(`${malformed} malformed guard lifecycle event(s)`);
+  if (starts.length !== responses.length || completeIds.length !== starts.length) {
+    violations.push(`${starts.length} guard start(s), ${responses.length} response(s), ${completeIds.length} complete pair(s)`);
+  }
+  if (completeIds.length !== bashCalls) {
+    violations.push(`${bashCalls} Bash tool use(s) but ${completeIds.length} complete guard lifecycle pair(s)`);
+  }
+  const failed = responses.filter((event) => event.outcome !== "success" || event.exit_code !== 0);
+  if (failed.length) {
+    violations.push(`${failed.length} guard response(s) did not complete successfully with exit 0`);
+  }
+  return {
+    valid: violations.length === 0,
+    bashCalls,
+    starts: starts.length,
+    responses: responses.length,
+    complete: completeIds.length,
+    duplicateEvents: Math.max(0, lifecycle.length - unique.size - malformed),
+    responseOutcomes: responses.map((event) => ({
+      hookId: event.hook_id,
+      outcome: event.outcome ?? null,
+      exitCode: Number.isFinite(Number(event.exit_code)) ? Number(event.exit_code) : null,
+    })),
+    violations,
+  };
+}
 
 export const claudeAdapter = {
   id: "claude",
 
-  buildInvocation({ executable = "claude", prefix = [], prompt, model, schema, subjectRoot, tools = "Read,Grep,Glob,Bash", allowedTools = [] }) {
+  buildInvocation({
+    executable = "claude", prefix = [], prompt, model, schema, subjectRoot,
+    tools = "Read,Grep,Glob,Bash", allowedTools = [], settingsPath = null,
+  }) {
+    const isolationArgs = settingsPath
+      ? ["--settings", settingsPath, "--strict-mcp-config", "--no-chrome", "--disable-slash-commands", "--include-hook-events"]
+      : ["--safe-mode"];
     return {
       command: executable,
       args: [
@@ -12,7 +66,8 @@ export const claudeAdapter = {
         "-p", prompt,
         "--output-format", "stream-json",
         "--verbose",
-        "--safe-mode",
+        ...isolationArgs,
+        "--setting-sources", "",
         "--no-session-persistence",
         "--exclude-dynamic-system-prompt-sections",
         "--permission-mode", "dontAsk",
@@ -28,25 +83,42 @@ export const claudeAdapter = {
   parseTranscript(raw, task) {
     const { events, malformedLines } = parseEventStream(raw, "Claude stream");
     const rawUsage = [];
-    const totals = { uncachedInput: 0, cacheWrite: 0, cacheRead: 0, output: 0 };
+    const usageByMessage = new Map();
+    const messageUsageEvents = [];
     const toolCalls = [];
     const byId = new Map();
     let resultValue = "";
     let reportedCostUsd = null;
     let turns = null;
-    let resultPermissionDenials = 0;
+    let resultPermissionDenials = [];
+    let terminalUsage = null;
+    let terminalApiErrorStatus = null;
+    let terminalReason = null;
+    const rateLimitEvents = [];
+    let anonymousMessage = 0;
     for (const event of events) {
-      if (event.type === "assistant") {
+      if (event.type === "rate_limit_event") {
+        rateLimitEvents.push(event.rate_limit_info ?? {});
+      } else if (event.type === "assistant") {
         const value = event.message?.usage;
         if (value) {
           rawUsage.push(value);
-          totals.uncachedInput += Number(value.input_tokens ?? 0);
-          totals.cacheWrite += Number(value.cache_creation_input_tokens ?? 0);
-          totals.cacheRead += Number(value.cache_read_input_tokens ?? 0);
-          totals.output += Number(value.output_tokens ?? 0);
+          const messageId = typeof event.message?.id === "string" && event.message.id
+            ? event.message.id
+            : `anonymous-${++anonymousMessage}`;
+          const normalized = {
+            messageId,
+            inputTokens: Number(value.input_tokens ?? 0),
+            cacheWrite: Number(value.cache_creation_input_tokens ?? value.cache_creation ?? 0),
+            cacheRead: Number(value.cache_read_input_tokens ?? value.cache_read ?? 0),
+            output: Number(value.output_tokens ?? value.output ?? 0),
+          };
+          messageUsageEvents.push(normalized);
+          usageByMessage.set(messageId, normalized);
         }
         for (const block of event.message?.content ?? []) {
           if (block.type !== "tool_use") continue;
+          if (block.id && byId.has(block.id)) continue;
           const call = { id: block.id ?? null, name: block.name, input: block.input ?? {}, status: "attempted", output: null };
           toolCalls.push(call);
           if (call.id) byId.set(call.id, call);
@@ -57,29 +129,119 @@ export const claudeAdapter = {
           const call = byId.get(block.tool_use_id);
           if (!call) continue;
           call.output = contentText(block.content);
-          call.status = block.is_error ? "error" : "executed";
+          if (block.is_error && call.output.includes(BASH_GUARD_DENIAL)) {
+            call.status = "denied";
+            call.denialSource = "eval-bash-guard";
+          } else {
+            call.status = block.is_error ? "error" : "executed";
+          }
         }
       } else if (event.type === "result") {
         resultValue = event.structured_output ?? event.result ?? resultValue;
         if (Number.isFinite(Number(event.total_cost_usd))) reportedCostUsd = Number(event.total_cost_usd);
         if (Number.isFinite(Number(event.num_turns))) turns = Number(event.num_turns);
-        resultPermissionDenials = Array.isArray(event.permission_denials) ? event.permission_denials.length : 0;
+        resultPermissionDenials = Array.isArray(event.permission_denials) ? event.permission_denials : [];
+        if (event.usage && typeof event.usage === "object") terminalUsage = event.usage;
+        if (event.api_error_status !== null && event.api_error_status !== undefined
+          && Number.isFinite(Number(event.api_error_status))) terminalApiErrorStatus = Number(event.api_error_status);
+        if (typeof event.terminal_reason === "string") terminalReason = event.terminal_reason;
       }
     }
+    const rejectedRateLimit = rateLimitEvents.find((event) => event?.status === "rejected") ?? null;
+    const providerFailure = rejectedRateLimit || terminalApiErrorStatus === 429 ? {
+      provider: "claude",
+      type: "rate_limit",
+      retryable: true,
+      rateLimitStatus: rejectedRateLimit?.status ?? null,
+      rateLimitType: rejectedRateLimit?.rateLimitType ?? null,
+      resetsAt: rejectedRateLimit?.resetsAt !== null && rejectedRateLimit?.resetsAt !== undefined
+        && Number.isFinite(Number(rejectedRateLimit.resetsAt)) ? Number(rejectedRateLimit.resetsAt) : null,
+      apiErrorStatus: terminalApiErrorStatus,
+      terminalReason,
+    } : null;
+    const uniqueMessages = [...usageByMessage.values()];
+    const messageTotals = uniqueMessages.reduce((totals, value) => ({
+      inputTokens: totals.inputTokens + value.inputTokens,
+      cacheWrite: totals.cacheWrite + value.cacheWrite,
+      cacheRead: totals.cacheRead + value.cacheRead,
+      output: totals.output + value.output,
+    }), { inputTokens: 0, cacheWrite: 0, cacheRead: 0, output: 0 });
+    const terminal = terminalUsage ? {
+      inputTokens: Number(terminalUsage.input_tokens ?? 0),
+      cacheWrite: Number(terminalUsage.cache_creation_input_tokens ?? terminalUsage.cache_creation ?? 0),
+      cacheRead: Number(terminalUsage.cache_read_input_tokens ?? terminalUsage.cache_read ?? 0),
+      output: Number(terminalUsage.output_tokens ?? terminalUsage.output ?? 0),
+    } : null;
+    const accountingValid = terminal !== null
+      && terminal.inputTokens === messageTotals.inputTokens
+      && terminal.cacheWrite === messageTotals.cacheWrite
+      && terminal.cacheRead === messageTotals.cacheRead;
+    const accountingReason = terminal === null
+      ? "missing_terminal_usage"
+      : accountingValid
+        ? null
+        : "terminal_unique_message_input_cache_mismatch";
+    const selected = accountingValid ? terminal : null;
     const usage = usageRecord({
-      ...totals,
-      reportedInput: totals.uncachedInput + totals.cacheWrite + totals.cacheRead,
-      reportedTotal: totals.uncachedInput + totals.cacheWrite + totals.cacheRead + totals.output,
+      uncachedInput: selected?.inputTokens,
+      cacheWrite: selected?.cacheWrite,
+      cacheRead: selected?.cacheRead,
+      output: selected?.output,
+      reportedInput: selected ? selected.inputTokens + selected.cacheWrite + selected.cacheRead : null,
+      reportedTotal: selected ? selected.inputTokens + selected.cacheWrite + selected.cacheRead + selected.output : null,
       reportedCostUsd,
-    }, rawUsage);
+      accountingValid,
+      accountingReason,
+    }, rawUsage, {
+      terminal: terminal ? {
+        ...terminal,
+        processed: terminal.inputTokens + terminal.cacheWrite + terminal.cacheRead + terminal.output,
+        raw: terminalUsage,
+      } : null,
+      perMessage: {
+        uniqueMessageCount: uniqueMessages.length,
+        duplicateEventCount: Math.max(0, messageUsageEvents.length - uniqueMessages.length),
+        inputTokens: messageTotals.inputTokens,
+        cacheWrite: messageTotals.cacheWrite,
+        cacheRead: messageTotals.cacheRead,
+        output: messageTotals.output,
+        processed: messageTotals.inputTokens + messageTotals.cacheWrite + messageTotals.cacheRead + messageTotals.output,
+        messages: uniqueMessages,
+      },
+    });
+    const seenPermissionDenialToolIds = new Set();
+    const uniqueResultPermissionDenials = resultPermissionDenials.filter((denial) => {
+      const toolUseId = typeof denial?.tool_use_id === "string" && denial.tool_use_id ? denial.tool_use_id : null;
+      if (!toolUseId) return true;
+      if (seenPermissionDenialToolIds.has(toolUseId)) return false;
+      seenPermissionDenialToolIds.add(toolUseId);
+      return true;
+    });
+    const unmatchedPermissionDenials = [];
+    for (const denial of uniqueResultPermissionDenials) {
+      const call = typeof denial?.tool_use_id === "string" ? byId.get(denial.tool_use_id) : null;
+      if (!call) { unmatchedPermissionDenials.push(denial); continue; }
+      call.status = "denied";
+      call.permissionDenial = denial;
+    }
+    const synthesizedPermissionDenials = toolCalls
+      .filter((call) => call.status === "denied" && !call.permissionDenial)
+      .map((call) => ({ tool_name: call.name, tool_use_id: call.id, source: call.denialSource ?? "tool_result" }));
+    const permissionDenialDetails = [...uniqueResultPermissionDenials, ...synthesizedPermissionDenials];
     const tools = toolMetrics(toolCalls, task);
-    tools.permissionDenials += resultPermissionDenials;
+    const guardLifecycle = bashGuardLifecycle(events, toolCalls);
     return {
       provider: "claude",
       usage,
       turns,
       toolCalls,
       ...tools,
+      permissionDenials: toolCalls.filter((call) => call.status === "denied").length + unmatchedPermissionDenials.length,
+      permissionDenialDetails,
+      duplicatePermissionDenials: resultPermissionDenials.length - uniqueResultPermissionDenials.length,
+      unmatchedPermissionDenials: unmatchedPermissionDenials.length,
+      bashGuardLifecycle: guardLifecycle,
+      providerFailure,
       malformedLines,
       structured: parseStructuredAnswer(resultValue),
       rawResult: resultValue,

--- a/evaluate/adapters/agents/shared.mjs
+++ b/evaluate/adapters/agents/shared.mjs
@@ -1,6 +1,7 @@
 import { parseJsonLines } from "../../core/jsonl.mjs";
 import { round } from "../../core/stats.mjs";
-import { evidenceKey, recordEvidenceKey } from "../../graders/retrieval.mjs";
+import { evidenceMatchesRecord } from "../../core/evidence.mjs";
+import { firstResponseMetrics } from "../../graders/retrieval.mjs";
 
 const FILE_SHELL = /(?:^|\s)(?:rg|grep|find|fd|cat|head|tail|sed|awk|ls)(?:\s|$)/;
 
@@ -10,7 +11,7 @@ export function contentText(content) {
   return content == null ? "" : JSON.stringify(content);
 }
 
-export function usageRecord(fields, raw) {
+export function usageRecord(fields, raw, audit = {}) {
   const uncachedInput = Number.isFinite(fields.uncachedInput) ? fields.uncachedInput : null;
   const cacheWrite = Number.isFinite(fields.cacheWrite) ? fields.cacheWrite : null;
   const cacheRead = Number.isFinite(fields.cacheRead) ? fields.cacheRead : null;
@@ -33,6 +34,10 @@ export function usageRecord(fields, raw) {
     reportedCostUsd,
     newTokens,
     cacheUseRatio: cacheRead !== null && cacheDenominator ? round(cacheRead / cacheDenominator) : null,
+    accountingValid: fields.accountingValid !== false,
+    accountingReason: fields.accountingReason ?? null,
+    terminal: audit.terminal ?? null,
+    perMessage: audit.perMessage ?? null,
     raw,
   };
 }
@@ -42,8 +47,7 @@ export function initialScopeRank(payload, task) {
   const facts = records.filter((record) => record.type === "fact");
   const gold = task.gold ?? [];
   if (gold.length) {
-    const keys = new Set(gold.map(evidenceKey));
-    const index = facts.findIndex((fact) => keys.has(recordEvidenceKey(fact)));
+    const index = facts.findIndex((fact) => gold.some((evidence) => evidenceMatchesRecord(evidence, fact)));
     return index < 0 ? null : index + 1;
   }
   const expected = task.expectedSymbols ?? [];
@@ -51,11 +55,16 @@ export function initialScopeRank(payload, task) {
   return index < 0 ? null : index + 1;
 }
 
+export function initialScopeEvidence(payload, task) {
+  const { records, errors } = parseJsonLines(payload, "scope tool result");
+  const metrics = firstResponseMetrics(task, records);
+  return { ...metrics, parseErrors: errors };
+}
+
 function graphKind(command) {
   if (/\bgraph\s+scope\b/.test(command)) return "scope";
   if (/\bgraph\s+get\b/.test(command)) return "get";
   if (/\bgraph\s+query\b/.test(command)) return "query";
-  if (/\bgraph\s+vocab\b/.test(command)) return "vocab";
   if (/\bimpact\b/.test(command)) return "impact";
   return null;
 }
@@ -66,7 +75,11 @@ function scopeQuery(command) {
 }
 
 export function toolMetrics(toolCalls, task) {
-  const graph = { scope: 0, get: 0, query: 0, vocab: 0, impact: 0, calls: 0, distinctScopeQueries: 0, fallbacks: 0, initialScopeRank: null };
+  const graph = {
+    scope: 0, get: 0, query: 0, impact: 0, calls: 0, distinctScopeQueries: 0, fallbacks: 0,
+    initialScopeRank: null, initialFileRank: null, initialFileRecallAt5: null, initialFileHitAt5: null,
+    initialSourceSpanRecall: null, initialDirectedFlowCoverage: null, initialReturnedFiles: [],
+  };
   const scopeQueries = new Set();
   let toolErrors = 0;
   let permissionDenials = 0;
@@ -75,8 +88,9 @@ export function toolMetrics(toolCalls, task) {
     if (call.status === "error") toolErrors += 1;
     if (call.status === "denied") permissionDenials += 1;
     if (typeof call.output === "string") toolResultChars += call.output.length;
-    if (["Read", "Grep", "Glob"].includes(call.name)) graph.fallbacks += 1;
+    if (call.status !== "denied" && ["Read", "Grep", "Glob"].includes(call.name)) graph.fallbacks += 1;
     if (call.name !== "Bash") continue;
+    if (call.status === "denied") continue;
     const command = String(call.input?.command ?? "");
     const kind = graphKind(command);
     if (kind) {
@@ -84,7 +98,16 @@ export function toolMetrics(toolCalls, task) {
       graph.calls += 1;
       if (kind === "scope") {
         scopeQueries.add(scopeQuery(command));
-        if (graph.initialScopeRank === null && typeof call.output === "string") graph.initialScopeRank = initialScopeRank(call.output, task);
+        if (graph.scope === 1 && typeof call.output === "string") {
+          graph.initialScopeRank = initialScopeRank(call.output, task);
+          const evidence = initialScopeEvidence(call.output, task);
+          graph.initialFileRank = evidence.firstRelevantFileRank;
+          graph.initialFileRecallAt5 = evidence.fileRecallAt5;
+          graph.initialFileHitAt5 = evidence.fileHitAt5;
+          graph.initialSourceSpanRecall = evidence.returnedSourceSpanRecall;
+          graph.initialDirectedFlowCoverage = evidence.directedFlowCoverage;
+          graph.initialReturnedFiles = evidence.returnedFiles;
+        }
       }
     } else if (FILE_SHELL.test(command)) graph.fallbacks += 1;
   }

--- a/evaluate/compare/index.mjs
+++ b/evaluate/compare/index.mjs
@@ -6,13 +6,13 @@ import { assertGraphOutputIsolation } from "../core/artifacts.mjs";
 import { buildConfiguredArmArtifacts, prepareEvaluation, validateSubjectFixture } from "./lib/prepare.mjs";
 import { generateReport } from "./lib/report.mjs";
 import { runEvaluation } from "./lib/runner.mjs";
-import { loadSuite, resolveArmCommands, suiteContext } from "./lib/suite.mjs";
+import { loadSuite, resolveArmCommands, resolveSelectedArmIds, suiteContext } from "./lib/suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const HARNESS_ROOT = resolve(HERE, "..", "..");
 
 export function parseArgs(argv) {
-  const args = { mode: null, repo: process.cwd(), model: null, agent: "claude", policy: "forced-first", repetitions: 1, timeoutMs: 300_000, resume: false, armCli: {}, noIndex: false };
+  const args = { mode: null, repo: process.cwd(), model: null, agent: "claude", policy: "forced-first", repetitions: null, timeoutMs: 300_000, resume: false, armCli: {}, arms: null, noIndex: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (["--validate", "--prepare", "--run", "--report"].includes(arg)) {
@@ -28,6 +28,12 @@ export function parseArgs(argv) {
     else if (arg === "--timeout-ms") args.timeoutMs = Number(argv[++i]);
     else if (arg === "--resume") args.resume = true;
     else if (arg === "--no-index") args.noIndex = true;
+    else if (arg === "--arms") {
+      if (args.arms !== null) throw new Error("--arms may be specified only once");
+      const value = argv[++i];
+      if (typeof value !== "string" || value.trim() === "") throw new Error("--arms requires a comma-separated list of arm IDs");
+      args.arms = value.split(",").map((id) => id.trim());
+    }
     else if (arg === "--arm-cli") {
       const value = argv[++i] ?? "", split = value.indexOf("=");
       if (split < 1) throw new Error("--arm-cli must be id=/path/to/cli.js");
@@ -41,7 +47,7 @@ export function parseArgs(argv) {
   if (!args.mode) throw new Error("choose one of --validate, --prepare, --run, or --report");
   if (!args.suite) throw new Error("--suite <file> is required");
   if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) throw new Error("--timeout-ms must be positive");
-  if (!Number.isInteger(args.repetitions) || args.repetitions < 1) throw new Error("--repetitions must be a positive integer");
+  if (args.repetitions !== null && (!Number.isInteger(args.repetitions) || args.repetitions < 1)) throw new Error("--repetitions must be a positive integer");
   if (!["claude", "codex"].includes(args.agent)) throw new Error("--agent must be claude or codex");
   if (!["forced-first", "optional"].includes(args.policy)) throw new Error("--policy must be forced-first or optional");
   return args;
@@ -50,13 +56,14 @@ export function parseArgs(argv) {
 export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const suite = loadSuite(args.suite);
+  const selectedArmIds = resolveSelectedArmIds(suite, args.arms);
   const outputDir = args.output ?? join(HARNESS_ROOT, ".mex", "eval-results", "compare", suite.id);
   if (args.mode === "validate") {
-    console.log(`valid suite: ${suite.id} (${suite.tasks.length} tasks, ${Object.keys(suite.arms).length} arms)`);
+    console.log(`valid suite: ${suite.id} (${suite.tasks.length} tasks, ${selectedArmIds.length} selected arms: ${selectedArmIds.join(", ")})`);
     return;
   }
   if (args.mode === "report") {
-    const report = generateReport({ suite, outputDir });
+    const report = generateReport({ suite, outputDir, selectedArmIds: args.arms === null ? null : selectedArmIds });
     console.log(JSON.stringify(report, null, 2));
     return;
   }
@@ -65,8 +72,10 @@ export async function main(argv = process.argv.slice(2)) {
   const context = suiteContext(suite, HARNESS_ROOT, args.repo);
   if (args.mode === "prepare") {
     const subjectFixture = validateSubjectFixture(suite, args.repo);
-    const artifacts = buildConfiguredArmArtifacts({ suite, context, outputDir, overrides: args.armCli });
-    const armCommands = resolveArmCommands(suite, context, artifacts.overrides);
+    const artifacts = buildConfiguredArmArtifacts({
+      suite, context, outputDir, overrides: args.armCli, selectedArmIds,
+    });
+    const armCommands = resolveArmCommands(suite, context, artifacts.overrides, selectedArmIds);
     const manifest = prepareEvaluation({
       suite,
       subjectRoot: args.repo,
@@ -76,27 +85,29 @@ export async function main(argv = process.argv.slice(2)) {
       index: !args.noIndex,
       subjectFixture,
       artifactMetadata: artifacts.metadata,
+      selectedArmIds,
     });
     console.log(`prepared ${suite.id} at ${outputDir} (${manifest.goldEvidence.length} tasks; no repository was cloned)`);
     return;
   }
   const existingOverrides = { ...args.armCli };
-  for (const [armId, arm] of Object.entries(suite.arms)) {
+  for (const armId of selectedArmIds) {
+    const arm = suite.arms[armId];
     if (!existingOverrides[armId] && arm.buildFromGit) {
       const artifactCli = join(outputDir, "artifacts", armId, arm.buildFromGit.cli);
       if (existsSync(artifactCli)) existingOverrides[armId] = artifactCli;
     }
   }
-  const armCommands = resolveArmCommands(suite, context, existingOverrides);
+  const armCommands = resolveArmCommands(suite, context, existingOverrides, selectedArmIds);
   if (args.mode === "run") {
     if (!args.model) throw new Error("--run requires --model <name>");
     const agentCommand = args.agentCli ? [args.agentCli] : undefined;
     const result = await runEvaluation({
       suite, subjectRoot: args.repo, outputDir, armCommands, model: args.model,
       timeoutMs: args.timeoutMs, resume: args.resume, agentCommand,
-      agentId: args.agent, policy: args.policy, repetitions: args.repetitions,
+      agentId: args.agent, policy: args.policy, repetitions: args.repetitions, selectedArmIds,
     });
-    const report = generateReport({ suite, outputDir, rows: result.rows });
+    const report = generateReport({ suite, outputDir, rows: result.rows, selectedArmIds });
     console.log(JSON.stringify(report, null, 2));
     if (!report.executionValid) process.exitCode = 1;
     return;

--- a/evaluate/compare/lib/answer.mjs
+++ b/evaluate/compare/lib/answer.mjs
@@ -1,22 +1,39 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
+import { evidencePath, evidenceSpan } from "../../core/evidence.mjs";
+
+export const MIN_SUBSTANTIVE_ANSWER_LENGTH = 40;
 
 export const ANSWER_SCHEMA = {
   type: "object",
   additionalProperties: false,
   properties: {
-    answer: { type: "string" },
-    symbols: { type: "array", items: { type: "string" } },
+    answer: {
+      type: "string",
+      minLength: MIN_SUBSTANTIVE_ANSWER_LENGTH,
+      description: `Required. A substantive, source-grounded explanatory answer of at least ${MIN_SUBSTANTIVE_ANSWER_LENGTH} characters; never a placeholder.`,
+    },
+    symbols: {
+      type: "array",
+      minItems: 1,
+      description: "Required and non-empty. Exact source declaration names as written in the repository; never graph node IDs.",
+      items: { type: "string", minLength: 1 },
+    },
     evidence: {
       type: "array",
+      minItems: 1,
+      description: "Required and non-empty. Repository-relative source citations that support the answer.",
       items: {
         type: "object",
         additionalProperties: false,
-        properties: { path: { type: "string" }, line: { type: "integer", minimum: 1 } },
+        properties: { path: { type: "string", minLength: 1 }, line: { type: "integer", minimum: 1 } },
         required: ["path", "line"],
       },
     },
-    complete: { type: "boolean" },
+    complete: {
+      type: "boolean",
+      description: "Required. True only when the substantive answer covers the question.",
+    },
   },
   required: ["answer", "symbols", "evidence", "complete"],
 };
@@ -34,10 +51,26 @@ export function parseStructuredAnswer(value) {
     }
   }
   if (!answer || typeof answer !== "object" || Array.isArray(answer)) return { ok: false, error: "answer must be an object" };
-  if (typeof answer.answer !== "string" || !Array.isArray(answer.symbols) || answer.symbols.some((v) => typeof v !== "string")) {
-    return { ok: false, error: "answer and symbols have invalid types" };
+  const requiredKeys = ANSWER_SCHEMA.required;
+  const keys = Object.keys(answer);
+  const missingKeys = requiredKeys.filter((key) => !Object.hasOwn(answer, key));
+  const extraKeys = keys.filter((key) => !requiredKeys.includes(key));
+  if (missingKeys.length > 0) return { ok: false, error: `answer is missing required keys: ${missingKeys.join(", ")}` };
+  if (extraKeys.length > 0) return { ok: false, error: `answer has unsupported keys: ${extraKeys.join(", ")}` };
+  if (typeof answer.answer !== "string" || Array.from(answer.answer).length < MIN_SUBSTANTIVE_ANSWER_LENGTH) {
+    return { ok: false, error: `answer must be a substantive string of at least ${MIN_SUBSTANTIVE_ANSWER_LENGTH} characters` };
   }
-  if (!Array.isArray(answer.evidence) || answer.evidence.some((e) => !e || typeof e.path !== "string" || !Number.isInteger(e.line) || e.line < 1)) {
+  if (!Array.isArray(answer.symbols) || answer.symbols.length === 0
+    || answer.symbols.some((value) => typeof value !== "string" || value.length === 0)) {
+    return { ok: false, error: "symbols must be a non-empty array of non-empty strings" };
+  }
+  if (!Array.isArray(answer.evidence) || answer.evidence.length === 0 || answer.evidence.some((evidence) => {
+    if (!evidence || typeof evidence !== "object" || Array.isArray(evidence)) return true;
+    const evidenceKeys = Object.keys(evidence);
+    if (evidenceKeys.length !== 2 || !Object.hasOwn(evidence, "path") || !Object.hasOwn(evidence, "line")) return true;
+    return typeof evidence.path !== "string" || evidence.path.length === 0
+      || !Number.isInteger(evidence.line) || evidence.line < 1;
+  })) {
     return { ok: false, error: "evidence must contain path and positive integer line" };
   }
   if (typeof answer.complete !== "boolean") return { ok: false, error: "complete must be boolean" };
@@ -51,11 +84,15 @@ export function gradeAnswer(answer, taskOrSymbols, subjectRoot = null) {
   const ranks = expected.map((symbol) => answer.symbols.indexOf(symbol));
   const matched = expected.filter((symbol) => answer.symbols.includes(symbol));
   const missing = expected.filter((symbol) => !answer.symbols.includes(symbol));
-  const expectedPaths = Array.isArray(taskOrSymbols)
-    ? []
-    : (taskOrSymbols.gold ?? []).map((entry) => entry.path.replace(/^\.\//, "").replaceAll("\\", "/"));
-  const citedPaths = new Set(answer.evidence.map((entry) => entry.path.replace(/^\.\//, "").replaceAll("\\", "/")));
+  const gold = Array.isArray(taskOrSymbols) ? [] : (taskOrSymbols.gold ?? []);
+  const expectedPaths = gold.map(evidencePath);
+  const citedPaths = new Set(answer.evidence.map(evidencePath));
   const missingEvidencePaths = expectedPaths.filter((path) => !citedPaths.has(path));
+  const missingEvidenceSpans = gold.filter((entry) => {
+    const span = evidenceSpan(entry);
+    return span && !answer.evidence.some((citation) => evidencePath(citation) === evidencePath(entry)
+      && citation.line >= span.startLine && citation.line <= span.endLine);
+  }).map((entry) => ({ symbol: entry.symbol, path: evidencePath(entry), ...evidenceSpan(entry) }));
   const invalidEvidence = [];
   if (!Array.isArray(taskOrSymbols) && taskOrSymbols.gold?.length && subjectRoot) {
     const root = resolve(subjectRoot);
@@ -69,10 +106,11 @@ export function gradeAnswer(answer, taskOrSymbols, subjectRoot = null) {
     }
   }
   return {
-    correct: expected.length > 0 && missing.length === 0 && missingEvidencePaths.length === 0 && invalidEvidence.length === 0 && answer.complete === true,
+    correct: expected.length > 0 && missing.length === 0 && missingEvidencePaths.length === 0 && missingEvidenceSpans.length === 0 && invalidEvidence.length === 0 && answer.complete === true,
     matchedSymbols: matched,
     missingSymbols: missing,
     missingEvidencePaths,
+    missingEvidenceSpans,
     invalidEvidence,
     answerSymbolRank: ranks.filter((rank) => rank >= 0).length ? Math.min(...ranks.filter((rank) => rank >= 0)) + 1 : null,
   };

--- a/evaluate/compare/lib/bash-guard.mjs
+++ b/evaluate/compare/lib/bash-guard.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { shellWords, validateTranscriptPolicy } from "./policy.mjs";
+
+export const BASH_GUARD_DENIAL = "MEX_EVAL_BASH_DENIED";
+export const BASH_GUARD_HOOK_NAME = "MEX eval Bash policy guard";
+
+const ALLOWED_BASH_INPUT_FIELDS = new Set(["command", "description", "timeout"]);
+
+function forbiddenInputFields(input) {
+  return Object.keys(input).filter((field) => !ALLOWED_BASH_INPUT_FIELDS.has(field));
+}
+
+export function guardBashInput(input, command) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return { allowed: false, violations: ["invalid PreToolUse input"] };
+  }
+  if (input.hook_event_name !== "PreToolUse" || input.tool_name !== "Bash") {
+    return { allowed: false, violations: ["guard invoked outside Bash PreToolUse"] };
+  }
+  if (!Array.isArray(command) || command.length === 0 || command.some((part) => typeof part !== "string" || !part)) {
+    return { allowed: false, violations: ["missing exact graph-wrapper command"] };
+  }
+  if (!input.tool_input || typeof input.tool_input !== "object" || Array.isArray(input.tool_input)) {
+    return { allowed: false, violations: ["invalid Bash tool input"] };
+  }
+  const forbidden = forbiddenInputFields(input.tool_input);
+  if (forbidden.length) {
+    return { allowed: false, violations: [`forbidden Bash input field(s): ${forbidden.sort().join(", ")}`] };
+  }
+  if (typeof input.tool_input.command !== "string" || !input.tool_input.command.trim()) {
+    return { allowed: false, violations: ["missing Bash command"] };
+  }
+  const call = {
+    name: "Bash",
+    status: "attempted",
+    input: input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {},
+  };
+  let words;
+  try { words = shellWords(String(call.input.command ?? "")); }
+  catch { return { allowed: false, violations: ["malformed shell command"] }; }
+  if (!command.every((part, index) => words[index] === part)) {
+    return { allowed: false, violations: ["graph wrapper must be invoked directly"] };
+  }
+  const violations = validateTranscriptPolicy(
+    [call],
+    "guard",
+    { kind: "graph", role: "released" },
+    { guard: command },
+    { requireGraphFirst: false },
+  );
+  return { allowed: violations.length === 0, violations };
+}
+
+function deny(reason) {
+  process.stdout.write(`${JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: `${BASH_GUARD_DENIAL}: ${reason}`,
+    },
+  })}\n`);
+}
+
+function allow() {
+  process.stdout.write("{}\n");
+}
+
+async function main() {
+  try {
+    const configPath = process.argv[2];
+    if (!configPath) return deny("guard configuration is missing");
+    const config = JSON.parse(readFileSync(configPath, "utf8"));
+    let raw = "";
+    for await (const chunk of process.stdin) raw += chunk;
+    const decision = guardBashInput(JSON.parse(raw), config.command);
+    if (!decision.allowed) deny(decision.violations.join("; "));
+    else allow();
+  } catch (error) {
+    deny(`guard failed closed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+if (process.argv[1] && realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1])) await main();

--- a/evaluate/compare/lib/policy.mjs
+++ b/evaluate/compare/lib/policy.mjs
@@ -1,5 +1,9 @@
-const CONTROL_OPERATOR = /(?:\r|\n|&&|\|\||[;|<>`]|\$\()/;
 const SQLITE = /\b(?:sqlite3?|better-sqlite3|graph\.db(?:-wal|-shm)?)\b/i;
+const EXECUTABLE_TOOLS = new Set(["Bash", "Read", "Grep", "Glob"]);
+const FOLLOWUP_SCOPE_STATUSES = {
+  "graph query": new Set(["partial", "degraded", "no-match"]),
+  "graph get": new Set(["partial", "degraded"]),
+};
 
 export function shellQuote(word) {
   return /^[A-Za-z0-9_./:@%+=,-]+$/.test(word) ? word : `'${word.replaceAll("'", `'\\''`)}'`;
@@ -21,8 +25,35 @@ export function shellWords(command) {
   return words;
 }
 
+/** Detect shell composition without mistaking quoted/escaped search syntax for a pipe. */
+function hasControlOperator(command) {
+  let quote = null;
+  let escaped = false;
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (escaped) { escaped = false; continue; }
+    if (char === "\\" && quote !== "'") { escaped = true; continue; }
+    if (quote) {
+      if (char === quote) { quote = null; continue; }
+      // Command substitution remains active inside double quotes.
+      if (quote === '"' && (char === "`" || (char === "$" && command[index + 1] === "("))) return true;
+      continue;
+    }
+    if (char === "'" || char === '"') { quote = char; continue; }
+    if (char === "\r" || char === "\n" || char === ";" || char === "|" || char === "<" || char === ">" || char === "`") return true;
+    if (char === "&") return true;
+    if (char === "$" && command[index + 1] === "(") return true;
+  }
+  return false;
+}
+
 function startsWith(words, prefix) {
   return prefix.every((word, index) => words[index] === word);
+}
+
+function containsSequence(words, sequence) {
+  if (sequence.length === 0 || sequence.length > words.length) return false;
+  return words.some((_, start) => sequence.every((word, offset) => words[start + offset] === word));
 }
 
 function unwrapShell(words) {
@@ -35,20 +66,108 @@ function unwrapShell(words) {
 
 const FILE_COMMANDS = new Set(["rg", "grep", "find", "fd", "cat", "head", "tail", "sed", "awk", "ls", "pwd", "wc"]);
 
+function readOnlyFileComposition(command) {
+  const segments = [];
+  const operators = [];
+  let segment = "", quote = null, escaped = false;
+  const push = (operator = null) => {
+    if (!segment.trim()) return false;
+    segments.push(segment.trim());
+    segment = "";
+    if (operator) operators.push(operator);
+    return true;
+  };
+  for (let index = 0; index < command.length; index++) {
+    const char = command[index];
+    if (escaped) { segment += char; escaped = false; continue; }
+    if (char === "\\" && quote !== "'") { segment += char; escaped = true; continue; }
+    if (quote) {
+      segment += char;
+      if (char === quote) quote = null;
+      else if (quote === '"' && (char === "`" || (char === "$" && command[index + 1] === "("))) return null;
+      continue;
+    }
+    if (char === "'" || char === '"') { quote = char; segment += char; continue; }
+    if (char === "`" || char === ";" || char === "<" || char === ">" || char === "\r" || char === "\n") return null;
+    if (char === "$" && command[index + 1] === "(") return null;
+    if (char === "&") {
+      if (command[index + 1] !== "&" || !push("&&")) return null;
+      index += 1;
+      continue;
+    }
+    if (char === "|") {
+      if (command[index + 1] === "|" || !push("|")) return null;
+      continue;
+    }
+    segment += char;
+  }
+  if (quote || escaped || !push()) return null;
+  let commands;
+  try { commands = segments.map((value) => shellWords(value)); } catch { return null; }
+  const valid = commands.every((words, index) => {
+    const executable = words[0]?.split("/").at(-1);
+    if (executable === "cd") return index === 0 && words.length === 2 && operators[0] === "&&";
+    return FILE_COMMANDS.has(executable);
+  });
+  return valid ? commands : null;
+}
+
+export function isDeniedFileShellAttempt(call, armCommands) {
+  if (call?.name !== "Bash" || call.status !== "denied") return false;
+  const command = String(call.input?.command ?? "").trim();
+  if (!command || SQLITE.test(command)) return false;
+  if (hasControlOperator(command)) {
+    const commands = readOnlyFileComposition(command);
+    if (!commands) return false;
+    if (commands.some((words) => Object.values(armCommands).some((prefix) => containsSequence(words, prefix)))) return false;
+    return true;
+  }
+  let words;
+  try { words = unwrapShell(shellWords(command)); } catch { return false; }
+  if (Object.values(armCommands).some((prefix) => containsSequence(words, prefix))) return false;
+  return FILE_COMMANDS.has(words[0]?.split("/").at(-1));
+}
+
+function scopeStatus(output) {
+  const records = [];
+  for (const line of String(output ?? "").split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch { return null; }
+  }
+  const terminal = records.at(-1);
+  return terminal?.type === "summary" && typeof terminal.status === "string" ? terminal.status : null;
+}
+
+function scopeQuery(command) {
+  const match = command.match(/\bgraph\s+scope\s+(?:"([^"]*)"|'([^']*)'|([^\n]+?))(?:\s+--|$)/);
+  return (match?.[1] ?? match?.[2] ?? match?.[3] ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
 export function validateTranscriptPolicy(toolCalls, armId, arm, armCommands, options = {}) {
   const violations = [];
   const graphCommandOwners = Object.entries(armCommands);
   const graphCalls = [];
   for (const call of toolCalls) {
     const serializedInput = JSON.stringify(call.input ?? {});
-    if (SQLITE.test(serializedInput)) violations.push(`raw SQLite access through ${call.name}`);
+    // StructuredOutput is Claude's final answer transport, not an executable tool.
+    // Prose may legitimately explain graph.db without attempting to inspect it.
+    if (EXECUTABLE_TOOLS.has(call.name) && SQLITE.test(serializedInput)) violations.push(`raw SQLite access through ${call.name}`);
+    if (isDeniedFileShellAttempt(call, armCommands)) continue;
     if (call.name !== "Bash") continue;
     const command = String(call.input?.command ?? "").trim();
-    if (CONTROL_OPERATOR.test(command)) { violations.push(`shell control operator: ${command}`); continue; }
+    if (hasControlOperator(command)) { violations.push(`shell control operator: ${command}`); continue; }
     if (SQLITE.test(command)) { violations.push(`raw SQLite access: ${command}`); continue; }
     let words;
     try { words = unwrapShell(shellWords(command)); } catch (error) { violations.push(error.message); continue; }
     const executable = words[0]?.split("/").at(-1);
+    const embeddedGraphBinary = graphCommandOwners.find(([, prefix]) => containsSequence(words, prefix) && !startsWith(words, prefix));
+    if (embeddedGraphBinary) {
+      const [owner] = embeddedGraphBinary;
+      violations.push(owner === armId ? `indirect graph binary: ${command}` : `cross-arm binary (${owner}): ${command}`);
+      continue;
+    }
     if (options.allowFileShell && FILE_COMMANDS.has(executable)) continue;
     if (arm.kind === "grep") { violations.push("grep arm used non-file-search Bash"); continue; }
     const own = armCommands[armId];
@@ -59,14 +178,27 @@ export function validateTranscriptPolicy(toolCalls, armId, arm, armCommands, opt
     }
     const args = words.slice(own.length);
     const commandKey = args[0] === "impact" ? "impact" : `${args[0] ?? ""} ${args[1] ?? ""}`.trim();
-    const allowed = arm.vocabRetry
-      ? new Set(["graph scope", "graph query", "graph get", "graph vocab", "impact"])
-      : new Set(["graph scope", "graph query", "graph get", "impact"]);
+    const allowed = new Set(["graph scope", "graph query", "graph get", "impact"]);
     if (!allowed.has(commandKey)) violations.push(`disallowed graph command: ${command}`);
-    else graphCalls.push(commandKey);
+    else graphCalls.push({ command: commandKey, invocation: command, status: call.status, output: call.output });
   }
-  if (arm.kind === "graph" && options.requireGraphFirst !== false && graphCalls[0] !== "graph scope") violations.push("graph arm did not start with graph scope");
-  if (graphCalls.filter((command) => command === "graph vocab").length > 1) violations.push("more than one graph vocab call");
-  if (!arm.vocabRetry && graphCalls.includes("graph vocab")) violations.push("baseline arm used graph vocab");
+  if (arm.kind === "graph" && options.requireGraphFirst !== false && graphCalls[0]?.command !== "graph scope") violations.push("graph arm did not start with graph scope");
+  const candidate = arm.role === "patched";
+  if (candidate) {
+    let latestScopeStatus = null;
+    for (const call of graphCalls) {
+      if (call.command === "graph scope") {
+        latestScopeStatus = call.status === "executed" ? scopeStatus(call.output) : null;
+        continue;
+      }
+      const allowedStatuses = FOLLOWUP_SCOPE_STATUSES[call.command];
+      if (allowedStatuses && !allowedStatuses.has(latestScopeStatus)) {
+        violations.push(`${call.command} requires a preceding scope summary with status ${[...allowedStatuses].join(", ")} (got ${latestScopeStatus ?? "missing"})`);
+      }
+    }
+    const distinctQueries = new Set(graphCalls.filter((call) => call.command === "graph scope")
+      .map((call) => scopeQuery(call.invocation)).filter(Boolean));
+    if (distinctQueries.size > 1) violations.push(`candidate used ${distinctQueries.size} distinct graph scope queries; maximum is 1`);
+  }
   return violations;
 }

--- a/evaluate/compare/lib/prepare.mjs
+++ b/evaluate/compare/lib/prepare.mjs
@@ -2,10 +2,11 @@ import { constants, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSy
 import { createHash } from "node:crypto";
 import { dirname, join, relative, resolve } from "node:path";
 import { runSync } from "./process.mjs";
-import { expandToken, suiteHash } from "./suite.mjs";
+import { expandToken, resolveSelectedArmIds, suiteHash } from "./suite.mjs";
 import { validateEvidenceInSource } from "../../graph/lib/fixture.mjs";
 import { commandBundleIdentity } from "../../core/hash.mjs";
 import { inspectGraphDatabase } from "../../graph/lib/integrity.mjs";
+import { inspectGoldCoverage } from "../../graph/lib/coverage.mjs";
 
 function sha256(value) { return createHash("sha256").update(value).digest("hex"); }
 
@@ -78,12 +79,13 @@ export function validateSubjectFixture(suite, subjectRoot) {
 }
 
 /** Build configured control CLIs from local git objects. This uses git archive, never clone. */
-export function buildConfiguredArmArtifacts({ suite, context, outputDir, overrides }) {
+export function buildConfiguredArmArtifacts({ suite, context, outputDir, overrides, selectedArmIds = null }) {
   const generated = { ...overrides };
   const metadata = {};
   const artifactsDir = join(outputDir, "artifacts");
   mkdirSync(artifactsDir, { recursive: true });
-  for (const [armId, arm] of Object.entries(suite.arms)) {
+  for (const armId of resolveSelectedArmIds(suite, selectedArmIds)) {
+    const arm = suite.arms[armId];
     if (arm.kind !== "graph" || !arm.buildFromGit) continue;
     const build = arm.buildFromGit;
     const sourceRoot = resolve(expandToken(build.root, context));
@@ -142,14 +144,16 @@ export class GraphDbGuard {
   }
 }
 
-export function buildArmIndices({ suite, subjectRoot, armCommands, outputDir }) {
+export function buildArmIndices({ suite, subjectRoot, armCommands, outputDir, goldEvidence = [], selectedArmIds = null }) {
+  const armIds = resolveSelectedArmIds(suite, selectedArmIds);
   const indexDir = join(outputDir, "indices");
   const scratch = join(outputDir, ".prepare-scratch");
   mkdirSync(indexDir, { recursive: true });
   const guard = new GraphDbGuard(subjectRoot, scratch);
   const indices = {};
   try {
-    for (const [armId, arm] of Object.entries(suite.arms)) {
+    for (const armId of armIds) {
+      const arm = suite.arms[armId];
       if (arm.kind !== "graph") continue;
       guard.clear();
       const [command, ...prefix] = armCommands[armId];
@@ -167,6 +171,10 @@ export function buildArmIndices({ suite, subjectRoot, armCommands, outputDir }) 
         buildOutput: result.stdout.trim(),
         buildSummary,
         integrity: sqlite ? inspectGraphDatabase(snapshot, buildSummary) : null,
+        goldCoverage: sqlite ? inspectGoldCoverage(snapshot, goldEvidence.map((task) => ({
+          ...suite.tasks.find((entry) => entry.id === task.taskId),
+          gold: task.symbols,
+        }))) : { status: "unavailable", reason: "graph index is not SQLite", tasks: [] },
       };
     }
   } finally {
@@ -176,11 +184,16 @@ export function buildArmIndices({ suite, subjectRoot, armCommands, outputDir }) 
   return indices;
 }
 
-export function prepareEvaluation({ suite, subjectRoot, harnessRoot, armCommands, outputDir, index = true, subjectFixture, artifactMetadata = {} }) {
+export function prepareEvaluation({
+  suite, subjectRoot, harnessRoot, armCommands, outputDir, index = true,
+  subjectFixture, artifactMetadata = {}, selectedArmIds = null,
+}) {
+  const armIds = resolveSelectedArmIds(suite, selectedArmIds);
   mkdirSync(outputDir, { recursive: true });
   const { subject, goldEvidence } = subjectFixture ?? validateSubjectFixture(suite, subjectRoot);
   const harness = repositoryIdentity(harnessRoot);
-  const cli = Object.fromEntries(Object.entries(armCommands).map(([armId, command]) => {
+  const cli = Object.fromEntries(armIds.filter((armId) => armCommands[armId]).map((armId) => {
+    const command = armCommands[armId];
     const bundle = commandBundleIdentity(command);
     const script = bundle.entrypoint;
     return [armId, {
@@ -192,10 +205,18 @@ export function prepareEvaluation({ suite, subjectRoot, harnessRoot, armCommands
       revision: artifactMetadata[armId]?.revision ?? suite.arms[armId].revision ?? null,
     }];
   }));
-  const indices = index ? buildArmIndices({ suite, subjectRoot, armCommands, outputDir }) : {};
+  const indices = index
+    ? buildArmIndices({ suite, subjectRoot, armCommands, outputDir, goldEvidence, selectedArmIds: armIds })
+    : {};
+  const graphCoverage = Object.fromEntries(armIds.map((armId) => [armId,
+    suite.arms[armId].kind === "graph"
+      ? (indices[armId]?.goldCoverage ?? { status: "not_prepared", tasks: [] })
+      : { status: "not_applicable", reason: "files-only arm has no graph", tasks: [] },
+  ]));
   const manifest = {
-    schemaVersion: 2, suiteId: suite.id, suiteSha256: suiteHash(suite), preparedAt: new Date().toISOString(),
-    subject, harness: { ...harness, diffSha256: worktreeDiffHash(harnessRoot) }, cli, indices, goldEvidence,
+    schemaVersion: 3, suiteId: suite.id, suiteSha256: suiteHash(suite), preparedAt: new Date().toISOString(),
+    selectedArmIds: armIds,
+    subject, harness: { ...harness, diffSha256: worktreeDiffHash(harnessRoot) }, cli, indices, goldEvidence, graphCoverage,
   };
   writeFileSync(join(outputDir, "prepare.json"), `${JSON.stringify(manifest, null, 2)}\n`);
   return manifest;

--- a/evaluate/compare/lib/prepare.mjs
+++ b/evaluate/compare/lib/prepare.mjs
@@ -43,8 +43,12 @@ export function worktreeDiffHash(root) {
 }
 
 function findSymbol(root, symbol) {
-  const result = runSync("rg", ["--line-number", "--column", "--no-heading", "--color", "never", "--fixed-strings", "--glob", "!.git/**", "--glob", "!.mex/**", symbol, "."], { cwd: root });
-  if (![0, 1].includes(result.code)) throw new Error(`rg failed while locating ${symbol}: ${result.stderr.trim()}`);
+  const result = runSync("git", [
+    "grep", "--no-index", "--line-number", "--column", "--no-color",
+    "--fixed-strings", "--exclude-standard", "-e", symbol,
+    "--", ".", ":(exclude).git/**", ":(exclude).mex/**",
+  ], { cwd: root });
+  if (![0, 1].includes(result.code)) throw new Error(`git grep failed while locating ${symbol}: ${result.stderr.trim()}`);
   const rows = result.stdout.split("\n").filter(Boolean).map((line) => {
     const match = line.match(/^(.+?):(\d+):(\d+):(.*)$/);
     if (!match) return null;

--- a/evaluate/compare/lib/prompt.mjs
+++ b/evaluate/compare/lib/prompt.mjs
@@ -1,24 +1,35 @@
 import { shellQuote } from "./policy.mjs";
+import { MIN_SUBSTANTIVE_ANSWER_LENGTH } from "./answer.mjs";
 
 export function buildPrompt(task, armId, arm, command, subjectRoot, policy = "forced-first") {
   const common = [
     "Investigate the repository and answer the question using only the permitted tools.",
     `The repository root is ${subjectRoot}. Treat all answer evidence paths as relative to that root.`,
     `Question: ${task.question}`,
-    "Return the requested JSON object. Cite repository-relative paths and exact 1-based line numbers. Set complete to true only when the answer covers the question.",
+    "Return exactly one JSON object with all four required root keys: answer, symbols, evidence, and complete. Do not omit any key or embed keys inside answer.",
+    `The answer field must be a substantive, source-grounded explanation of at least ${MIN_SUBSTANTIVE_ANSWER_LENGTH} characters. Never return a placeholder such as test, TODO, N/A, or unknown.`,
+    "The symbols and evidence fields must each be non-empty arrays. In symbols, return exact source declaration names as written in the repository, never graph node IDs.",
+    "Keep all four fields as sibling root keys; never use XML or pseudo-field markup such as <parameter> inside answer.",
+    "Cite repository-relative paths and exact 1-based line numbers. Set complete to true only when the substantive answer covers the question.",
   ];
   if (arm.kind === "grep") {
     return [...common, "Use repository file search and reads only. Do not inspect .mex or any graph database."].join("\n\n");
   }
   const cli = command.map(shellQuote).join(" ");
+  const candidate = arm.role === "patched";
   const graphFlow = policy === "optional"
-    ? `The graph CLI is available as \`${cli}\`. Use graph scope/query/get/impact when useful, but choose the retrieval strategy yourself.`
-    : arm.vocabRetry
-      ? `Start with \`${cli} graph scope "<question>"\`. If it emits VOCABULARY_MISMATCH or clearly irrelevant results, run \`${cli} graph vocab\`, select 1-12 project terms, and retry scope exactly once. Then use graph query/get as needed.`
-      : `Start with \`${cli} graph scope "<question>"\`. Then use graph query/get as needed.`;
+    ? `The graph CLI is available as \`${cli}\`, but you may choose repository files instead. If you use the graph, start with \`${cli} graph scope "<question>"\`${candidate ? " and use only one distinct Scope request" : ""}.`
+    : `Start with \`${cli} graph scope "<question>"\`${candidate ? " and use only one distinct Scope request" : ""}.`;
+  const followupContract = candidate
+    ? [
+      "Read the Scope summary status. When it is ok, do not run graph query/get or another Scope. A targeted graph query is allowed only after partial, degraded, or no-match. A targeted graph get is allowed only after partial or degraded.",
+      "Do not retry Scope with different wording. Treat an insufficient graph response as a reason to use the permitted repository file tools.",
+    ]
+    : ["Use graph query/get only when the released Scope response is insufficient."];
   return [
     ...common,
     graphFlow,
+    ...followupContract,
     "You may fall back to Read, Grep, or Glob only when graph retrieval is insufficient. Never inspect .mex/graph.db or use SQLite directly. Bash may only invoke the exact graph CLI shown above.",
   ].join("\n\n");
 }

--- a/evaluate/compare/lib/report.mjs
+++ b/evaluate/compare/lib/report.mjs
@@ -1,17 +1,26 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { bootstrapMeanInterval, distribution, mean, round, sum } from "../../core/stats.mjs";
+import { bootstrapMeanInterval, distribution, mean, median, round, sum } from "../../core/stats.mjs";
+import { normalizeRepoPath, uniqueRequiredPaths } from "../../core/evidence.mjs";
 import { objectHash } from "../../core/hash.mjs";
-import { suiteHash } from "./suite.mjs";
+import { resolveSelectedArmIds, suiteHash } from "./suite.mjs";
 
 const DELTA_METRICS = [
   "newTokens", "uncachedInput", "cacheWrite", "cacheRead", "output", "reportedTotal", "processed", "costUsd",
   "uniqueToolResultChars", "uniqueToolResultTokens", "elapsedMs", "turns", "toolCalls", "graphCalls",
-  "scopeCalls", "distinctScopeQueries", "vocabularyRetries", "fallbacks",
+  "scopeCalls", "distinctScopeQueries", "fallbacks",
 ];
+const ACCOUNTING_METRICS = new Set([
+  "newTokens", "uncachedInput", "cacheWrite", "cacheRead", "output", "reportedTotal", "processed", "costUsd", "cacheUseRatio",
+]);
+const MIN_GATE_TASKS = 2;
 
 function numericDelta(a, b) {
   return Number.isFinite(a) && Number.isFinite(b) ? b - a : null;
+}
+
+function numericPercentChange(a, b) {
+  return Number.isFinite(a) && Number.isFinite(b) && a > 0 ? (b - a) * 100 / a : null;
 }
 
 export function pairedDeltas(rows, armIds) {
@@ -25,21 +34,57 @@ export function pairedDeltas(rows, armIds) {
         const a = taskRows.find((row) => row.arm === from);
         const b = taskRows.find((row) => row.arm === to);
         if (!a || !b || a.valid === false || b.valid === false) continue;
+        const accountingValid = a.metrics.tokenAccountingValid !== false && b.metrics.tokenAccountingValid !== false;
         matched.push({
           taskId: a.taskId,
           repetition: a.repetition ?? 1,
-          ...Object.fromEntries(DELTA_METRICS.map((metric) => [metric, numericDelta(a.metrics[metric], b.metrics[metric])])),
+          ...Object.fromEntries(DELTA_METRICS.map((metric) => [metric,
+            ACCOUNTING_METRICS.has(metric) && !accountingValid
+              ? null
+              : numericDelta(a.metrics[metric], b.metrics[metric]),
+          ])),
+          percentChange: Object.fromEntries(DELTA_METRICS.map((metric) => [metric,
+            ACCOUNTING_METRICS.has(metric) && !accountingValid
+              ? null
+              : numericPercentChange(a.metrics[metric], b.metrics[metric]),
+          ])),
         });
       }
       const means = {};
+      const macroMedians = {};
       const confidence95 = {};
+      const perTaskMedian = [...Map.groupBy(matched, (row) => row.taskId)].map(([taskId, taskRows]) => ({
+        taskId,
+        ...Object.fromEntries(DELTA_METRICS.map((metric) => [metric, round(median(taskRows.map((row) => row[metric]).filter(Number.isFinite)))])),
+        percentChange: Object.fromEntries(DELTA_METRICS.map((metric) => [metric,
+          round(median(taskRows.map((row) => row.percentChange[metric]).filter(Number.isFinite))),
+        ])),
+      }));
+      const percentMeans = {};
+      const percentMacroMedians = {};
+      const percentConfidence95 = {};
       for (const metric of DELTA_METRICS) {
         const values = matched.map((row) => row[metric]).filter(Number.isFinite);
         means[metric] = round(mean(values));
+        macroMedians[metric] = round(median(perTaskMedian.map((row) => row[metric]).filter(Number.isFinite)));
         const interval = bootstrapMeanInterval(values);
         confidence95[metric] = { low: round(interval.low), high: round(interval.high), samples: interval.samples };
+        const taskPercentValues = perTaskMedian.map((row) => row.percentChange[metric]).filter(Number.isFinite);
+        percentMeans[metric] = round(mean(taskPercentValues));
+        percentMacroMedians[metric] = round(median(taskPercentValues));
+        const percentInterval = bootstrapMeanInterval(taskPercentValues);
+        percentConfidence95[metric] = {
+          low: round(percentInterval.low), high: round(percentInterval.high), samples: percentInterval.samples,
+          tasks: taskPercentValues.length,
+        };
       }
-      pairs.push({ from, to, matchedPairs: matched.length, perTaskRepetition: matched, perTask: matched, mean: means, confidence95 });
+      pairs.push({
+        from, to, matchedPairs: matched.length,
+        tokenEligiblePairs: matched.filter((row) => Number.isFinite(row.newTokens)).length,
+        costEligiblePairs: matched.filter((row) => Number.isFinite(row.costUsd)).length,
+        perTaskRepetition: matched, perTask: perTaskMedian, mean: means, macroMedian: macroMedians, confidence95,
+        percentChange: { mean: percentMeans, macroMedian: percentMacroMedians, confidence95: percentConfidence95 },
+      });
     }
   }
   return pairs;
@@ -87,16 +132,23 @@ function readBlindFiles(blindPath, revealPath, generated) {
 
 function summarizeArm(armRows) {
   const valid = armRows.filter((row) => row.valid);
+  const tokenValid = valid.filter((row) => row.metrics.tokenAccountingValid !== false);
   const scopeRows = valid.filter((row) => Number(row.metrics.scopeCalls ?? row.metrics.graphCalls) > 0);
-  const finite = (metric) => valid.map((row) => row.metrics[metric]).filter(Number.isFinite);
+  const finite = (metric) => (ACCOUNTING_METRICS.has(metric) ? tokenValid : valid).map((row) => row.metrics[metric]).filter(Number.isFinite);
   const usage = {};
-  for (const metric of ["uncachedInput", "cacheWrite", "cacheRead", "output", "reportedTotal", "newTokens", "costUsd"]) {
+  for (const metric of ["uncachedInput", "cacheWrite", "cacheRead", "output", "reportedTotal", "processed", "newTokens", "costUsd"]) {
     usage[metric] = distribution(finite(metric));
     usage[metric].total = finite(metric).length ? round(sum(finite(metric))) : null;
   }
   return {
     runs: armRows.length,
     valid: valid.length,
+    tokenAccountingEligible: tokenValid.length,
+    tokenAccountingInvalid: valid.length - tokenValid.length,
+    tokenAccountingInvalidReasons: Object.fromEntries([...Map.groupBy(
+      valid.filter((row) => row.metrics.tokenAccountingValid === false),
+      (row) => row.metrics.tokenAccountingReason ?? "unknown",
+    )].map(([reason, entries]) => [reason, entries.length])),
     automaticCorrect: valid.filter((row) => row.grade.correct).length,
     complete: valid.filter((row) => row.answer?.complete).length,
     usage,
@@ -104,9 +156,15 @@ function summarizeArm(armRows) {
     meanFallbacks: round(mean(finite("fallbacks"))),
     meanScopeCalls: round(mean(finite("scopeCalls"))),
     meanDistinctScopeQueries: round(mean(finite("distinctScopeQueries"))),
-    initialScopeRecallAt5: scopeRows.length ? round(scopeRows.filter((row) => Number.isFinite(row.metrics.expectedSymbolInitialScopeRank) && row.metrics.expectedSymbolInitialScopeRank <= 5).length / scopeRows.length) : null,
-    initialScopeMissRate: scopeRows.length ? round(scopeRows.filter((row) => !Number.isFinite(row.metrics.expectedSymbolInitialScopeRank)).length / scopeRows.length) : null,
-    initialScopeMrr: scopeRows.length ? round(mean(scopeRows.map((row) => Number.isFinite(row.metrics.expectedSymbolInitialScopeRank) ? 1 / row.metrics.expectedSymbolInitialScopeRank : 0))) : null,
+    permissionDenials: distribution(finite("permissionDenials")),
+    deniedFileShellAttempts: distribution(finite("deniedFileShellAttempts")),
+    unexplainedPermissionDenials: distribution(finite("unexplainedPermissionDenials")),
+    firstResponseTopFiveFileHitRate: scopeRows.length ? round(scopeRows.filter((row) => row.metrics.firstResponseFileHitAt5 === true).length / scopeRows.length) : null,
+    firstResponseFileMissRate: scopeRows.length ? round(scopeRows.filter((row) => !Number.isFinite(row.metrics.firstResponseFileRank)).length / scopeRows.length) : null,
+    firstResponseFileMrr: scopeRows.length ? round(mean(scopeRows.map((row) => Number.isFinite(row.metrics.firstResponseFileRank) ? 1 / row.metrics.firstResponseFileRank : 0))) : null,
+    firstResponseSourceSpanRecall: round(mean(scopeRows.map((row) => row.metrics.firstResponseSourceSpanRecall).filter(Number.isFinite))),
+    firstResponseDirectedFlowCoverage: round(mean(scopeRows.map((row) => row.metrics.firstResponseDirectedFlowCoverage).filter(Number.isFinite))),
+    graphEvidenceCoverage: round(mean(scopeRows.map((row) => row.metrics.graphEvidenceCoverage).filter(Number.isFinite))),
     latencyMs: distribution(finite("elapsedMs")),
     toolResultChars: distribution(finite("uniqueToolResultChars")),
   };
@@ -121,8 +179,315 @@ function manualLabels(blind, rows) {
   return rows.map((row) => ({ row, manual: byRun.get(row.runId) }));
 }
 
-export function generateReport({ suite, outputDir, rows: suppliedRows }) {
-  const rows = suppliedRows ?? loadRows(outputDir);
+function criterionStatus(passed) {
+  return passed === null ? "insufficient-sample" : passed ? "pass" : "fail";
+}
+
+function pairedNewTokenCriterion(pair) {
+  const taskValues = pair?.perTask?.map((row) => row.percentChange?.newTokens).filter(Number.isFinite) ?? [];
+  const observed = pair?.percentChange?.macroMedian?.newTokens;
+  const rawInterval = pair?.percentChange?.confidence95?.newTokens;
+  const sufficient = taskValues.length >= MIN_GATE_TASKS
+    && Number.isFinite(observed) && Number.isFinite(rawInterval?.low) && Number.isFinite(rawInterval?.high);
+  const passed = sufficient ? observed <= -30 && rawInterval.high < 0 : null;
+  return {
+    comparison: pair ? `${pair.from}->${pair.to}` : null,
+    metric: "newTokens",
+    statistic: "macro-median paired percent change",
+    eligibleTasks: taskValues.length,
+    minimumTasks: MIN_GATE_TASKS,
+    observedPercent: sufficient ? round(observed) : null,
+    maximumPercent: -30,
+    bootstrapMean95Percent: {
+      low: sufficient ? round(rawInterval.low) : null,
+      high: sufficient ? round(rawInterval.high) : null,
+      samples: sufficient ? rawInterval.samples : 0,
+    },
+    requiresConfidenceHighBelow: 0,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function pairedNonRegressionCriterion(pair, metric) {
+  const taskValues = pair?.perTask?.map((row) => row[metric]).filter(Number.isFinite) ?? [];
+  const observedMacroMedian = pair?.macroMedian?.[metric];
+  const observedMean = pair?.mean?.[metric];
+  const sufficient = taskValues.length >= MIN_GATE_TASKS
+    && Number.isFinite(observedMacroMedian) && Number.isFinite(observedMean);
+  const passed = sufficient ? observedMacroMedian <= 0 && observedMean <= 0 : null;
+  return {
+    comparison: pair ? `${pair.from}->${pair.to}` : null,
+    metric,
+    statistic: "paired mean and macro-median delta",
+    eligibleTasks: taskValues.length,
+    minimumTasks: MIN_GATE_TASKS,
+    observedDelta: sufficient ? round(observedMacroMedian) : null,
+    observedMacroMedianDelta: sufficient ? round(observedMacroMedian) : null,
+    observedMeanDelta: sufficient ? round(observedMean) : null,
+    maximumDelta: 0,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function fallbackReductionCriterion(rows, releasedId, candidateId) {
+  const values = (armId) => rows.filter((row) => row.arm === armId && row.valid !== false)
+    .map((row) => row.metrics.fallbacks).filter(Number.isFinite);
+  const released = releasedId ? values(releasedId) : [];
+  const candidate = candidateId ? values(candidateId) : [];
+  const releasedMean = mean(released);
+  const candidateMean = mean(candidate);
+  const sufficient = released.length >= MIN_GATE_TASKS && candidate.length >= MIN_GATE_TASKS
+    && Number.isFinite(releasedMean) && releasedMean > 0 && Number.isFinite(candidateMean);
+  const reduction = sufficient ? (releasedMean - candidateMean) * 100 / releasedMean : null;
+  const passed = sufficient ? reduction >= 60 : null;
+  return {
+    comparison: releasedId && candidateId ? `${releasedId}->${candidateId}` : null,
+    metric: "fileToolFallbacks",
+    statistic: "mean fallback reduction",
+    releasedSamples: released.length,
+    candidateSamples: candidate.length,
+    minimumSamplesPerArm: MIN_GATE_TASKS,
+    releasedMean: sufficient ? round(releasedMean) : null,
+    candidateMean: sufficient ? round(candidateMean) : null,
+    observedReductionPercent: sufficient ? round(reduction) : null,
+    minimumReductionPercent: 60,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function correctnessCriterion(finalCorrectness, candidateId, controlIds, pilotValid) {
+  const controls = Object.fromEntries(controlIds.map((armId) => [armId, finalCorrectness[armId] ?? null]));
+  const candidate = candidateId ? finalCorrectness[candidateId] : null;
+  const sufficient = pilotValid && Boolean(candidateId) && controlIds.length >= 1
+    && Number.isFinite(candidate) && Object.values(controls).every(Number.isFinite);
+  const passed = sufficient ? Object.values(controls).every((value) => candidate >= value) : null;
+  return {
+    comparison: candidateId ? `${candidateId}->${controlIds.join(",")}` : null,
+    metric: "finalCorrectness",
+    statistic: "correct run count",
+    candidate: sufficient ? candidate : null,
+    controls: sufficient ? controls : Object.fromEntries(controlIds.map((armId) => [armId, null])),
+    requiresCompletedBlindReview: true,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function configuredSamples(suite, rows, candidateId, taskFilter = () => true) {
+  const tasks = (suite?.tasks ?? []).filter(taskFilter);
+  const repetitions = suite?.requiredRepetitions;
+  if (!candidateId || !Number.isInteger(repetitions) || repetitions < 1) {
+    return { tasks, expected: 0, samples: [], missing: tasks.map((task) => ({ taskId: task.id, repetition: null })) };
+  }
+  const samples = [];
+  const missing = [];
+  for (const task of tasks) {
+    for (let repetition = 1; repetition <= repetitions; repetition++) {
+      const matches = rows.filter((row) => row.arm === candidateId && row.taskId === task.id && (row.repetition ?? 1) === repetition);
+      if (matches.length === 1) samples.push({ task, repetition, row: matches[0] });
+      else missing.push({ taskId: task.id, repetition, matches: matches.length });
+    }
+  }
+  return { tasks, expected: tasks.length * repetitions, samples, missing };
+}
+
+function repetitionCriterion(suite, rows, selectedArmIds = null) {
+  const required = suite?.requiredRepetitions;
+  const armIds = suite?.arms ? resolveSelectedArmIds(suite, selectedArmIds) : [];
+  const tasks = suite?.tasks ?? [];
+  if (!Number.isInteger(required) || required < 1 || !armIds.length || !tasks.length) {
+    return {
+      metric: "repetitions", required: required ?? null, observed: [], expectedRuns: null, actualRuns: rows.length,
+      missing: [], duplicates: [], extras: [], eligible: false, status: "insufficient-sample", passed: null,
+    };
+  }
+  const expectedKeys = new Set();
+  for (const task of tasks) for (const armId of armIds) for (let repetition = 1; repetition <= required; repetition++) {
+    expectedKeys.add(`${task.id}\0${armId}\0${repetition}`);
+  }
+  const counts = new Map();
+  const extras = [];
+  for (const row of rows) {
+    const key = `${row.taskId}\0${row.arm}\0${row.repetition ?? 1}`;
+    if (!expectedKeys.has(key)) extras.push({ taskId: row.taskId, arm: row.arm, repetition: row.repetition ?? 1 });
+    else counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const unpack = (key) => {
+    const [taskId, arm, repetition] = key.split("\0");
+    return { taskId, arm, repetition: Number(repetition) };
+  };
+  const missing = [...expectedKeys].filter((key) => !counts.has(key)).map(unpack);
+  const duplicates = [...counts].filter(([, count]) => count > 1).map(([key, count]) => ({ ...unpack(key), count }));
+  const observed = [...new Set(rows.map((row) => row.repetition ?? 1).filter(Number.isInteger))].sort((a, b) => a - b);
+  const sufficient = missing.length === 0;
+  const passed = sufficient ? duplicates.length === 0 && extras.length === 0 : null;
+  return {
+    metric: "repetitions",
+    required,
+    observed,
+    expectedRuns: expectedKeys.size,
+    actualRuns: rows.length,
+    missing,
+    duplicates,
+    extras,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function distinctScopeCriterion(suite, rows, candidateId, maximum) {
+  const sampleSet = configuredSamples(suite, rows, candidateId);
+  const values = sampleSet.samples.map(({ row }) => row.metrics.distinctScopeQueries);
+  const sufficient = sampleSet.expected > 0 && sampleSet.missing.length === 0 && values.every(Number.isFinite);
+  const observedMaximum = sufficient ? Math.max(...values) : null;
+  const passed = sufficient ? observedMaximum <= maximum : null;
+  return {
+    comparison: candidateId ?? null,
+    metric: "distinctScopeQueries",
+    statistic: "maximum per candidate run",
+    expectedSamples: sampleSet.expected,
+    eligibleSamples: values.filter(Number.isFinite).length,
+    missingSamples: sampleSet.missing,
+    observedMaximum,
+    maximum,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function fileHitAt5Criterion(suite, rows, candidateId, minimum) {
+  const sampleSet = configuredSamples(suite, rows, candidateId, (task) => uniqueRequiredPaths(task.gold ?? []).length > 0);
+  const values = sampleSet.samples.map(({ row }) => row.metrics.firstResponseFileHitAt5);
+  const sufficient = sampleSet.expected > 0 && sampleSet.missing.length === 0 && values.every((value) => typeof value === "boolean");
+  const observed = sufficient ? values.filter(Boolean).length / values.length : null;
+  const passed = sufficient ? observed >= minimum : null;
+  return {
+    comparison: candidateId ?? null,
+    metric: "firstResponseFileHitAt5",
+    statistic: "candidate run rate",
+    eligibleTasks: sampleSet.tasks.length,
+    expectedSamples: sampleSet.expected,
+    eligibleSamples: values.filter((value) => typeof value === "boolean").length,
+    missingSamples: sampleSet.missing,
+    observed: round(observed),
+    minimum,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function hasSourceSpan(evidence) {
+  const start = evidence?.startLine ?? evidence?.line;
+  const end = evidence?.endLine ?? start;
+  return Number.isInteger(start) && start > 0 && Number.isInteger(end) && end >= start;
+}
+
+function sourceSpanCriterion(suite, rows, candidateId, minimum) {
+  const sampleSet = configuredSamples(suite, rows, candidateId, (task) =>
+    Array.isArray(task.gold) && task.gold.length > 0 && task.gold.every(hasSourceSpan));
+  const values = sampleSet.samples.map(({ row }) => row.metrics.firstResponseSourceSpanRecall);
+  const sufficient = sampleSet.expected > 0 && sampleSet.missing.length === 0 && values.every(Number.isFinite);
+  const observed = sufficient ? mean(values) : null;
+  const passed = sufficient ? observed >= minimum : null;
+  return {
+    comparison: candidateId ?? null,
+    metric: "firstResponseSourceSpanRecall",
+    statistic: "mean candidate run recall",
+    eligibleTasks: sampleSet.tasks.length,
+    expectedSamples: sampleSet.expected,
+    eligibleSamples: values.filter(Number.isFinite).length,
+    missingSamples: sampleSet.missing,
+    observed: round(observed),
+    minimum,
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+function requiredFilesCriterion(suite, rows, candidateId) {
+  const allTasksHaveFiles = (suite?.tasks ?? []).every((task) => uniqueRequiredPaths(task.gold ?? []).length > 0);
+  const sampleSet = configuredSamples(suite, rows, candidateId, (task) => uniqueRequiredPaths(task.gold ?? []).length > 0);
+  const failures = [];
+  let observationsAvailable = true;
+  for (const { task, repetition, row } of sampleSet.samples) {
+    const returned = row.metrics.firstResponseReturnedFiles;
+    if (!Array.isArray(returned)) { observationsAvailable = false; continue; }
+    const returnedSet = new Set(returned.map(normalizeRepoPath).filter(Boolean));
+    const missingFiles = uniqueRequiredPaths(task.gold ?? []).filter((path) => !returnedSet.has(path));
+    if (missingFiles.length) failures.push({ taskId: task.id, repetition, missingFiles });
+  }
+  const sufficient = allTasksHaveFiles && sampleSet.expected > 0 && sampleSet.missing.length === 0 && observationsAvailable;
+  const passed = sufficient ? failures.length === 0 : null;
+  return {
+    comparison: candidateId ?? null,
+    metric: "allRequiredFilesInFirstScope",
+    statistic: "every configured task and repetition",
+    requiredTasks: suite?.tasks?.length ?? 0,
+    eligibleTasks: sampleSet.tasks.length,
+    expectedSamples: sampleSet.expected,
+    observedSamples: sampleSet.samples.length,
+    missingSamples: sampleSet.missing,
+    failures: sufficient ? failures : [],
+    eligible: sufficient,
+    status: criterionStatus(passed),
+    passed,
+  };
+}
+
+export function buildReleaseGate({
+  candidateVsFiles, rows, releasedId, candidateId, controlIds, finalCorrectness, pilotValid,
+  suite = null, selectedArmIds = null,
+}) {
+  const criteria = {
+    newTokensVsFiles: pairedNewTokenCriterion(candidateVsFiles),
+    processedTokensVsFiles: pairedNonRegressionCriterion(candidateVsFiles, "processed"),
+    costVsFiles: pairedNonRegressionCriterion(candidateVsFiles, "costUsd"),
+    ...(releasedId ? { fallbacksVsReleased: fallbackReductionCriterion(rows, releasedId, candidateId) } : {}),
+    correctnessVsControls: correctnessCriterion(finalCorrectness, candidateId, controlIds, pilotValid),
+  };
+  if (suite?.requiredRepetitions !== undefined) {
+    criteria.repetitions = repetitionCriterion(suite, rows, selectedArmIds);
+  }
+  const configured = suite?.releaseGates ?? {};
+  if (configured.maxDistinctScopeQueries !== undefined) {
+    criteria.candidateDistinctScopes = distinctScopeCriterion(suite, rows, candidateId, configured.maxDistinctScopeQueries);
+  }
+  if (configured.firstResponseFileHitAt5 !== undefined) {
+    criteria.firstResponseFileHitAt5 = fileHitAt5Criterion(suite, rows, candidateId, configured.firstResponseFileHitAt5);
+  }
+  if (configured.firstResponseSourceSpanRecall !== undefined) {
+    criteria.firstResponseSourceSpanRecall = sourceSpanCriterion(suite, rows, candidateId, configured.firstResponseSourceSpanRecall);
+  }
+  if (configured.allRequiredFilesInFirstScope === true) {
+    criteria.allRequiredFilesInFirstScope = requiredFilesCriterion(suite, rows, candidateId);
+  }
+  const failures = Object.entries(criteria).filter(([, criterion]) => criterion.passed === false).map(([name]) => name);
+  const insufficient = Object.entries(criteria).filter(([, criterion]) => criterion.passed === null).map(([name]) => name);
+  const passed = failures.length ? false : insufficient.length ? null : true;
+  return {
+    kind: releasedId ? "hard-release-gate" : "candidate-vs-files-gate",
+    status: criterionStatus(passed),
+    eligible: insufficient.length === 0,
+    passed,
+    failures,
+    insufficient,
+    criteria,
+  };
+}
+
+export function generateReport({ suite, outputDir, rows: suppliedRows, selectedArmIds = null }) {
+  const loadedRows = suppliedRows ?? loadRows(outputDir);
   const preparePath = join(outputDir, "prepare.json");
   if (existsSync(preparePath)) {
     const prepared = JSON.parse(readFileSync(preparePath, "utf8"));
@@ -131,10 +496,29 @@ export function generateReport({ suite, outputDir, rows: suppliedRows }) {
   const manifestPath = join(outputDir, "run-manifest.json");
   const runManifest = existsSync(manifestPath) ? JSON.parse(readFileSync(manifestPath, "utf8")) : null;
   const runIdentity = runManifest?.runIdentity ?? null;
-  const armIds = Object.keys(suite.arms);
+  const scheduledArmIds = runManifest?.schedule
+    ? Object.keys(suite.arms).filter((armId) => runManifest.schedule.some((item) => item.armId === armId))
+    : null;
+  const manifestArmIds = runManifest?.selectedArmIds
+    ? resolveSelectedArmIds(suite, runManifest.selectedArmIds)
+    : scheduledArmIds && [2, 3].includes(scheduledArmIds.length)
+      ? resolveSelectedArmIds(suite, scheduledArmIds)
+      : null;
+  const requestedArmIds = selectedArmIds === null
+    ? null
+    : resolveSelectedArmIds(suite, selectedArmIds);
+  if (requestedArmIds && manifestArmIds
+    && JSON.stringify(requestedArmIds) !== JSON.stringify(manifestArmIds)) {
+    throw new Error("report arm selection does not match the run manifest");
+  }
+  const armIds = requestedArmIds ?? manifestArmIds ?? Object.keys(suite.arms);
+  const selectedArmSet = new Set(armIds);
+  const rows = loadedRows.filter((row) => selectedArmSet.has(row.arm));
   const byArm = Object.fromEntries(armIds.map((armId) => [armId, summarizeArm(rows.filter((row) => row.arm === armId))]));
-  const expectedRunCount = runManifest?.schedule?.length ?? suite.tasks.length * armIds.length;
-  const executionValid = rows.length === expectedRunCount && rows.every((row) => row.valid)
+  const expectedRunCount = runManifest?.schedule?.length
+    ?? suite.tasks.length * armIds.length * (suite.requiredRepetitions ?? 1);
+  const executionValid = runManifest?.status === "complete"
+    && rows.length === expectedRunCount && rows.every((row) => row.valid)
     && (!runIdentity || rows.every((row) => row.runIdentity === runIdentity));
   const blindPath = join(outputDir, "blind-review.json");
   const revealPath = join(outputDir, "blind-reveal.json");
@@ -151,8 +535,11 @@ export function generateReport({ suite, outputDir, rows: suppliedRows }) {
   });
   const disagreementsAdjudicated = disagreements.every((item) => item.adjudicated);
   const pilotValid = executionValid && manuallyScored && disagreementsAdjudicated;
-  const roleId = (role, fallback) => Object.keys(suite.arms).find((id) => suite.arms[id].role === role) ?? (suite.arms[fallback] ? fallback : null);
-  const controlIds = [roleId("control", "grep"), roleId("released", "baseline")].filter(Boolean);
+  const roleId = (role, fallback) => armIds.find((id) => suite.arms[id].role === role)
+    ?? (armIds.includes(fallback) ? fallback : null);
+  const filesId = roleId("control", "grep");
+  const baselineId = roleId("released", "baseline");
+  const controlIds = [...new Set([filesId, baselineId].filter(Boolean))];
   const patchedId = roleId("patched", "patched");
   const finalCorrectness = Object.fromEntries(armIds.map((armId) => [armId, rows.filter((row) => row.arm === armId).reduce((count, row) => {
     if (!manuallyScored) return count + Number(row.grade.correct);
@@ -160,27 +547,44 @@ export function generateReport({ suite, outputDir, rows: suppliedRows }) {
     return count + Number(manual?.correct === true);
   }, 0)]));
   const noCorrectnessRegression = Boolean(patchedId) && controlIds.every((armId) => finalCorrectness[patchedId] >= finalCorrectness[armId]);
-  const baselineId = roleId("released", "baseline");
   const allDeltas = pairedDeltas(rows, armIds);
-  const baselineToPatched = allDeltas.find((entry) => entry.from === baselineId && entry.to === patchedId)
-    ?? allDeltas.find((entry) => entry.from === patchedId && entry.to === baselineId);
-  const signed = baselineToPatched?.from === baselineId ? 1 : -1;
+  // Build role-oriented pairs separately so gate signs never depend on JSON
+  // arm ordering. `allDeltas` remains unchanged for descriptive comparisons.
+  const candidateVsFiles = filesId && patchedId ? pairedDeltas(rows, [filesId, patchedId])[0] ?? null : null;
+  const baselineToPatched = baselineId && patchedId ? pairedDeltas(rows, [baselineId, patchedId])[0] ?? null : null;
+  // A selected two-arm run is an explicitly descriptive tuning pilot. Its
+  // configured retrieval checks apply to the repetitions actually scheduled
+  // for that pilot, while the suite's full-release repetition contract remains
+  // visible at the top level and is still required by aggregate release gates.
+  const gateSuite = !baselineId && Number.isInteger(runManifest?.repetitions)
+    ? { ...suite, requiredRepetitions: runManifest.repetitions }
+    : suite;
   const improvements = {
-    retrievalMrr: Boolean(baselineId && patchedId && byArm[patchedId].initialScopeMrr > byArm[baselineId].initialScopeMrr),
+    retrievalMrr: Boolean(baselineId && patchedId && byArm[patchedId].firstResponseFileMrr > byArm[baselineId].firstResponseFileMrr),
     fallbackBehavior: Boolean(baselineId && patchedId && byArm[patchedId].meanFallbacks < byArm[baselineId].meanFallbacks),
-    pairedNewTokens: Boolean(baselineToPatched && Number.isFinite(baselineToPatched.mean.newTokens) && signed * baselineToPatched.mean.newTokens < 0),
-    pairedCost: Boolean(baselineToPatched && Number.isFinite(baselineToPatched.mean.costUsd) && signed * baselineToPatched.mean.costUsd < 0),
+    pairedNewTokens: Boolean(baselineToPatched && Number.isFinite(baselineToPatched.mean.newTokens) && baselineToPatched.mean.newTokens < 0),
+    pairedCost: Boolean(baselineToPatched && Number.isFinite(baselineToPatched.mean.costUsd) && baselineToPatched.mean.costUsd < 0),
   };
+  const gate = buildReleaseGate({
+    candidateVsFiles, rows, releasedId: baselineId, candidateId: patchedId, controlIds,
+    finalCorrectness, pilotValid, suite: gateSuite, selectedArmIds: armIds,
+  });
   const decision = {
-    descriptivePilotOnly: true,
+    descriptivePilotOnly: !baselineId,
+    releasedComparisonDescriptive: Boolean(baselineToPatched),
     usesManualFinalLabels: manuallyScored,
     noCorrectnessRegression,
     improvements,
-    patchedWin: pilotValid && noCorrectnessRegression && Object.values(improvements).some(Boolean),
+    hardGateStatus: gate.status,
+    patchedWin: gate.passed === true,
   };
   const report = {
     schemaVersion: 2,
     suiteId: suite.id,
+    requiredRepetitions: suite.requiredRepetitions ?? null,
+    runRepetitions: runManifest?.repetitions ?? null,
+    releaseGateConfiguration: suite.releaseGates ?? null,
+    selectedArmIds: armIds,
     runIdentity,
     generatedAt: new Date().toISOString(),
     executionValid,
@@ -193,7 +597,29 @@ export function generateReport({ suite, outputDir, rows: suppliedRows }) {
     expectedRunCount,
     byArm,
     pairedDeltas: allDeltas,
+    primaryPair: candidateVsFiles,
+    releasedPair: baselineToPatched,
+    usageAccounting: rows.map((row) => ({
+      runId: row.runId,
+      arm: row.arm,
+      taskId: row.taskId,
+      repetition: row.repetition ?? 1,
+      valid: row.metrics.tokenAccountingValid !== false,
+      reason: row.metrics.tokenAccountingReason ?? null,
+      terminal: row.metrics.terminalUsage ?? null,
+      perMessage: row.metrics.perMessageUsage ?? null,
+      selected: {
+        uncachedInput: row.metrics.uncachedInput ?? null,
+        cacheWrite: row.metrics.cacheWrite ?? null,
+        cacheRead: row.metrics.cacheRead ?? null,
+        output: row.metrics.output ?? null,
+        processed: row.metrics.processed ?? null,
+        newTokens: row.metrics.newTokens ?? null,
+        costUsd: row.metrics.costUsd ?? null,
+      },
+    })),
     finalCorrectness,
+    gate,
     decision,
   };
   writeFileSync(join(outputDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
@@ -208,4 +634,61 @@ export function loadRows(outputDir) {
   const runsDir = join(outputDir, "runs");
   if (!existsSync(runsDir)) return [];
   return readdirSync(runsDir).filter((name) => name.endsWith(".json")).sort().map((name) => JSON.parse(readFileSync(join(runsDir, name), "utf8")));
+}
+
+/** Combine independently generated suite reports into one release decision. */
+export function aggregateReleaseReports(entries) {
+  const criteria = {};
+  for (const entry of entries ?? []) {
+    const suite = entry?.suite;
+    const suiteId = suite?.id;
+    if (typeof suiteId !== "string" || !suiteId) throw new Error("aggregate entries require a suite with an id");
+    if (criteria[suiteId]) throw new Error(`duplicate aggregate suite: ${suiteId}`);
+    const report = entry?.report ?? null;
+    const repetition = report?.gate?.criteria?.repetitions ?? null;
+    const identityMatches = report ? report.suiteId === suiteId : null;
+    const required = suite.requiredRepetitions ?? null;
+    const expectedObserved = Number.isInteger(required)
+      ? Array.from({ length: required }, (_, index) => index + 1)
+      : null;
+    const repetitionMetadataAvailable = Boolean(report) && Number.isInteger(report.requiredRepetitions)
+      && Number.isInteger(repetition?.required) && Array.isArray(repetition?.observed);
+    const configuredRepetitionsMatch = !report || !repetitionMetadataAvailable
+      ? null
+      : report.requiredRepetitions === required
+        && repetition.required === required
+        && JSON.stringify(repetition.observed) === JSON.stringify(expectedObserved);
+    const decisionsAvailable = typeof repetition?.passed === "boolean" && typeof report?.gate?.passed === "boolean";
+    const sufficient = Boolean(report) && identityMatches === true && configuredRepetitionsMatch === true && decisionsAvailable;
+    const passed = !report
+      ? null
+      : identityMatches === false || configuredRepetitionsMatch === false
+        ? false
+        : sufficient
+          ? repetition.passed === true && report.gate.passed === true
+          : null;
+    criteria[suiteId] = {
+      requiredRepetitions: suite.requiredRepetitions ?? null,
+      reportPresent: Boolean(report),
+      reportSuiteId: report?.suiteId ?? null,
+      observedRepetitions: repetition?.observed ?? [],
+      configuredRepetitionsMatch,
+      suiteGateStatus: report?.gate?.status ?? null,
+      eligible: sufficient,
+      status: criterionStatus(passed),
+      passed,
+    };
+  }
+  const failures = Object.entries(criteria).filter(([, criterion]) => criterion.passed === false).map(([suiteId]) => suiteId);
+  const insufficient = Object.entries(criteria).filter(([, criterion]) => criterion.passed === null).map(([suiteId]) => suiteId);
+  const passed = failures.length ? false : insufficient.length || Object.keys(criteria).length === 0 ? null : true;
+  return {
+    kind: "multi-suite-hard-release-gate",
+    status: criterionStatus(passed),
+    eligible: insufficient.length === 0 && Object.keys(criteria).length > 0,
+    passed,
+    failures,
+    insufficient,
+    criteria,
+  };
 }

--- a/evaluate/compare/lib/runner.mjs
+++ b/evaluate/compare/lib/runner.mjs
@@ -1,53 +1,299 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getAgentAdapter } from "../../adapters/agents/index.mjs";
+import { restoreGraphDbAndRemoveScratch } from "../../core/artifacts.mjs";
 import { commandBundleIdentity, objectHash } from "../../core/hash.mjs";
 import { ANSWER_SCHEMA, gradeAnswer } from "./answer.mjs";
-import { shellQuote, validateTranscriptPolicy } from "./policy.mjs";
+import { BASH_GUARD_DENIAL, BASH_GUARD_HOOK_NAME } from "./bash-guard.mjs";
+import { isDeniedFileShellAttempt, shellQuote, validateTranscriptPolicy } from "./policy.mjs";
 import { buildPrompt } from "./prompt.mjs";
 import { runTimed } from "./process.mjs";
 import { fileHash, GraphDbGuard, repositoryIdentity, worktreeDiffHash } from "./prepare.mjs";
 import { buildSchedule } from "./schedule.mjs";
-import { suiteHash } from "./suite.mjs";
+import { resolveSelectedArmIds, suiteHash } from "./suite.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GRAPH_COMMAND = join(HERE, "graph-command.mjs");
+const BASH_GUARD_SOURCE = join(HERE, "bash-guard.mjs");
+const POLICY_SOURCE = join(HERE, "policy.mjs");
+const BASH_GUARD_LAUNCHER_COMMAND = "/bin/sh";
+const BASH_GUARD_LAUNCHER_SCRIPT = [
+  '"$1" "$2" "$3"',
+  "guard_status=$?",
+  'if [ "$guard_status" -ne 0 ]; then',
+  `  printf '%s\\n' '${BASH_GUARD_DENIAL}: guard process failed before a decision' >&2`,
+  "  exit 2",
+  "fi",
+  "exit 0",
+].join("\n");
 
-function allowedTools(arm, command) {
-  if (arm.kind === "grep") return { tools: "Read,Grep,Glob", allowed: ["Read", "Grep", "Glob"] };
-  const prefix = command.map(shellQuote).join(" ");
-  return { tools: "Read,Grep,Glob,Bash", allowed: ["Read", "Grep", "Glob", `Bash(${prefix} graph *)`, `Bash(${prefix} impact *)`] };
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
-export function claudeArgs({ prompt, model, arm, command }) {
-  const tools = allowedTools(arm, command);
+function privateWrite(path, value) {
+  writeFileSync(path, value, { mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+function pinFile(source, destination) {
+  const before = fileHash(source);
+  copyFileSync(source, destination);
+  chmodSync(destination, 0o400);
+  const sourceAfter = fileHash(source);
+  const pinned = fileHash(destination);
+  if (sourceAfter !== before || pinned !== before) throw new Error(`guard source changed while pinning ${source}`);
+  return pinned;
+}
+
+export function buildBashGuardHook({ nodePath = process.execPath, guardPath, configPath }) {
+  if (![nodePath, guardPath, configPath].every((value) => typeof value === "string" && value)) {
+    throw new Error("Bash guard hook requires exact node, guard, and configuration paths");
+  }
+  return {
+    type: "command",
+    command: BASH_GUARD_LAUNCHER_COMMAND,
+    args: ["-c", BASH_GUARD_LAUNCHER_SCRIPT, BASH_GUARD_HOOK_NAME, nodePath, guardPath, configPath],
+    timeout: 5,
+    statusMessage: BASH_GUARD_HOOK_NAME,
+  };
+}
+
+function preToolInput(command, extra = {}) {
+  return {
+    session_id: "mex-eval-guard-preflight",
+    cwd: process.cwd(),
+    hook_event_name: "PreToolUse",
+    tool_name: "Bash",
+    tool_input: { command, ...extra },
+    tool_use_id: "mex-eval-guard-preflight-tool",
+  };
+}
+
+function invokeGuardProbe(hook, input, label) {
+  const result = spawnSync(hook.command, hook.args, {
+    input,
+    encoding: "utf8",
+    timeout: 5_000,
+    maxBuffer: 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) {
+    const detail = result.error?.message ?? result.stderr?.trim() ?? `exit ${result.status}`;
+    throw new Error(`Claude Bash guard ${label} probe failed: ${detail}`);
+  }
+  try {
+    return JSON.parse(result.stdout.trim());
+  } catch (error) {
+    throw new Error(`Claude Bash guard ${label} probe returned invalid JSON: ${error.message}`);
+  }
+}
+
+function assertDeniedProbe(output, label) {
+  const decision = output?.hookSpecificOutput;
+  if (decision?.hookEventName !== "PreToolUse" || decision.permissionDecision !== "deny"
+    || !String(decision.permissionDecisionReason ?? "").includes(BASH_GUARD_DENIAL)) {
+    throw new Error(`Claude Bash guard ${label} probe did not return the expected denial`);
+  }
+}
+
+export function preflightClaudeBashGuard({ settingsPath, configPath, guardPath, policyPath, command }) {
+  const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+  const config = JSON.parse(readFileSync(configPath, "utf8"));
+  const expectedHook = buildBashGuardHook({ guardPath, configPath });
+  const configured = settings?.hooks?.PreToolUse;
+  if (!Array.isArray(configured) || configured.length !== 1 || configured[0]?.matcher !== "Bash"
+    || !Array.isArray(configured[0]?.hooks) || configured[0].hooks.length !== 1
+    || !sameJson(configured[0].hooks[0], expectedHook)) {
+    throw new Error("Claude Bash guard settings do not match the pinned exec-form hook");
+  }
+  if (!sameJson(config.command, command)) throw new Error("Claude Bash guard configuration changed before preflight");
+
+  const hashes = {
+    settings: fileHash(settingsPath),
+    config: fileHash(configPath),
+    guard: fileHash(guardPath),
+    policy: fileHash(policyPath),
+    launcher: objectHash(BASH_GUARD_LAUNCHER_SCRIPT),
+  };
+  const prefix = command.map(shellQuote).join(" ");
+  const allowed = invokeGuardProbe(expectedHook, `${JSON.stringify(preToolInput(`${prefix} graph scope "guard preflight"`))}\n`, "allow");
+  if (!allowed || typeof allowed !== "object" || Array.isArray(allowed) || Object.keys(allowed).length !== 0) {
+    throw new Error("Claude Bash guard allow probe did not return an empty decision");
+  }
+  assertDeniedProbe(invokeGuardProbe(expectedHook, `${JSON.stringify(preToolInput("git status"))}\n`, "deny"), "deny");
+  assertDeniedProbe(invokeGuardProbe(expectedHook, "{malformed\n", "malformed"), "malformed");
+
+  for (const [name, path] of Object.entries({ settings: settingsPath, config: configPath, guard: guardPath, policy: policyPath })) {
+    if (fileHash(path) !== hashes[name]) throw new Error(`Claude Bash guard ${name} changed during preflight`);
+  }
+  return { valid: true, hashes, probes: { allow: true, deny: true, malformed: true } };
+}
+
+export function toolPolicyForArm(arm, command) {
+  if (arm.kind === "grep") return { tools: "Read,Grep,Glob", allowed: ["Read", "Grep", "Glob"] };
+  const prefix = command.map(shellQuote).join(" ");
+  return {
+    tools: "Read,Grep,Glob,Bash",
+    allowed: [
+      "Read", "Grep", "Glob",
+      `Bash(${prefix} graph scope *)`,
+      `Bash(${prefix} graph query *)`,
+      `Bash(${prefix} graph get *)`,
+      `Bash(${prefix} impact *)`,
+    ],
+  };
+}
+
+export function claudeArgs({ prompt, model, arm, command, settingsPath = null }) {
+  const tools = toolPolicyForArm(arm, command);
   return [
-    "-p", prompt, "--output-format", "stream-json", "--verbose", "--safe-mode",
+    "-p", prompt, "--output-format", "stream-json", "--verbose",
+    ...(settingsPath
+      ? ["--settings", settingsPath, "--strict-mcp-config", "--no-chrome", "--disable-slash-commands", "--include-hook-events"]
+      : ["--safe-mode"]),
+    "--setting-sources", "",
     "--no-session-persistence", "--exclude-dynamic-system-prompt-sections",
     "--permission-mode", "dontAsk", "--model", model, "--json-schema", JSON.stringify(ANSWER_SCHEMA),
     "--tools", tools.tools, "--allowedTools", ...tools.allowed,
   ];
 }
 
-export async function runSession({ agentCommand, agentId = "claude", policy = "forced-first", subjectRoot, model, task, armId, arm, armCommands, timeoutMs }) {
+function assertPreparedIdentity({
+  suite,
+  subjectRoot,
+  selectedArmCommands,
+  armIds,
+  prepared,
+  preparePath,
+  prepareSha256,
+  manifestPath = null,
+  runningManifestSha256 = null,
+}) {
+  if (!existsSync(preparePath) || fileHash(preparePath) !== prepareSha256) {
+    throw new Error("prepared comparison manifest changed during evaluation");
+  }
+  if (prepared.suiteSha256 && prepared.suiteSha256 !== suiteHash(suite)) {
+    throw new Error("suite changed after preparation");
+  }
+  if (manifestPath && runningManifestSha256
+    && (!existsSync(manifestPath) || fileHash(manifestPath) !== runningManifestSha256)) {
+    throw new Error("active comparison run manifest changed during evaluation");
+  }
+
+  const preparedArmIds = resolveSelectedArmIds(suite, prepared.selectedArmIds ?? null);
+  const unpreparedArmIds = armIds.filter((armId) => !preparedArmIds.includes(armId));
+  if (unpreparedArmIds.length) {
+    throw new Error(`selected arm(s) were not prepared: ${unpreparedArmIds.join(", ")}`);
+  }
+
+  if (prepared.subject) {
+    const currentSubject = repositoryIdentity(subjectRoot);
+    const currentDiff = worktreeDiffHash(subjectRoot);
+    if ((prepared.subject.root && currentSubject.root !== prepared.subject.root)
+      || currentSubject.sha !== prepared.subject.sha
+      || currentDiff !== prepared.subject.diffSha256) {
+      throw new Error("subject repository no longer matches the prepared fixture");
+    }
+  }
+  if (prepared.harness?.root) {
+    const currentHarness = repositoryIdentity(prepared.harness.root);
+    const currentDiff = worktreeDiffHash(prepared.harness.root);
+    if (currentHarness.root !== prepared.harness.root
+      || currentHarness.sha !== prepared.harness.sha
+      || currentDiff !== prepared.harness.diffSha256) {
+      throw new Error("evaluation harness no longer matches the prepared fixture");
+    }
+  }
+
+  for (const armId of armIds) {
+    if (suite.arms[armId].kind !== "graph") continue;
+    const command = selectedArmCommands[armId];
+    if (!command) throw new Error(`missing CLI command for selected graph arm ${armId}`);
+    const preparedCli = prepared.cli?.[armId];
+    if (!preparedCli) {
+      if (prepared.schemaVersion >= 3) throw new Error(`missing prepared CLI identity for ${armId}`);
+      continue;
+    }
+    if (JSON.stringify(command) !== JSON.stringify(preparedCli.command)) {
+      throw new Error(`CLI command changed after prepare for ${armId}`);
+    }
+    const bundle = commandBundleIdentity(command);
+    const script = bundle.entrypoint;
+    if (preparedCli.sha256 && (!script || !existsSync(script) || fileHash(script) !== preparedCli.sha256)) {
+      throw new Error(`CLI bytes changed after prepare for ${armId}`);
+    }
+    if (preparedCli.bundleSha256 && bundle.bundleSha256 !== preparedCli.bundleSha256) {
+      throw new Error(`CLI bundle changed after prepare for ${armId}`);
+    }
+  }
+  for (const armId of armIds) {
+    const index = prepared.indices?.[armId];
+    if (!index) {
+      if (prepared.schemaVersion >= 3 && suite.arms[armId].kind === "graph") {
+        throw new Error(`missing prepared graph index for ${armId}`);
+      }
+      continue;
+    }
+    if (index.sha256 && (!existsSync(index.path) || fileHash(index.path) !== index.sha256)) {
+      throw new Error(`prepared graph index changed for ${armId}`);
+    }
+  }
+}
+
+function assertScheduleIdentity(context, checkpoint) {
+  try {
+    assertPreparedIdentity(context);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`comparison evaluation identity drift ${checkpoint}: ${message}`, { cause: error });
+  }
+}
+
+export async function runSession({ agentCommand, agentId = "claude", policy = "forced-first", subjectRoot, model, task, armId, arm, armCommands, timeoutMs, graphCoverage = null }) {
   const adapter = getAgentAdapter(agentId);
   const sessionRoot = mkdtempSync(join(tmpdir(), `mex-agent-${agentId}-`));
   const sessionCommands = {};
   try {
     for (const [id, realCommand] of Object.entries(armCommands)) {
       const configPath = join(sessionRoot, `${id}-graph-command.json`);
-      writeFileSync(configPath, `${JSON.stringify({ subjectRoot, command: realCommand }, null, 2)}\n`);
+      privateWrite(configPath, `${JSON.stringify({ subjectRoot, command: realCommand }, null, 2)}\n`);
       sessionCommands[id] = [process.execPath, GRAPH_COMMAND, configPath];
     }
     const command = sessionCommands[armId] ?? [];
     const prompt = buildPrompt(task, armId, arm, command, subjectRoot, policy);
     const schemaPath = join(sessionRoot, "answer-schema.json");
-    writeFileSync(schemaPath, `${JSON.stringify(ANSWER_SCHEMA, null, 2)}\n`);
+    privateWrite(schemaPath, `${JSON.stringify(ANSWER_SCHEMA, null, 2)}\n`);
+    let settingsPath = null;
+    let guardPreflight = null;
+    if (agentId === "claude") {
+      const pinnedGuardPath = join(sessionRoot, "bash-guard.mjs");
+      const pinnedPolicyPath = join(sessionRoot, "policy.mjs");
+      pinFile(BASH_GUARD_SOURCE, pinnedGuardPath);
+      pinFile(POLICY_SOURCE, pinnedPolicyPath);
+      const guardCommand = command.length ? command : [join(sessionRoot, "bash-disabled")];
+      const guardConfigPath = join(sessionRoot, "bash-guard.json");
+      privateWrite(guardConfigPath, `${JSON.stringify({ command: guardCommand }, null, 2)}\n`);
+      settingsPath = join(sessionRoot, "claude-settings.json");
+      const guardHook = buildBashGuardHook({ guardPath: pinnedGuardPath, configPath: guardConfigPath });
+      privateWrite(settingsPath, `${JSON.stringify({
+        hooks: {
+          PreToolUse: [{ matcher: "Bash", hooks: [guardHook] }],
+        },
+      }, null, 2)}\n`);
+      guardPreflight = preflightClaudeBashGuard({
+        settingsPath,
+        configPath: guardConfigPath,
+        guardPath: pinnedGuardPath,
+        policyPath: pinnedPolicyPath,
+        command: guardCommand,
+      });
+    }
     const defaultCommand = agentId === "codex" ? ["codex"] : ["claude"];
     const [agent, ...agentPrefix] = agentCommand ?? defaultCommand;
-    const toolPolicy = allowedTools(arm, command);
+    const toolPolicy = toolPolicyForArm(arm, command);
     const invocation = adapter.buildInvocation({
       executable: agent,
       prefix: agentPrefix,
@@ -58,6 +304,7 @@ export async function runSession({ agentCommand, agentId = "claude", policy = "f
       subjectRoot,
       tools: toolPolicy.tools,
       allowedTools: toolPolicy.allowed,
+      settingsPath,
     });
     const processResult = await runTimed(invocation.command, invocation.args, { cwd: sessionRoot, timeoutMs });
     const parsed = adapter.parseTranscript(processResult.stdout, task);
@@ -65,12 +312,20 @@ export async function runSession({ agentCommand, agentId = "claude", policy = "f
       allowFileShell: agentId === "codex",
       requireGraphFirst: policy === "forced-first",
     });
-  if (parsed.permissionDenials) violations.push(`${parsed.permissionDenials} permission denial(s)`);
+  const deniedFileShellAttempts = parsed.toolCalls.filter((call) => isDeniedFileShellAttempt(call, sessionCommands)).length;
+  const permissionDenials = Number(parsed.permissionDenials ?? 0);
+  const unexplainedPermissionDenials = Math.max(0, permissionDenials - deniedFileShellAttempts);
+  if (agentId === "claude" && !parsed.bashGuardLifecycle?.valid) {
+    for (const violation of parsed.bashGuardLifecycle?.violations ?? ["missing Bash guard lifecycle audit"]) {
+      violations.push(`Claude Bash guard lifecycle: ${violation}`);
+    }
+  }
+  if (unexplainedPermissionDenials) violations.push(`${unexplainedPermissionDenials} unexplained permission denial(s)`);
   if (parsed.malformedLines) violations.push(`${parsed.malformedLines} malformed stream line(s)`);
   if (!parsed.structured.ok) violations.push(parsed.structured.error);
+  if (parsed.providerFailure?.retryable) violations.push(`retryable ${parsed.providerFailure.provider} provider ${parsed.providerFailure.type}`);
   if (processResult.timedOut) violations.push("session timeout");
   if (processResult.code !== 0) violations.push(`agent exited ${processResult.code}`);
-  if (parsed.graph.vocab > 1) violations.push("more than one vocabulary retry");
   const answer = parsed.structured.ok ? parsed.structured.value : null;
   const usage = parsed.usage;
   return {
@@ -83,13 +338,25 @@ export async function runSession({ agentCommand, agentId = "claude", policy = "f
       uncachedInput: usage.uncachedInput, cacheCreation: usage.cacheWrite, cacheWrite: usage.cacheWrite,
       cacheRead: usage.cacheRead, output: usage.output, processed: usage.reportedTotal,
       reportedTotal: usage.reportedTotal, newTokens: usage.newTokens, cacheUseRatio: usage.cacheUseRatio,
-      rawUsage: usage.raw, costUsd: usage.reportedCostUsd, elapsedMs: processResult.elapsedMs, turns: parsed.turns,
+      tokenAccountingValid: usage.accountingValid, tokenAccountingReason: usage.accountingReason,
+      terminalUsage: usage.terminal, perMessageUsage: usage.perMessage, rawUsage: usage.raw,
+      costUsd: usage.reportedCostUsd, elapsedMs: processResult.elapsedMs, turns: parsed.turns,
       toolCalls: parsed.toolCalls.length, graphCalls: parsed.graph.calls, scopeCalls: parsed.graph.scope,
-      distinctScopeQueries: parsed.graph.distinctScopeQueries, vocabularyRetries: parsed.graph.vocab,
+      distinctScopeQueries: parsed.graph.distinctScopeQueries,
       fallbacks: arm.kind === "graph" ? parsed.graph.fallbacks : 0, expectedSymbolInitialScopeRank: parsed.graph.initialScopeRank,
+      firstResponseFileRank: parsed.graph.initialFileRank, firstResponseFileRecallAt5: parsed.graph.initialFileRecallAt5,
+      firstResponseFileHitAt5: parsed.graph.initialFileHitAt5, firstResponseSourceSpanRecall: parsed.graph.initialSourceSpanRecall,
+      firstResponseDirectedFlowCoverage: parsed.graph.initialDirectedFlowCoverage, firstResponseReturnedFiles: parsed.graph.initialReturnedFiles,
+      graphEvidenceCoverage: graphCoverage?.evidenceCoverage ?? null, graphMissingEvidence: graphCoverage?.missingEvidence ?? null,
       uniqueToolResultChars: parsed.toolResultChars, uniqueToolResultTokens: parsed.toolResultTokensApprox,
-      toolErrors: parsed.toolErrors,
+      toolErrors: parsed.toolErrors, permissionDenials,
+      duplicatePermissionDenials: parsed.duplicatePermissionDenials ?? 0,
+      deniedFileShellAttempts, unexplainedPermissionDenials,
+      bashGuardLifecycle: parsed.bashGuardLifecycle ?? null,
     },
+    graphCoverage,
+    guardPreflight,
+    providerFailure: parsed.providerFailure ?? null,
     answer, grade: answer ? gradeAnswer(answer, task, subjectRoot) : { correct: false, matchedSymbols: [], missingSymbols: task.expectedSymbols ?? task.gold?.map((entry) => entry.symbol) ?? [], answerSymbolRank: null },
     valid: violations.length === 0, violations,
   };
@@ -98,30 +365,30 @@ export async function runSession({ agentCommand, agentId = "claude", policy = "f
   }
 }
 
-export async function runEvaluation({ suite, subjectRoot, outputDir, armCommands, model, timeoutMs = 300_000, resume = false, agentCommand, agentId = "claude", policy = "forced-first", repetitions = 1 }) {
+export async function runEvaluation({
+  suite, subjectRoot, outputDir, armCommands, model, timeoutMs = 300_000, resume = false,
+  agentCommand, agentId = "claude", policy = "forced-first", repetitions = null, selectedArmIds = null,
+}) {
+  const armIds = resolveSelectedArmIds(suite, selectedArmIds);
+  const selectedArmCommands = Object.fromEntries(armIds
+    .filter((armId) => armCommands[armId])
+    .map((armId) => [armId, armCommands[armId]]));
+  const runRepetitions = repetitions ?? suite.requiredRepetitions ?? 1;
   const preparePath = join(outputDir, "prepare.json");
   if (!existsSync(preparePath)) throw new Error(`missing ${preparePath}; run --prepare first`);
+  const prepareSha256 = fileHash(preparePath);
   const prepared = JSON.parse(readFileSync(preparePath, "utf8"));
-  if (prepared.suiteSha256 && prepared.suiteSha256 !== suiteHash(suite)) throw new Error("suite changed after preparation");
-  if (prepared.subject) {
-    const currentSubject = repositoryIdentity(subjectRoot);
-    const currentDiff = worktreeDiffHash(subjectRoot);
-    if (currentSubject.sha !== prepared.subject.sha || currentDiff !== prepared.subject.diffSha256) {
-      throw new Error("subject repository no longer matches the prepared fixture");
-    }
-  }
-  for (const [armId, command] of Object.entries(armCommands)) {
-    const preparedCli = prepared.cli?.[armId];
-    if (!preparedCli) continue;
-    if (JSON.stringify(command) !== JSON.stringify(preparedCli.command)) throw new Error(`CLI command changed after prepare for ${armId}`);
-    const script = command[0] === process.execPath ? command[1] : command[0];
-    if (preparedCli.sha256 && fileHash(script) !== preparedCli.sha256) throw new Error(`CLI bytes changed after prepare for ${armId}`);
-    if (preparedCli.bundleSha256 && commandBundleIdentity(command).bundleSha256 !== preparedCli.bundleSha256) throw new Error(`CLI bundle changed after prepare for ${armId}`);
-  }
-  for (const [armId, index] of Object.entries(prepared.indices ?? {})) {
-    if (index.sha256 && fileHash(index.path) !== index.sha256) throw new Error(`prepared graph index changed for ${armId}`);
-  }
-  const schedule = buildSchedule(suite.tasks, Object.keys(suite.arms), repetitions);
+  const identityContext = {
+    suite,
+    subjectRoot,
+    selectedArmCommands,
+    armIds,
+    prepared,
+    preparePath,
+    prepareSha256,
+  };
+  assertPreparedIdentity(identityContext);
+  const schedule = buildSchedule(suite.tasks, armIds, runRepetitions);
   const runsDir = join(outputDir, "runs"), transcriptsDir = join(outputDir, "transcripts");
   mkdirSync(runsDir, { recursive: true }); mkdirSync(transcriptsDir, { recursive: true });
   const manifestPath = join(outputDir, "run-manifest.json");
@@ -131,7 +398,8 @@ export async function runEvaluation({ suite, subjectRoot, outputDir, armCommands
     model,
     agentId,
     policy,
-    repetitions,
+    selectedArmIds: armIds,
+    repetitions: runRepetitions,
     timeoutMs,
     agentCommand: agentCommand ?? null,
     schedule: schedule.map(({ runId, taskIndex, repetition, orderIndex, armId }) => ({ runId, taskIndex, repetition, orderIndex, armId })),
@@ -146,36 +414,82 @@ export async function runEvaluation({ suite, subjectRoot, outputDir, armCommands
   const rows = [];
   const startedAt = existsSync(manifestPath) ? JSON.parse(readFileSync(manifestPath, "utf8")).startedAt : new Date().toISOString();
   const baseManifest = {
-    schemaVersion: 2, suiteId: suite.id, runIdentity, model, agent: agentId, policy, repetitions, timeoutMs, startedAt, status: "running",
+    schemaVersion: 3, suiteId: suite.id, runIdentity, model, agent: agentId, policy,
+    selectedArmIds: armIds, repetitions: runRepetitions, timeoutMs, startedAt, status: "running",
     schedule: schedule.map(({ runId, taskIndex, repetition, orderIndex, armId }) => ({ runId, taskIndex, repetition, orderIndex, armId })),
   };
   writeFileSync(manifestPath, `${JSON.stringify(baseManifest, null, 2)}\n`);
+  const runningManifestSha256 = fileHash(manifestPath);
+  const scheduleIdentityContext = {
+    ...identityContext,
+    manifestPath,
+    runningManifestSha256,
+  };
+  let activeRunId = null;
   try {
-    for (const item of schedule) {
-      const resultPath = join(runsDir, `${item.runId}.json`);
-      if (resume && existsSync(resultPath)) {
-        const existing = JSON.parse(readFileSync(resultPath, "utf8"));
-        if (existing.runIdentity !== runIdentity || existing.runId !== item.runId) throw new Error(`resume identity mismatch: ${item.runId}`);
-        if (!existsSync(join(transcriptsDir, `${item.runId}.jsonl`))) throw new Error(`resume transcript missing: ${item.runId}`);
-        rows.push(existing);
-        continue;
+    try {
+      for (const item of schedule) {
+        activeRunId = item.runId;
+        assertScheduleIdentity(scheduleIdentityContext, `before ${item.runId}`);
+        const resultPath = join(runsDir, `${item.runId}.json`);
+        if (resume && existsSync(resultPath)) {
+          const existing = JSON.parse(readFileSync(resultPath, "utf8"));
+          if (existing.runIdentity !== runIdentity || existing.runId !== item.runId) throw new Error(`resume identity mismatch: ${item.runId}`);
+          if (!existsSync(join(transcriptsDir, `${item.runId}.jsonl`))) throw new Error(`resume transcript missing: ${item.runId}`);
+          rows.push(existing);
+          assertScheduleIdentity(scheduleIdentityContext, `after ${item.runId}`);
+          continue;
+        }
+        if (!resume && existsSync(resultPath)) throw new Error(`run already exists: ${item.runId}; use --resume or a different --output`);
+        const arm = suite.arms[item.armId];
+        if (arm.kind === "graph") {
+          const snapshot = prepared.indices?.[item.armId]?.path;
+          if (!snapshot || !existsSync(snapshot)) throw new Error(`missing prepared graph index for ${item.armId}`);
+          guard.activate(snapshot);
+        } else guard.clear();
+        process.stderr.write(`[eval:compare] ${item.runId}\n`);
+        const preparedGold = prepared.goldEvidence?.find((entry) => entry.taskId === item.task.id);
+        const evaluatedTask = preparedGold ? { ...item.task, gold: preparedGold.symbols } : item.task;
+        const armCoverage = prepared.graphCoverage?.[item.armId] ?? prepared.indices?.[item.armId]?.goldCoverage ?? null;
+        const graphCoverage = armCoverage?.tasks?.find((entry) => entry.taskId === item.task.id) ?? null;
+        const session = await runSession({
+          agentCommand, agentId, policy, subjectRoot, model, task: evaluatedTask,
+          armId: item.armId, arm, armCommands: selectedArmCommands, timeoutMs, graphCoverage,
+        });
+        writeFileSync(join(transcriptsDir, `${item.runId}.jsonl`), session.transcript);
+        // Restore the subject's original graph before hashing the live source tree.
+        // The transcript remains useful for diagnosis, but a drifting session must
+        // never become a graded row.
+        guard.restore();
+        assertScheduleIdentity(scheduleIdentityContext, `after ${item.runId}`);
+        if (session.providerFailure?.retryable && session.providerFailure.type === "rate_limit") {
+          const status = session.providerFailure.apiErrorStatus ?? session.providerFailure.rateLimitStatus ?? "unknown";
+          throw new Error(`retryable ${session.providerFailure.provider} provider rate limit (${status}); resume after the provider limit resets`);
+        }
+        const row = { runIdentity, runId: item.runId, taskId: item.task.id, arm: item.armId, taskIndex: item.taskIndex, repetition: item.repetition, orderIndex: item.orderIndex, ...session };
+        delete row.transcript;
+        writeFileSync(resultPath, `${JSON.stringify(row, null, 2)}\n`);
+        rows.push(row);
       }
-      if (!resume && existsSync(resultPath)) throw new Error(`run already exists: ${item.runId}; use --resume or a different --output`);
-      const arm = suite.arms[item.armId];
-      if (arm.kind === "graph") {
-        const snapshot = prepared.indices?.[item.armId]?.path;
-        if (!snapshot || !existsSync(snapshot)) throw new Error(`missing prepared graph index for ${item.armId}`);
-        guard.activate(snapshot);
-      } else guard.clear();
-      process.stderr.write(`[eval:compare] ${item.runId}\n`);
-      const session = await runSession({ agentCommand, agentId, policy, subjectRoot, model, task: item.task, armId: item.armId, arm, armCommands, timeoutMs });
-      writeFileSync(join(transcriptsDir, `${item.runId}.jsonl`), session.transcript);
-      const row = { runIdentity, runId: item.runId, taskId: item.task.id, arm: item.armId, taskIndex: item.taskIndex, repetition: item.repetition, orderIndex: item.orderIndex, ...session };
-      delete row.transcript;
-      writeFileSync(resultPath, `${JSON.stringify(row, null, 2)}\n`);
-      rows.push(row);
+      activeRunId = null;
+      assertScheduleIdentity(scheduleIdentityContext, "after schedule");
+    } finally {
+      restoreGraphDbAndRemoveScratch(guard, scratch);
     }
-  } finally { guard.restore(); rmSync(scratch, { recursive: true, force: true }); }
+    assertScheduleIdentity(scheduleIdentityContext, "before completion");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const manifest = {
+      ...baseManifest,
+      status: "aborted",
+      completedAt: new Date().toISOString(),
+      resultCount: rows.length,
+      ...(activeRunId ? { failedRunId: activeRunId } : {}),
+      error: message,
+    };
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    throw error;
+  }
   const manifest = { ...baseManifest, status: "complete", completedAt: new Date().toISOString(), resultCount: rows.length };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
   return { rows, manifest };

--- a/evaluate/compare/lib/schedule.mjs
+++ b/evaluate/compare/lib/schedule.mjs
@@ -2,12 +2,18 @@ export const SIX_ARM_ORDERS = Object.freeze([
   [0, 1, 2], [0, 2, 1], [1, 0, 2], [1, 2, 0], [2, 0, 1], [2, 1, 0],
 ]);
 
+export const TWO_ARM_ORDERS = Object.freeze([
+  [0, 1], [1, 0],
+]);
+
 /** Deterministic balanced order across matched task repetitions. */
 export function buildSchedule(tasks, armIds, repetitions = 1) {
-  if (armIds.length !== 3) throw new Error("comparison schedule requires exactly three arms");
+  if (![2, 3].includes(armIds.length)) throw new Error("comparison schedule requires two or three arms");
+  if (new Set(armIds).size !== armIds.length) throw new Error("comparison schedule arm IDs must be unique");
   if (!Number.isInteger(repetitions) || repetitions < 1) throw new Error("repetitions must be a positive integer");
+  const orders = armIds.length === 2 ? TWO_ARM_ORDERS : SIX_ARM_ORDERS;
   return tasks.flatMap((task, taskIndex) => Array.from({ length: repetitions }, (_, repetitionIndex) => {
-    const permutation = SIX_ARM_ORDERS[(taskIndex * repetitions + repetitionIndex) % SIX_ARM_ORDERS.length];
+    const permutation = orders[(taskIndex * repetitions + repetitionIndex) % orders.length];
     return permutation.map((armIndex, orderIndex) => ({
       runId: `${String(taskIndex + 1).padStart(2, "0")}-${task.id}${repetitions > 1 ? `-r${String(repetitionIndex + 1).padStart(2, "0")}` : ""}-${armIds[armIndex]}`,
       taskIndex,

--- a/evaluate/compare/lib/suite.mjs
+++ b/evaluate/compare/lib/suite.mjs
@@ -3,6 +3,7 @@ import { dirname, isAbsolute, resolve } from "node:path";
 import { fileHash, objectHash } from "../../core/hash.mjs";
 
 const ARM_KINDS = new Set(["grep", "graph"]);
+const ARM_ROLES = new Set(["control", "released", "patched"]);
 
 function requiredString(value, label) {
   if (typeof value !== "string" || value.trim() === "") throw new Error(`${label} must be a non-empty string`);
@@ -22,19 +23,63 @@ function validateGold(value, label) {
     const item = `${label}[${index}]`;
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) throw new Error(`${item} must be an object`);
     requiredString(entry.symbol, `${item}.symbol`);
-    requiredString(entry.kind, `${item}.kind`);
+    if (entry.kind !== undefined) requiredString(entry.kind, `${item}.kind`);
     requiredString(entry.path, `${item}.path`);
     if (isAbsolute(entry.path)) throw new Error(`${item}.path must be repository-relative`);
     if (entry.line !== undefined && (!Number.isInteger(entry.line) || entry.line < 1)) throw new Error(`${item}.line must be positive`);
+    if (entry.startLine !== undefined && (!Number.isInteger(entry.startLine) || entry.startLine < 1)) throw new Error(`${item}.startLine must be positive`);
+    if (entry.endLine !== undefined && (!Number.isInteger(entry.endLine) || entry.endLine < (entry.startLine ?? entry.line ?? 1))) {
+      throw new Error(`${item}.endLine must not precede its source span`);
+    }
   });
+}
+
+function validateFlows(value, label) {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  value.forEach((flow, index) => {
+    if (!flow || typeof flow !== "object" || Array.isArray(flow)) throw new Error(`${label}[${index}] must be an object`);
+    for (const endpoint of ["from", "to"]) {
+      const item = flow[endpoint];
+      if (!item || typeof item !== "object" || Array.isArray(item)) throw new Error(`${label}[${index}].${endpoint} must be an object`);
+      requiredString(item.symbol, `${label}[${index}].${endpoint}.symbol`);
+      requiredString(item.path, `${label}[${index}].${endpoint}.path`);
+      if (isAbsolute(item.path)) throw new Error(`${label}[${index}].${endpoint}.path must be repository-relative`);
+    }
+    if (flow.kinds !== undefined) stringArray(flow.kinds, `${label}[${index}].kinds`, { min: 1 });
+  });
+}
+
+function validateReleaseGates(value, label) {
+  if (value === undefined) return;
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  const allowed = new Set([
+    "maxDistinctScopeQueries", "firstResponseFileHitAt5", "firstResponseSourceSpanRecall", "allRequiredFilesInFirstScope",
+  ]);
+  for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${label}.${key} is not supported`);
+  if (value.maxDistinctScopeQueries !== undefined && value.maxDistinctScopeQueries !== 1) {
+    throw new Error(`${label}.maxDistinctScopeQueries must be exactly 1`);
+  }
+  for (const key of ["firstResponseFileHitAt5", "firstResponseSourceSpanRecall"]) {
+    if (value[key] !== undefined && (!Number.isFinite(value[key]) || value[key] < 0 || value[key] > 1)) {
+      throw new Error(`${label}.${key} must be between 0 and 1`);
+    }
+  }
+  if (value.allRequiredFilesInFirstScope !== undefined && typeof value.allRequiredFilesInFirstScope !== "boolean") {
+    throw new Error(`${label}.allRequiredFilesInFirstScope must be boolean`);
+  }
 }
 
 export function validateSuite(raw, source = "suite") {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`${source} must contain a JSON object`);
-  if (raw.schemaVersion !== 1) throw new Error(`${source}.schemaVersion must be 1`);
+  if (![1, 2].includes(raw.schemaVersion)) throw new Error(`${source}.schemaVersion must be 1 or 2`);
   requiredString(raw.id, `${source}.id`);
   if (!raw.subject || typeof raw.subject !== "object") throw new Error(`${source}.subject is required`);
   requiredString(raw.subject.name, `${source}.subject.name`);
+  if (raw.requiredRepetitions !== undefined && (!Number.isInteger(raw.requiredRepetitions) || raw.requiredRepetitions < 1)) {
+    throw new Error(`${source}.requiredRepetitions must be a positive integer`);
+  }
+  validateReleaseGates(raw.releaseGates, `${source}.releaseGates`);
   if (!Array.isArray(raw.tasks) || raw.tasks.length === 0) throw new Error(`${source}.tasks must be a non-empty array`);
 
   const taskIds = new Set();
@@ -48,6 +93,14 @@ export function validateSuite(raw, source = "suite") {
       validateGold(task.gold, `${label}.gold`);
       if (task.expectedSymbols === undefined) task.expectedSymbols = task.gold.map((entry) => entry.symbol);
     }
+    validateFlows(task.requiredFlows, `${label}.requiredFlows`);
+    for (const [flowIndex, flow] of (task.requiredFlows ?? []).entries()) {
+      for (const endpoint of ["from", "to"]) {
+        if (!(task.gold ?? []).some((entry) => entry.symbol === flow[endpoint].symbol && entry.path === flow[endpoint].path)) {
+          throw new Error(`${label}.requiredFlows[${flowIndex}].${endpoint} must identify task gold evidence`);
+        }
+      }
+    }
     stringArray(task.expectedSymbols, `${label}.expectedSymbols`, { min: 1 });
   }
 
@@ -57,11 +110,11 @@ export function validateSuite(raw, source = "suite") {
   for (const id of armIds) {
     const arm = raw.arms[id];
     if (!ARM_KINDS.has(arm?.kind)) throw new Error(`${source}.arms.${id}.kind must be grep or graph`);
+    requiredString(arm.role, `${source}.arms.${id}.role`);
+    if (!ARM_ROLES.has(arm.role)) throw new Error(`${source}.arms.${id}.role must be control, released, or patched`);
     if (arm.kind === "graph") {
       if (arm.cli !== undefined) stringArray(arm.cli, `${source}.arms.${id}.cli`, { min: 1 });
-      if (arm.vocabRetry !== undefined && typeof arm.vocabRetry !== "boolean") {
-        throw new Error(`${source}.arms.${id}.vocabRetry must be boolean`);
-      }
+      if (arm.vocabRetry !== undefined) throw new Error(`${source}.arms.${id}.vocabRetry is obsolete and must be removed`);
       if (arm.buildFromGit !== undefined) {
         const build = arm.buildFromGit;
         if (!build || typeof build !== "object") throw new Error(`${source}.arms.${id}.buildFromGit must be an object`);
@@ -75,6 +128,17 @@ export function validateSuite(raw, source = "suite") {
   }
   if (armIds.filter((id) => raw.arms[id].kind === "grep").length !== 1) {
     throw new Error(`${source}.arms must contain exactly one grep arm`);
+  }
+  for (const role of ARM_ROLES) {
+    if (armIds.filter((id) => raw.arms[id].role === role).length !== 1) {
+      throw new Error(`${source}.arms must contain exactly one ${role} role`);
+    }
+  }
+  const control = raw.arms[armIds.find((id) => raw.arms[id].role === "control")];
+  if (control.kind !== "grep") throw new Error(`${source}.arms control role must use kind grep`);
+  for (const role of ["released", "patched"]) {
+    const arm = raw.arms[armIds.find((id) => raw.arms[id].role === role)];
+    if (arm.kind !== "graph") throw new Error(`${source}.arms ${role} role must use kind graph`);
   }
   return raw;
 }
@@ -94,9 +158,31 @@ export function expandToken(token, context) {
   return token.replaceAll(/\{(suiteDir|harnessRoot|subjectRoot|armRoot)\}/g, (_, key) => context[key]);
 }
 
-export function resolveArmCommands(suite, context, overrides = {}) {
+export function resolveSelectedArmIds(suite, requested = null) {
+  const available = Object.keys(suite.arms);
+  if (requested === null || requested === undefined) return available;
+  if (!Array.isArray(requested)) throw new Error("--arms must be a comma-separated list of arm IDs");
+  const normalized = requested.map((id) => typeof id === "string" ? id.trim() : "");
+  if (![2, 3].includes(normalized.length) || normalized.some((id) => id === "")) {
+    throw new Error("--arms must select exactly two or three non-empty arm IDs");
+  }
+  if (new Set(normalized).size !== normalized.length) throw new Error("--arms must not contain duplicate arm IDs");
+  const unknown = normalized.filter((id) => !suite.arms[id]);
+  if (unknown.length) throw new Error(`unknown arm ID(s): ${unknown.join(", ")}`);
+  if (normalized.length === 2) {
+    const roles = new Set(normalized.map((id) => suite.arms[id].role));
+    if (!roles.has("control") || !roles.has("patched")) {
+      throw new Error("a two-arm pilot must select the control and patched arms");
+    }
+  }
+  const selected = new Set(normalized);
+  return available.filter((id) => selected.has(id));
+}
+
+export function resolveArmCommands(suite, context, overrides = {}, armIds = null) {
   const commands = {};
-  for (const [id, arm] of Object.entries(suite.arms)) {
+  for (const id of resolveSelectedArmIds(suite, armIds)) {
+    const arm = suite.arms[id];
     if (arm.kind === "grep") continue;
     const override = overrides[id];
     const raw = override ? [process.execPath, resolve(override)] : arm.cli;

--- a/evaluate/compare/lib/transcript.mjs
+++ b/evaluate/compare/lib/transcript.mjs
@@ -1,74 +1,42 @@
-import { parseStructuredAnswer } from "./answer.mjs";
+import { claudeAdapter } from "../../adapters/agents/claude.mjs";
 
-function payloadText(content) {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) return content.map((block) => typeof block === "string" ? block : block?.text ?? JSON.stringify(block)).join("\n");
-  return content == null ? "" : JSON.stringify(content);
-}
-
-function scopeRank(payload, expectedSymbols) {
-  const facts = payload.split("\n").flatMap((line) => {
-    try { const record = JSON.parse(line); return record.type === "fact" ? [record] : []; }
-    catch { return []; }
-  });
-  const ranks = [];
-  for (const symbol of expectedSymbols) {
-    const index = facts.findIndex((fact) => fact.name === symbol || fact.symbol === symbol || JSON.stringify(fact).includes(symbol));
-    if (index >= 0) ranks.push(index + 1);
-  }
-  return ranks.length ? Math.min(...ranks) : null;
-}
-
+/**
+ * Compatibility wrapper for historical comparison consumers. New runs use the
+ * Claude adapter directly; sharing it here prevents usage accounting from
+ * drifting between the legacy reader and the active runner.
+ */
 export function parseTranscript(raw, expectedSymbols = []) {
-  const usage = { uncachedInput: 0, cacheCreation: 0, cacheRead: 0, output: 0 };
-  const toolCalls = [], toolUseById = new Map(), payloads = [], graph = { calls: 0, vocabRetries: 0, fallbacks: 0, initialScopeRank: null };
-  let resultValue = "", costUsd = 0, turns = 0, permissionDenials = 0, malformedLines = 0;
-  for (const line of raw.split("\n")) {
-    if (!line.trim()) continue;
-    let event;
-    try { event = JSON.parse(line); } catch { malformedLines += 1; continue; }
-    if (event.type === "assistant") {
-      const u = event.message?.usage ?? {};
-      usage.uncachedInput += Number(u.input_tokens ?? 0);
-      usage.cacheCreation += Number(u.cache_creation_input_tokens ?? 0);
-      usage.cacheRead += Number(u.cache_read_input_tokens ?? 0);
-      usage.output += Number(u.output_tokens ?? 0);
-      for (const block of event.message?.content ?? []) {
-        if (block.type !== "tool_use") continue;
-        const call = { id: block.id, name: block.name, input: block.input ?? {} };
-        toolCalls.push(call);
-        if (block.id) toolUseById.set(block.id, call);
-        if (["Read", "Grep", "Glob"].includes(block.name)) graph.fallbacks += 1;
-        if (block.name === "Bash") {
-          const command = String(block.input?.command ?? "");
-          if (/\bgraph\s+(?:scope|query|get|vocab)\b|\bimpact\b/.test(command)) graph.calls += 1;
-          if (/\bgraph\s+vocab\b/.test(command)) graph.vocabRetries += 1;
-        }
-      }
-    } else if (event.type === "user") {
-      for (const block of event.message?.content ?? []) {
-        if (block.type !== "tool_result") continue;
-        const text = payloadText(block.content);
-        payloads.push(text);
-        const call = toolUseById.get(block.tool_use_id);
-        if (graph.initialScopeRank === null && call?.name === "Bash" && /\bgraph\s+scope\b/.test(String(call.input?.command ?? ""))) {
-          graph.initialScopeRank = scopeRank(text, expectedSymbols);
-        }
-      }
-    } else if (event.type === "result") {
-      resultValue = event.structured_output ?? event.result ?? resultValue;
-      costUsd = Number(event.total_cost_usd ?? costUsd);
-      turns = Number(event.num_turns ?? turns);
-      permissionDenials = Array.isArray(event.permission_denials) ? event.permission_denials.length : permissionDenials;
-    }
-  }
-  const uniquePayloads = [...new Set(payloads)];
-  const uniqueToolResultChars = uniquePayloads.reduce((sum, value) => sum + value.length, 0);
-  const structured = parseStructuredAnswer(resultValue);
+  const parsed = claudeAdapter.parseTranscript(raw, { expectedSymbols });
   return {
-    usage: { ...usage, processed: Object.values(usage).reduce((sum, n) => sum + n, 0) },
-    costUsd, turns, permissionDenials, malformedLines, toolCalls, graph,
-    uniqueToolResultChars, uniqueToolResultTokens: Math.ceil(uniqueToolResultChars / 4),
-    structured,
+    usage: {
+      uncachedInput: parsed.usage.uncachedInput,
+      cacheCreation: parsed.usage.cacheWrite,
+      cacheRead: parsed.usage.cacheRead,
+      output: parsed.usage.output,
+      processed: parsed.usage.reportedTotal,
+      accountingValid: parsed.usage.accountingValid,
+      accountingReason: parsed.usage.accountingReason,
+      terminal: parsed.usage.terminal,
+      perMessage: parsed.usage.perMessage,
+    },
+    costUsd: parsed.usage.reportedCostUsd,
+    turns: parsed.turns,
+    permissionDenials: parsed.permissionDenials,
+    malformedLines: parsed.malformedLines,
+    toolCalls: parsed.toolCalls,
+    graph: {
+      calls: parsed.graph.calls,
+      scope: parsed.graph.scope,
+      get: parsed.graph.get,
+      query: parsed.graph.query,
+      impact: parsed.graph.impact,
+      distinctScopeQueries: parsed.graph.distinctScopeQueries,
+      fallbacks: parsed.graph.fallbacks,
+      initialScopeRank: parsed.graph.initialScopeRank,
+    },
+    uniqueToolResultChars: parsed.toolResultChars,
+    uniqueToolResultTokens: parsed.toolResultTokensApprox,
+    structured: parsed.structured,
+    providerFailure: parsed.providerFailure,
   };
 }

--- a/evaluate/compare/suites/hono.json
+++ b/evaluate/compare/suites/hono.json
@@ -1,0 +1,110 @@
+{
+  "schemaVersion": 2,
+  "id": "hono-graph-agent-pilot",
+  "description": "Files-only versus released main versus the active MEX graph on a source-pinned Hono checkout.",
+  "requiredRepetitions": 3,
+  "releaseGates": {
+    "maxDistinctScopeQueries": 1,
+    "firstResponseFileHitAt5": 0.9,
+    "firstResponseSourceSpanRecall": 0.8,
+    "allRequiredFilesInFirstScope": true
+  },
+  "subject": {
+    "name": "honojs/hono",
+    "repository": "https://github.com/honojs/hono.git",
+    "revision": "0293343dbf8f0bca52b210a98bcef31cc61395ee"
+  },
+  "arms": {
+    "files": {
+      "kind": "grep",
+      "role": "control",
+      "label": "repository files only"
+    },
+    "main": {
+      "kind": "graph",
+      "role": "released",
+      "label": "main",
+      "buildFromGit": {
+        "root": "{harnessRoot}",
+        "revision": "main",
+        "commands": [["npm", "run", "build"]],
+        "cli": "dist/cli.js",
+        "shareNodeModules": true
+      }
+    },
+    "candidate": {
+      "kind": "graph",
+      "role": "patched",
+      "label": "active checkout",
+      "cli": ["node", "{harnessRoot}/dist/cli.js"]
+    }
+  },
+  "tasks": [
+    {
+      "id": "request-dispatch",
+      "question": "How does an incoming Request enter a Hono application, get matched to routes, and dispatch through one or multiple handlers?",
+      "gold": [
+        { "symbol": "#dispatch", "kind": "method", "path": "src/hono-base.ts", "startLine": 407, "endLine": 467 },
+        { "symbol": "fetch", "kind": "property", "path": "src/hono-base.ts", "startLine": 480, "endLine": 486 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "fetch", "path": "src/hono-base.ts" }, "to": { "symbol": "#dispatch", "path": "src/hono-base.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "smart-router-selection",
+      "question": "How does Hono's smart router choose the first router that supports all registered paths and then reuse it for later matches?",
+      "gold": [
+        { "symbol": "SmartRouter", "kind": "class", "path": "src/router/smart-router/router.ts", "startLine": 4, "endLine": 70 },
+        { "symbol": "match", "kind": "method", "path": "src/router/smart-router/router.ts", "startLine": 21, "endLine": 61 }
+      ]
+    },
+    {
+      "id": "middleware-composition",
+      "question": "How are Hono middleware handlers composed so next advances exactly once while errors and not-found responses are handled?",
+      "gold": [
+        { "symbol": "compose", "kind": "variable", "path": "src/compose.ts", "startLine": 15, "endLine": 73 },
+        { "symbol": "dispatch", "kind": "function", "path": "src/compose.ts", "startLine": 32, "endLine": 71 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "compose", "path": "src/compose.ts" }, "to": { "symbol": "dispatch", "path": "src/compose.ts" }, "kinds": ["calls", "references", "contains"] }
+      ]
+    },
+    {
+      "id": "request-validation",
+      "question": "How does request validation extract JSON, form, query, parameter, header, or cookie input and make the validated value available to later handlers?",
+      "gold": [
+        { "symbol": "validator", "kind": "variable", "path": "src/validator/validator.ts", "startLine": 46, "endLine": 172 },
+        { "symbol": "addValidatedData", "kind": "method", "path": "src/request.ts", "startLine": 335, "endLine": 337 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "validator", "path": "src/validator/validator.ts" }, "to": { "symbol": "addValidatedData", "path": "src/request.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "context-response-construction",
+      "question": "How does a Hono Context construct a Response while combining prepared headers, explicit headers, cookies, and status values?",
+      "gold": [
+        { "symbol": "Context", "kind": "class", "path": "src/context.ts", "startLine": 293, "endLine": 293 },
+        { "symbol": "#newResponse", "kind": "method", "path": "src/context.ts", "startLine": 608, "endLine": 656 },
+        { "symbol": "createResponseInstance", "kind": "variable", "path": "src/context.ts", "startLine": 288, "endLine": 291 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "#newResponse", "path": "src/context.ts" }, "to": { "symbol": "createResponseInstance", "path": "src/context.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "query-cache-key",
+      "question": "How does Hono build safe cache keys for QUERY requests using a bounded body digest, representation metadata, and Vary headers?",
+      "gold": [
+        { "symbol": "cache", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 183, "endLine": 324 },
+        { "symbol": "createQueryDigest", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 95, "endLine": 153 },
+        { "symbol": "createCacheKey", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 51, "endLine": 70 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "cache", "path": "src/middleware/cache/index.ts" }, "to": { "symbol": "createQueryDigest", "path": "src/middleware/cache/index.ts" }, "kinds": ["calls", "references"] },
+        { "from": { "symbol": "cache", "path": "src/middleware/cache/index.ts" }, "to": { "symbol": "createCacheKey", "path": "src/middleware/cache/index.ts" }, "kinds": ["calls", "references"] }
+      ]
+    }
+  ]
+}

--- a/evaluate/compare/suites/mex-graph.json
+++ b/evaluate/compare/suites/mex-graph.json
@@ -2,6 +2,11 @@
   "schemaVersion": 1,
   "id": "mex-graph-agent-pilot",
   "description": "Repeated files-only versus main versus active-checkout agent comparison for graph retrieval.",
+  "requiredRepetitions": 3,
+  "releaseGates": {
+    "maxDistinctScopeQueries": 1,
+    "firstResponseFileHitAt5": 0.9
+  },
   "subject": { "name": "mex" },
   "arms": {
     "files": {
@@ -19,15 +24,13 @@
         "commands": [["npm", "run", "build"]],
         "cli": "dist/cli.js",
         "shareNodeModules": true
-      },
-      "vocabRetry": false
+      }
     },
     "candidate": {
       "kind": "graph",
       "role": "patched",
       "label": "active checkout",
-      "cli": ["node", "{harnessRoot}/dist/cli.js"],
-      "vocabRetry": false
+      "cli": ["node", "{harnessRoot}/dist/cli.js"]
     }
   },
   "tasks": [

--- a/evaluate/compare/suites/typescript.json
+++ b/evaluate/compare/suites/typescript.json
@@ -2,6 +2,10 @@
   "schemaVersion": 1,
   "id": "typescript-pinned-pilot",
   "description": "Six-task n=1 pilot. The runner is generic; this suite preserves the original TypeScript experiment.",
+  "requiredRepetitions": 1,
+  "releaseGates": {
+    "maxDistinctScopeQueries": 1
+  },
   "subject": {
     "name": "microsoft/TypeScript",
     "repository": "https://github.com/microsoft/TypeScript.git",
@@ -24,15 +28,13 @@
         "commands": [["npm", "run", "build"]],
         "cli": "dist/cli.js",
         "shareNodeModules": true
-      },
-      "vocabRetry": false
+      }
     },
     "patched": {
       "kind": "graph",
       "role": "patched",
       "label": "patched mex",
-      "cli": ["node", "{harnessRoot}/dist/cli.js"],
-      "vocabRetry": true
+      "cli": ["node", "{harnessRoot}/dist/cli.js"]
     }
   },
   "tasks": [

--- a/evaluate/compare/test/compare.test.mjs
+++ b/evaluate/compare/test/compare.test.mjs
@@ -1,23 +1,36 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 import { spawnSync } from "node:child_process";
-import { parseStructuredAnswer } from "../lib/answer.mjs";
+import { ANSWER_SCHEMA, MIN_SUBSTANTIVE_ANSWER_LENGTH, parseStructuredAnswer } from "../lib/answer.mjs";
+import { guardBashInput } from "../lib/bash-guard.mjs";
+import { parseArgs } from "../index.mjs";
+import { buildPrompt } from "../lib/prompt.mjs";
 import { validateTranscriptPolicy } from "../lib/policy.mjs";
 import { prepareEvaluation } from "../lib/prepare.mjs";
-import { generateReport, pairedDeltas } from "../lib/report.mjs";
-import { runEvaluation, runSession } from "../lib/runner.mjs";
-import { buildSchedule, SIX_ARM_ORDERS } from "../lib/schedule.mjs";
+import { aggregateReleaseReports, buildReleaseGate, generateReport, pairedDeltas } from "../lib/report.mjs";
+import { buildBashGuardHook, claudeArgs, runEvaluation, runSession, toolPolicyForArm } from "../lib/runner.mjs";
+import { buildSchedule, SIX_ARM_ORDERS, TWO_ARM_ORDERS } from "../lib/schedule.mjs";
+import { loadSuite, resolveSelectedArmIds, validateSuite } from "../lib/suite.mjs";
 import { parseTranscript } from "../lib/transcript.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const FAKE = join(HERE, "fixtures", "fake-claude.mjs");
 const FAKE_CODEX = join(HERE, "fixtures", "fake-codex.mjs");
-const ARMS = { grep: { kind: "grep" }, baseline: { kind: "graph", vocabRetry: false }, patched: { kind: "graph", vocabRetry: true } };
+const ARMS = {
+  grep: { kind: "grep", role: "control" },
+  baseline: { kind: "graph", role: "released" },
+  patched: { kind: "graph", role: "patched" },
+};
 const COMMANDS = { baseline: ["node", "/tmp/baseline.js"], patched: ["node", "/tmp/patched.js"] };
+const SUITES = {
+  mex: join(HERE, "..", "suites", "mex-graph.json"),
+  hono: join(HERE, "..", "suites", "hono.json"),
+  typescript: join(HERE, "..", "suites", "typescript.json"),
+};
 
 test("six tasks use all six arm permutations exactly once", () => {
   const tasks = Array.from({ length: 6 }, (_, index) => ({ id: `t${index}` }));
@@ -36,31 +49,280 @@ test("repetitions balance all arm orders without losing pair identity", () => {
   assert.deepEqual(schedule.slice(0, 9).map((row) => row.repetition), [1, 1, 1, 2, 2, 2, 3, 3, 3]);
 });
 
+test("two-arm schedules alternate both orders and keep matched run identity", () => {
+  const tasks = Array.from({ length: 6 }, (_, index) => ({ id: `t${index}` }));
+  const armIds = ["grep", "patched"];
+  const schedule = buildSchedule(tasks, armIds);
+  assert.equal(schedule.length, 12);
+  const orders = tasks.map((_, index) => schedule.slice(index * 2, index * 2 + 2)
+    .map((row) => armIds.indexOf(row.armId)));
+  assert.deepEqual(orders, Array.from({ length: 6 }, (_, index) => TWO_ARM_ORDERS[index % 2]));
+  assert.equal(orders.filter((order) => order[0] === 0).length, 3);
+  assert.throws(() => buildSchedule(tasks, ["grep", "grep"]), /unique/);
+});
+
+test("--arms selects a canonical validated two-arm pilot", () => {
+  const args = parseArgs(["--run", "--suite", SUITES.mex, "--model", "fake", "--arms", "candidate,files"]);
+  assert.deepEqual(args.arms, ["candidate", "files"]);
+  const suite = loadSuite(SUITES.mex);
+  assert.deepEqual(resolveSelectedArmIds(suite, args.arms), ["files", "candidate"]);
+  assert.throws(() => resolveSelectedArmIds(suite, ["files", "files"]), /duplicate/);
+  assert.throws(() => resolveSelectedArmIds(suite, ["files", "missing"]), /unknown arm/);
+  assert.throws(() => resolveSelectedArmIds(suite, ["main", "candidate"]), /control and patched/);
+  assert.throws(() => parseArgs(["--run", "--suite", SUITES.mex, "--model", "fake", "--arms"]), /requires/);
+});
+
 test("stream JSON accounting sums assistant usage and deduplicates tool payloads", () => {
-  const assistant = (usage) => JSON.stringify({ type: "assistant", message: { usage, content: [] } });
+  const assistant = (id, usage, content = []) => JSON.stringify({ type: "assistant", message: { id, usage, content } });
   const tool = JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: "x", content: "same" }] } });
-  const result = JSON.stringify({ type: "result", structured_output: { answer: "S", symbols: ["S"], evidence: [{ path: "a", line: 1 }], complete: true }, total_cost_usd: 0.25, num_turns: 2 });
-  const parsed = parseTranscript([assistant({ input_tokens: 1, cache_creation_input_tokens: 2, cache_read_input_tokens: 3, output_tokens: 4 }), tool, assistant({ input_tokens: 5, output_tokens: 6 }), tool, result].join("\n"));
-  assert.deepEqual(parsed.usage, { uncachedInput: 6, cacheCreation: 2, cacheRead: 3, output: 10, processed: 21 });
+  const result = JSON.stringify({ type: "result", structured_output: { answer: "S is declared in the cited source and implements the requested behavior.", symbols: ["S"], evidence: [{ path: "a", line: 1 }], complete: true }, usage: { input_tokens: 6, cache_creation_input_tokens: 2, cache_read_input_tokens: 3, output_tokens: 10 }, total_cost_usd: 0.25, num_turns: 2 });
+  const parsed = parseTranscript([assistant("m1", { input_tokens: 1, cache_creation_input_tokens: 2, cache_read_input_tokens: 3, output_tokens: 4 }, [{ type: "tool_use", id: "x", name: "Read", input: { file_path: "a" } }]), tool, assistant("m2", { input_tokens: 5, output_tokens: 6 }), tool, result].join("\n"));
+  assert.deepEqual({
+    uncachedInput: parsed.usage.uncachedInput,
+    cacheCreation: parsed.usage.cacheCreation,
+    cacheRead: parsed.usage.cacheRead,
+    output: parsed.usage.output,
+    processed: parsed.usage.processed,
+    accountingValid: parsed.usage.accountingValid,
+  }, { uncachedInput: 6, cacheCreation: 2, cacheRead: 3, output: 10, processed: 21, accountingValid: true });
   assert.equal(parsed.uniqueToolResultChars, 4);
   assert.equal(parsed.costUsd, 0.25);
 });
 
-test("structured answers reject malformed evidence", () => {
-  assert.equal(parseStructuredAnswer('{"answer":"x","symbols":[],"evidence":[],"complete":true}').ok, true);
-  assert.equal(parseStructuredAnswer('{"answer":"x","symbols":[],"evidence":[{"path":"a","line":0}],"complete":true}').ok, false);
+test("structured answers reject placeholders and too-short answers", () => {
+  const base = { symbols: ["TargetSymbol"], evidence: [{ path: "src/target.ts", line: 1 }], complete: true };
+  assert.equal(parseStructuredAnswer({ answer: "test", ...base }).ok, false);
+  assert.equal(parseStructuredAnswer({ answer: "x".repeat(MIN_SUBSTANTIVE_ANSWER_LENGTH - 1), ...base }).ok, false);
+});
+
+test("structured answers require non-empty symbols and evidence", () => {
+  const validAnswer = "TargetSymbol handles the requested behavior in the cited source file.";
+  assert.equal(parseStructuredAnswer({ answer: validAnswer, evidence: [{ path: "src/target.ts", line: 1 }], complete: true }).ok, false);
+  assert.equal(parseStructuredAnswer({ answer: validAnswer, symbols: [], evidence: [{ path: "src/target.ts", line: 1 }], complete: true }).ok, false);
+  assert.equal(parseStructuredAnswer({ answer: validAnswer, symbols: ["TargetSymbol"], complete: true }).ok, false);
+  assert.equal(parseStructuredAnswer({ answer: validAnswer, symbols: ["TargetSymbol"], evidence: [], complete: true }).ok, false);
+});
+
+test("structured answers accept a valid concise answer and reject malformed evidence", () => {
+  const valid = {
+    answer: "TargetSymbol handles the requested behavior in the cited source file.",
+    symbols: ["TargetSymbol"],
+    evidence: [{ path: "src/target.ts", line: 1 }],
+    complete: true,
+  };
+  assert.deepEqual(parseStructuredAnswer(valid), { ok: true, value: valid });
+  assert.equal(parseStructuredAnswer({ ...valid, evidence: [{ path: "src/target.ts", line: 0 }] }).ok, false);
 });
 
 test("policy rejects shell operators, SQLite, cross-arm binaries, and missing scope", () => {
-  const bash = (command) => ({ name: "Bash", input: { command } });
+  const bash = (command, output = null, status = "executed") => ({ name: "Bash", input: { command }, output, status });
   assert.match(validateTranscriptPolicy([bash('node /tmp/patched.js graph scope x && rg y')], "patched", ARMS.patched, COMMANDS).join("\n"), /control operator/);
   assert.match(validateTranscriptPolicy([{ name: "Read", input: { file_path: ".mex/graph.db" } }], "grep", ARMS.grep, COMMANDS).join("\n"), /SQLite/);
+  assert.match(validateTranscriptPolicy([bash("sqlite3 .mex/graph.db 'select * from nodes'")], "grep", ARMS.grep, COMMANDS, { allowFileShell: true }).join("\n"), /SQLite/);
   assert.match(validateTranscriptPolicy([bash('node /tmp/baseline.js graph scope x')], "patched", ARMS.patched, COMMANDS).join("\n"), /cross-arm/);
+  assert.match(validateTranscriptPolicy([
+    bash("find /tmp -exec node /tmp/baseline.js graph scope x {} \\;"),
+  ], "patched", ARMS.patched, COMMANDS, { allowFileShell: true }).join("\n"), /cross-arm/);
   assert.match(validateTranscriptPolicy([{ name: "Read", input: { file_path: "src/a.ts" } }], "patched", ARMS.patched, COMMANDS).join("\n"), /did not start/);
+  assert.match(validateTranscriptPolicy([bash('node /tmp/patched.js graph vocab')], "patched", ARMS.patched, COMMANDS).join("\n"), /disallowed graph command/);
+});
+
+test("policy ignores graph database prose in final structured answers", () => {
+  const answer = {
+    name: "StructuredOutput",
+    input: { answer: "The index is stored in .mex/graph.db; do not query it with sqlite3." },
+    status: "executed",
+  };
+  assert.deepEqual(validateTranscriptPolicy([answer], "grep", ARMS.grep, COMMANDS), []);
+  assert.match(validateTranscriptPolicy([
+    { name: "Read", input: { file_path: ".mex/graph.db" }, status: "executed" },
+  ], "grep", ARMS.grep, COMMANDS).join("\n"), /raw SQLite access through Read/);
+});
+
+test("policy permits single read-only file commands without permitting shell composition", () => {
+  const bash = (command) => ({ name: "Bash", input: { command }, output: "", status: "executed" });
+  const calls = [
+    bash('node /tmp/baseline.js graph scope "question"'),
+    bash("pwd"),
+    bash("ls /repo/src"),
+    bash('grep -n "first\\|second" /repo/src/a.ts'),
+  ];
+  assert.deepEqual(validateTranscriptPolicy(calls, "baseline", ARMS.baseline, COMMANDS, { allowFileShell: true }), []);
+  assert.match(validateTranscriptPolicy([
+    bash('node /tmp/baseline.js graph scope "question"'),
+    bash("grep -n value /repo/src/a.ts | head -10"),
+  ], "baseline", ARMS.baseline, COMMANDS, { allowFileShell: true }).join("\n"), /shell control operator/);
+});
+
+test("candidate graph follow-ups require an executed non-ok Scope with an appropriate status", () => {
+  const bash = (command, status, execution = "executed") => ({
+    name: "Bash", input: { command }, status: execution,
+    output: status === null ? '{"type":"summary"}\n' : `{"type":"summary","status":"${status}"}\n`,
+  });
+  for (const status of ["partial", "degraded", "no-match"]) {
+    const calls = [bash('node /tmp/patched.js graph scope "question"', status), bash("node /tmp/patched.js graph query symbol Target", null)];
+    assert.equal(validateTranscriptPolicy(calls, "patched", ARMS.patched, COMMANDS).some((entry) => entry.includes("graph query requires")), false, status);
+  }
+  for (const status of ["partial", "degraded"]) {
+    const calls = [bash('node /tmp/patched.js graph scope "question"', status), bash("node /tmp/patched.js graph get node:target", null)];
+    assert.equal(validateTranscriptPolicy(calls, "patched", ARMS.patched, COMMANDS).some((entry) => entry.includes("graph get requires")), false, status);
+  }
+  for (const [command, status, execution] of [
+    ["graph query symbol Target", "ok", "executed"],
+    ["graph query symbol Target", null, "executed"],
+    ["graph query symbol Target", "partial", "error"],
+    ["graph get node:target", "no-match", "executed"],
+  ]) {
+    const calls = [bash('node /tmp/patched.js graph scope "question"', status, execution), bash(`node /tmp/patched.js ${command}`, null)];
+    assert.match(validateTranscriptPolicy(calls, "patched", ARMS.patched, COMMANDS).join("\n"), /requires a preceding scope summary/);
+  }
+  const released = [bash('node /tmp/baseline.js graph scope "question"', null), bash("node /tmp/baseline.js graph get node:target", null)];
+  assert.equal(validateTranscriptPolicy(released, "baseline", ARMS.baseline, COMMANDS).some((entry) => entry.includes("requires a preceding")), false);
+
+  const nonTerminalSummary = [{
+    name: "Bash", status: "executed", input: { command: 'node /tmp/patched.js graph scope "question"' },
+    output: '{"type":"summary","status":"partial"}\n{"type":"fact"}\n',
+  }, bash("node /tmp/patched.js graph query symbol Target", null)];
+  assert.match(validateTranscriptPolicy(nonTerminalSummary, "patched", ARMS.patched, COMMANDS).join("\n"), /got missing/);
+});
+
+test("candidate policy permits one normalized Scope query and rejects a second distinct request", () => {
+  const scope = (question) => ({
+    name: "Bash", status: "executed", input: { command: `node /tmp/patched.js graph scope "${question}"` },
+    output: '{"type":"summary","status":"ok"}\n',
+  });
+  assert.equal(validateTranscriptPolicy([scope("Same Question"), scope("same   question")], "patched", ARMS.patched, COMMANDS).some((entry) => entry.includes("distinct graph scope")), false);
+  assert.match(validateTranscriptPolicy([scope("first"), scope("second")], "patched", ARMS.patched, COMMANDS).join("\n"), /maximum is 1/);
+});
+
+test("candidate prompt exposes one-Scope and status-gated follow-ups without vocabulary retry guidance", () => {
+  const prompt = buildPrompt({ question: "Where?" }, "patched", ARMS.patched, COMMANDS.patched, "/repo");
+  assert.match(prompt, /only one distinct Scope/);
+  assert.match(prompt, /partial, degraded, or no-match/);
+  assert.doesNotMatch(prompt, /vocab|VOCABULARY|1-12 project terms/i);
+  const released = buildPrompt({ question: "Where?" }, "baseline", ARMS.baseline, COMMANDS.baseline, "/repo");
+  assert.doesNotMatch(released, /summary status|only one distinct Scope/);
+});
+
+test("answer contract requires exact source declaration names rather than graph node IDs", () => {
+  const prompt = buildPrompt({ question: "Where?" }, "patched", ARMS.patched, COMMANDS.patched, "/repo");
+  assert.match(prompt, /exact source declaration names/i);
+  assert.match(prompt, /never graph node IDs/i);
+  assert.match(ANSWER_SCHEMA.properties.symbols.description, /exact source declaration names/i);
+  assert.match(ANSWER_SCHEMA.properties.symbols.description, /never graph node IDs/i);
+});
+
+test("answer contract requires substantive output and every non-empty field", () => {
+  const prompt = buildPrompt({ question: "Where?" }, "patched", ARMS.patched, COMMANDS.patched, "/repo");
+  assert.equal(ANSWER_SCHEMA.properties.answer.minLength, MIN_SUBSTANTIVE_ANSWER_LENGTH);
+  assert.equal(ANSWER_SCHEMA.properties.symbols.minItems, 1);
+  assert.equal(ANSWER_SCHEMA.properties.evidence.minItems, 1);
+  for (const key of ANSWER_SCHEMA.required) assert.match(ANSWER_SCHEMA.properties[key].description, /required/i);
+  assert.match(prompt, /all four required root keys: answer, symbols, evidence, and complete/i);
+  assert.match(prompt, /substantive, source-grounded explanation/i);
+  assert.match(prompt, /never return a placeholder/i);
+  assert.match(prompt, /symbols and evidence fields must each be non-empty arrays/i);
+});
+
+test("Claude arm capabilities keep file tools equal and narrowly allow only the graph wrapper", () => {
+  const files = toolPolicyForArm(ARMS.grep, []);
+  const graph = toolPolicyForArm(ARMS.patched, COMMANDS.patched);
+  assert.equal(files.tools, "Read,Grep,Glob");
+  assert.deepEqual(files.allowed, ["Read", "Grep", "Glob"]);
+  assert.equal(graph.tools, "Read,Grep,Glob,Bash");
+  assert.deepEqual(graph.allowed.slice(0, 3), files.allowed);
+  assert.deepEqual(graph.allowed.slice(3), [
+    "Bash(node /tmp/patched.js graph scope *)",
+    "Bash(node /tmp/patched.js graph query *)",
+    "Bash(node /tmp/patched.js graph get *)",
+    "Bash(node /tmp/patched.js impact *)",
+  ]);
+  assert.equal(graph.allowed.includes("Bash"), false);
+
+  const args = claudeArgs({
+    prompt: "p", model: "m", arm: ARMS.patched, command: COMMANDS.patched,
+    settingsPath: "/tmp/claude-settings.json",
+  });
+  assert.equal(args[args.indexOf("--permission-mode") + 1], "dontAsk");
+  assert.equal(args[args.indexOf("--setting-sources") + 1], "");
+  assert.equal(args[args.indexOf("--settings") + 1], "/tmp/claude-settings.json");
+  assert.equal(args.includes("--include-hook-events"), true);
+  assert.deepEqual(args.slice(args.indexOf("--allowedTools") + 1), graph.allowed);
+});
+
+test("Claude Bash guard admits only direct fixed-wrapper graph operations", () => {
+  const input = (command, extra = {}) => ({ hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: { command, ...extra } });
+  assert.equal(guardBashInput(input('node /tmp/patched.js graph scope "question"'), COMMANDS.patched).allowed, true);
+  assert.equal(guardBashInput(input("node /tmp/patched.js graph get function:abc"), COMMANDS.patched).allowed, true);
+  assert.equal(guardBashInput(input("node /tmp/patched.js impact function:abc"), COMMANDS.patched).allowed, true);
+  for (const command of [
+    'cd /repo && grep -R "Target" src | head -20',
+    'node /tmp/patched.js graph scope "question" && grep Target src/a.ts',
+    "node /tmp/patched.js graph vocab",
+    "bash -lc 'node /tmp/patched.js graph scope question'",
+  ]) {
+    const decision = guardBashInput(input(command), COMMANDS.patched);
+    assert.equal(decision.allowed, false, command);
+    assert.ok(decision.violations.length > 0, command);
+  }
+  for (const forbidden of [
+    { run_in_background: true },
+    { run_in_background: false },
+    { dangerouslyDisableSandbox: true },
+    { bypassPermissions: true },
+    { sandbox: false },
+  ]) {
+    const decision = guardBashInput(input('node /tmp/patched.js graph scope "question"', forbidden), COMMANDS.patched);
+    assert.equal(decision.allowed, false, JSON.stringify(forbidden));
+    assert.match(decision.violations.join("\n"), /forbidden Bash input field/);
+  }
+  assert.equal(guardBashInput({ hook_event_name: "PreToolUse", tool_name: "Read", tool_input: { file_path: "/repo/src/a.ts" } }, COMMANDS.patched).allowed, false);
+});
+
+test("Claude Bash guard launcher maps guard startup failures to blocking exit 2", () => {
+  const hook = buildBashGuardHook({
+    nodePath: process.execPath,
+    guardPath: "/definitely/missing/mex-bash-guard.mjs",
+    configPath: "/definitely/missing/mex-bash-guard.json",
+  });
+  assert.equal(hook.command, "/bin/sh");
+  assert.equal(Array.isArray(hook.args), true);
+  const result = spawnSync(hook.command, hook.args, {
+    input: `${JSON.stringify({ hook_event_name: "PreToolUse", tool_name: "Bash", tool_input: { command: "git status" } })}\n`,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /MEX_EVAL_BASH_DENIED/);
+});
+
+test("comparison suites configure repetitions and reject obsolete vocabulary retry options", () => {
+  const suites = Object.fromEntries(Object.entries(SUITES).map(([id, path]) => [id, loadSuite(path)]));
+  assert.deepEqual(Object.fromEntries(Object.entries(suites).map(([id, suite]) => [id, suite.requiredRepetitions])), {
+    mex: 3, hono: 3, typescript: 1,
+  });
+  for (const suite of Object.values(suites)) {
+    for (const arm of Object.values(suite.arms)) assert.equal(Object.hasOwn(arm, "vocabRetry"), false);
+    assert.deepEqual(Object.values(suite.arms).map((arm) => arm.role).sort(), ["control", "patched", "released"]);
+  }
+  const obsolete = JSON.parse(readFileSync(SUITES.typescript, "utf8"));
+  obsolete.arms.patched.vocabRetry = true;
+  assert.throws(() => validateSuite(obsolete), /obsolete/);
+
+  const missingRole = JSON.parse(readFileSync(SUITES.typescript, "utf8"));
+  delete missingRole.arms.patched.role;
+  assert.throws(() => validateSuite(missingRole), /role must be a non-empty string/);
+
+  const duplicateRole = JSON.parse(readFileSync(SUITES.typescript, "utf8"));
+  duplicateRole.arms.patched.role = "released";
+  assert.throws(() => validateSuite(duplicateRole), /exactly one released role/);
+
+  const misleadingScopeLimit = JSON.parse(readFileSync(SUITES.typescript, "utf8"));
+  misleadingScopeLimit.releaseGates.maxDistinctScopeQueries = 2;
+  assert.throws(() => validateSuite(misleadingScopeLimit), /must be exactly 1/);
 });
 
 test("paired deltas are matched within each task", () => {
-  const row = (taskId, arm, processed) => ({ taskId, arm, metrics: { processed, costUsd: 0, uniqueToolResultChars: 0, uniqueToolResultTokens: 0, elapsedMs: 0, turns: 0, toolCalls: 0, graphCalls: 0, vocabularyRetries: 0, fallbacks: 0 } });
+  const row = (taskId, arm, processed) => ({ taskId, arm, metrics: { processed, costUsd: 0, uniqueToolResultChars: 0, uniqueToolResultTokens: 0, elapsedMs: 0, turns: 0, toolCalls: 0, graphCalls: 0, fallbacks: 0 } });
   const pairs = pairedDeltas([row("a", "grep", 10), row("a", "baseline", 7), row("b", "grep", 100), row("b", "baseline", 90)], ["grep", "baseline"]);
   assert.deepEqual(pairs[0].perTask.map((entry) => entry.processed), [-3, -10]);
   assert.equal(pairs[0].mean.processed, -6.5);
@@ -75,6 +337,361 @@ test("paired token accounting keeps cache reads separate from new-token deltas",
   const pair = pairedDeltas(rows, ["grep", "baseline"])[0];
   assert.equal(pair.mean.newTokens, -30);
   assert.equal(pair.mean.cacheRead, 400);
+});
+
+test("paired token decisions exclude mismatched usage while retaining non-token deltas", () => {
+  const rows = [
+    { taskId: "a", repetition: 1, arm: "grep", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100, cacheRead: 500, costUsd: 1, fallbacks: 2 } },
+    { taskId: "a", repetition: 1, arm: "baseline", valid: true, metrics: { tokenAccountingValid: false, newTokens: 10, cacheRead: 900, costUsd: 0.1, fallbacks: 0 } },
+  ];
+  const pair = pairedDeltas(rows, ["grep", "baseline"])[0];
+  assert.equal(pair.mean.newTokens, null);
+  assert.equal(pair.mean.cacheRead, null);
+  assert.equal(pair.mean.costUsd, null);
+  assert.equal(pair.mean.fallbacks, -2);
+  assert.equal(pair.tokenEligiblePairs, 0);
+  assert.equal(pair.costEligiblePairs, 0);
+});
+
+test("paired deltas report task-macro percentage changes and a task-level bootstrap interval", () => {
+  const rows = [
+    { taskId: "a", arm: "files", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100 } },
+    { taskId: "a", arm: "candidate", valid: true, metrics: { tokenAccountingValid: true, newTokens: 60 } },
+    { taskId: "b", arm: "files", valid: true, metrics: { tokenAccountingValid: true, newTokens: 200 } },
+    { taskId: "b", arm: "candidate", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100 } },
+  ];
+  const pair = pairedDeltas(rows, ["files", "candidate"])[0];
+  assert.deepEqual(pair.perTask.map((entry) => entry.percentChange.newTokens), [-40, -50]);
+  assert.equal(pair.percentChange.macroMedian.newTokens, -45);
+  assert.equal(pair.percentChange.confidence95.newTokens.tasks, 2);
+  assert.ok(pair.percentChange.confidence95.newTokens.high < 0);
+});
+
+function gateRows(candidateMetrics = {}) {
+  const rows = [];
+  for (const taskId of ["a", "b"]) {
+    rows.push({ taskId, arm: "files", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100, processed: 200, costUsd: 1, fallbacks: 0 } });
+    rows.push({ taskId, arm: "main", valid: true, metrics: { tokenAccountingValid: true, newTokens: 90, processed: 220, costUsd: 1.1, fallbacks: 5 } });
+    rows.push({ taskId, arm: "candidate", valid: true, metrics: {
+      tokenAccountingValid: true, newTokens: 60, processed: 190, costUsd: 0.9, fallbacks: 2, ...candidateMetrics,
+    } });
+  }
+  return rows;
+}
+
+function releaseGate(rows, finalCorrectness = { files: 2, main: 2, candidate: 2 }, pilotValid = true) {
+  return buildReleaseGate({
+    candidateVsFiles: pairedDeltas(rows, ["files", "candidate"])[0],
+    rows,
+    releasedId: "main",
+    candidateId: "candidate",
+    controlIds: ["files", "main"],
+    finalCorrectness,
+    pilotValid,
+  });
+}
+
+function configuredGateRows(suite) {
+  const armByRole = Object.fromEntries(Object.entries(suite.arms).map(([id, arm]) => [arm.role, id]));
+  const rows = [];
+  for (const task of suite.tasks) {
+    const requiredFiles = [...new Set((task.gold ?? []).map((entry) => entry.path))];
+    for (let repetition = 1; repetition <= suite.requiredRepetitions; repetition++) {
+      rows.push({ taskId: task.id, repetition, arm: armByRole.control, valid: true, metrics: {
+        tokenAccountingValid: true, newTokens: 100, processed: 200, costUsd: 1, fallbacks: 0,
+      } });
+      rows.push({ taskId: task.id, repetition, arm: armByRole.released, valid: true, metrics: {
+        tokenAccountingValid: true, newTokens: 90, processed: 220, costUsd: 1.1, fallbacks: 5,
+      } });
+      rows.push({ taskId: task.id, repetition, arm: armByRole.patched, valid: true, metrics: {
+        tokenAccountingValid: true, newTokens: 60, processed: 190, costUsd: 0.9, fallbacks: 2,
+        distinctScopeQueries: 1, firstResponseFileHitAt5: true, firstResponseSourceSpanRecall: 0.8,
+        firstResponseReturnedFiles: requiredFiles,
+      } });
+    }
+  }
+  return rows;
+}
+
+function configuredReleaseGate(suite, rows) {
+  const idByRole = Object.fromEntries(Object.entries(suite.arms).map(([id, arm]) => [arm.role, id]));
+  const expectedCorrect = suite.tasks.length * suite.requiredRepetitions;
+  return buildReleaseGate({
+    candidateVsFiles: pairedDeltas(rows, [idByRole.control, idByRole.patched])[0],
+    rows,
+    releasedId: idByRole.released,
+    candidateId: idByRole.patched,
+    controlIds: [idByRole.control, idByRole.released],
+    finalCorrectness: Object.fromEntries(Object.values(idByRole).map((id) => [id, expectedCorrect])),
+    pilotValid: true,
+    suite,
+  });
+}
+
+test("hard release gate enforces token, processed, cost, fallback, and correctness thresholds", () => {
+  const passing = releaseGate(gateRows());
+  assert.equal(passing.status, "pass");
+  assert.equal(passing.passed, true);
+  assert.equal(passing.criteria.newTokensVsFiles.observedPercent, -40);
+  assert.ok(passing.criteria.newTokensVsFiles.bootstrapMean95Percent.high < 0);
+  assert.equal(passing.criteria.fallbacksVsReleased.observedReductionPercent, 60);
+
+  const failing = releaseGate(
+    gateRows({ newTokens: 71, processed: 201, costUsd: 1.01, fallbacks: 3 }),
+    { files: 2, main: 2, candidate: 1 },
+  );
+  assert.equal(failing.status, "fail");
+  assert.equal(failing.passed, false);
+  assert.deepEqual(failing.failures, [
+    "newTokensVsFiles", "processedTokensVsFiles", "costVsFiles", "fallbacksVsReleased", "correctnessVsControls",
+  ]);
+});
+
+test("two-arm gate evaluates candidate versus files without an absent released arm", () => {
+  const rows = gateRows().filter((row) => row.arm !== "main");
+  const suite = {
+    requiredRepetitions: 1,
+    arms: {
+      files: { kind: "grep", role: "control" },
+      main: { kind: "graph", role: "released" },
+      candidate: { kind: "graph", role: "patched" },
+    },
+    tasks: [{ id: "a" }, { id: "b" }],
+  };
+  const gate = buildReleaseGate({
+    candidateVsFiles: pairedDeltas(rows, ["files", "candidate"])[0],
+    rows,
+    releasedId: null,
+    candidateId: "candidate",
+    controlIds: ["files"],
+    finalCorrectness: { files: 2, candidate: 2 },
+    pilotValid: true,
+    suite,
+    selectedArmIds: ["files", "candidate"],
+  });
+  assert.equal(gate.kind, "candidate-vs-files-gate");
+  assert.equal(gate.passed, true);
+  assert.equal(Object.hasOwn(gate.criteria, "fallbacksVsReleased"), false);
+  assert.deepEqual(gate.criteria.correctnessVsControls.controls, { files: 2 });
+  assert.equal(gate.criteria.repetitions.expectedRuns, 4);
+  assert.equal(gate.criteria.repetitions.actualRuns, 4);
+});
+
+test("hard release gate rejects a 30% macro token win when its bootstrap interval crosses zero", () => {
+  const rows = [];
+  for (const [taskId, newTokens] of [["a", 20], ["b", 60], ["c", 200]]) {
+    rows.push({ taskId, arm: "files", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100, processed: 200, costUsd: 1, fallbacks: 0 } });
+    rows.push({ taskId, arm: "main", valid: true, metrics: { tokenAccountingValid: true, newTokens: 90, processed: 220, costUsd: 1.1, fallbacks: 5 } });
+    rows.push({ taskId, arm: "candidate", valid: true, metrics: { tokenAccountingValid: true, newTokens, processed: 190, costUsd: 0.9, fallbacks: 2 } });
+  }
+  const gate = releaseGate(rows, { files: 3, main: 3, candidate: 3 });
+  assert.equal(gate.criteria.newTokensVsFiles.observedPercent, -40);
+  assert.ok(gate.criteria.newTokensVsFiles.bootstrapMean95Percent.high > 0);
+  assert.equal(gate.criteria.newTokensVsFiles.passed, false);
+  assert.equal(gate.passed, false);
+});
+
+test("processed and cost guards reject aggregate regressions hidden by a favorable task median", () => {
+  const rows = [];
+  for (const [taskId, processed, costUsd] of [["a", 190, 0.9], ["b", 190, 0.9], ["c", 500, 4]]) {
+    rows.push({ taskId, arm: "files", valid: true, metrics: { tokenAccountingValid: true, newTokens: 100, processed: 200, costUsd: 1, fallbacks: 0 } });
+    rows.push({ taskId, arm: "main", valid: true, metrics: { tokenAccountingValid: true, newTokens: 90, processed: 220, costUsd: 1.1, fallbacks: 5 } });
+    rows.push({ taskId, arm: "candidate", valid: true, metrics: { tokenAccountingValid: true, newTokens: 60, processed, costUsd, fallbacks: 2 } });
+  }
+  const gate = releaseGate(rows, { files: 3, main: 3, candidate: 3 });
+  assert.equal(gate.criteria.processedTokensVsFiles.observedMacroMedianDelta, -10);
+  assert.ok(gate.criteria.processedTokensVsFiles.observedMeanDelta > 0);
+  assert.equal(gate.criteria.processedTokensVsFiles.passed, false);
+  assert.equal(gate.criteria.costVsFiles.observedMacroMedianDelta, -0.1);
+  assert.ok(gate.criteria.costVsFiles.observedMeanDelta > 0);
+  assert.equal(gate.criteria.costVsFiles.passed, false);
+});
+
+test("hard release gate returns stable insufficient-sample nulls", () => {
+  const rows = gateRows().filter((row) => row.taskId === "a");
+  const gate = releaseGate(rows);
+  assert.equal(gate.status, "insufficient-sample");
+  assert.equal(gate.passed, null);
+  assert.equal(gate.criteria.newTokensVsFiles.observedPercent, null);
+  assert.deepEqual(gate.criteria.newTokensVsFiles.bootstrapMean95Percent, { low: null, high: null, samples: 0 });
+  assert.equal(gate.criteria.costVsFiles.observedDelta, null);
+  assert.equal(gate.criteria.fallbacksVsReleased.observedReductionPercent, null);
+});
+
+test("Hono hard gates require configured repetitions and first-Scope retrieval quality", () => {
+  const suite = loadSuite(SUITES.hono);
+  const rows = configuredGateRows(suite);
+  const passing = configuredReleaseGate(suite, rows);
+  assert.equal(suite.tasks.length, 6);
+  assert.equal(passing.status, "pass");
+  assert.deepEqual(passing.criteria.repetitions.observed, [1, 2, 3]);
+  assert.equal(passing.criteria.repetitions.expectedRuns, 54);
+  assert.equal(passing.criteria.candidateDistinctScopes.observedMaximum, 1);
+  assert.equal(passing.criteria.firstResponseFileHitAt5.observed, 1);
+  assert.equal(passing.criteria.firstResponseSourceSpanRecall.observed, 0.8);
+  assert.equal(passing.criteria.allRequiredFilesInFirstScope.requiredTasks, 6);
+  assert.equal(passing.criteria.allRequiredFilesInFirstScope.expectedSamples, 18);
+
+  const retrievalFailureRows = structuredClone(rows);
+  const candidates = retrievalFailureRows.filter((row) => row.arm === "candidate");
+  candidates[0].metrics.distinctScopeQueries = 2;
+  candidates[0].metrics.firstResponseSourceSpanRecall = 0;
+  candidates[0].metrics.firstResponseReturnedFiles = [];
+  candidates[1].metrics.firstResponseFileHitAt5 = false;
+  candidates[2].metrics.firstResponseFileHitAt5 = false;
+  const failing = configuredReleaseGate(suite, retrievalFailureRows);
+  assert.equal(failing.criteria.candidateDistinctScopes.passed, false);
+  assert.equal(failing.criteria.firstResponseFileHitAt5.observed, 0.8889);
+  assert.equal(failing.criteria.firstResponseFileHitAt5.passed, false);
+  assert.equal(failing.criteria.firstResponseSourceSpanRecall.passed, false);
+  assert.equal(failing.criteria.allRequiredFilesInFirstScope.passed, false);
+  assert.deepEqual(failing.criteria.allRequiredFilesInFirstScope.failures[0], {
+    taskId: suite.tasks[0].id,
+    repetition: 1,
+    missingFiles: [...new Set(suite.tasks[0].gold.map((entry) => entry.path))],
+  });
+  assert.equal(failing.status, "fail");
+});
+
+test("configured retrieval gates use stable insufficient-sample nulls", () => {
+  const suite = loadSuite(SUITES.hono);
+  const rows = configuredGateRows(suite);
+  rows.splice(rows.findIndex((row) => row.arm === "candidate"), 1);
+  const gate = configuredReleaseGate(suite, rows);
+  for (const name of [
+    "repetitions", "candidateDistinctScopes", "firstResponseFileHitAt5",
+    "firstResponseSourceSpanRecall", "allRequiredFilesInFirstScope",
+  ]) {
+    assert.equal(gate.criteria[name].status, "insufficient-sample", name);
+    assert.equal(gate.criteria[name].passed, null, name);
+  }
+  assert.equal(gate.status, "insufficient-sample");
+  assert.equal(gate.passed, null);
+});
+
+test("multi-suite release aggregation enforces MEX, Hono, and TypeScript repetition contracts", () => {
+  const suites = Object.values(SUITES).map(loadSuite);
+  const passingReport = (suite) => ({
+    suiteId: suite.id,
+    requiredRepetitions: suite.requiredRepetitions,
+    gate: {
+      status: "pass",
+      passed: true,
+      criteria: { repetitions: {
+        required: suite.requiredRepetitions,
+        observed: Array.from({ length: suite.requiredRepetitions }, (_, index) => index + 1),
+        passed: true,
+      } },
+    },
+  });
+  const entries = suites.map((suite) => ({ suite, report: passingReport(suite) }));
+  const passing = aggregateReleaseReports(entries);
+  assert.equal(passing.status, "pass");
+  assert.deepEqual(Object.fromEntries(Object.entries(passing.criteria).map(([id, criterion]) => [id, criterion.requiredRepetitions])), {
+    "mex-graph-agent-pilot": 3,
+    "hono-graph-agent-pilot": 3,
+    "typescript-pinned-pilot": 1,
+  });
+
+  const missing = aggregateReleaseReports(entries.map((entry, index) => index === 1 ? { suite: entry.suite, report: null } : entry));
+  assert.equal(missing.status, "insufficient-sample");
+  assert.deepEqual(missing.insufficient, ["hono-graph-agent-pilot"]);
+
+  const wrongCount = structuredClone(entries);
+  wrongCount[0].report.requiredRepetitions = 2;
+  const failing = aggregateReleaseReports(wrongCount);
+  assert.equal(failing.status, "fail");
+  assert.deepEqual(failing.failures, ["mex-graph-agent-pilot"]);
+
+  const incompleteMetadata = structuredClone(entries);
+  delete incompleteMetadata[2].report.gate.criteria.repetitions.observed;
+  const insufficient = aggregateReleaseReports(incompleteMetadata);
+  assert.equal(insufficient.status, "insufficient-sample");
+  assert.deepEqual(insufficient.insufficient, ["typescript-pinned-pilot"]);
+});
+
+test("report fails execution closed without a manifest while keeping role-oriented deltas descriptive", () => {
+  const output = mkdtempSync(join(tmpdir(), "mex-role-gate-"));
+  const suite = {
+    id: "role-gate",
+    arms: {
+      candidate: { kind: "graph", role: "patched" },
+      main: { kind: "graph", role: "released" },
+      files: { kind: "grep", role: "control" },
+    },
+    tasks: [{ id: "a" }, { id: "b" }],
+  };
+  const rows = gateRows().map((row, index) => ({
+    ...row,
+    runId: `run-${index}`,
+    grade: { correct: true },
+    answer: { complete: true },
+  }));
+  const report = generateReport({ suite, outputDir: output, rows });
+  assert.equal(report.executionValid, false);
+  assert.deepEqual([report.primaryPair.from, report.primaryPair.to], ["files", "candidate"]);
+  assert.deepEqual([report.releasedPair.from, report.releasedPair.to], ["main", "candidate"]);
+  assert.equal(report.gate.criteria.newTokensVsFiles.status, "pass");
+  assert.equal(report.gate.criteria.correctnessVsControls.status, "insufficient-sample");
+  assert.equal(report.gate.passed, null);
+  assert.equal(report.decision.releasedComparisonDescriptive, true);
+});
+
+test("report derives two-arm execution and candidate gate from the run manifest", () => {
+  const output = mkdtempSync(join(tmpdir(), "mex-two-arm-report-"));
+  const suite = {
+    id: "two-arm-report",
+    requiredRepetitions: 3,
+    arms: {
+      files: { kind: "grep", role: "control" },
+      main: { kind: "graph", role: "released" },
+      candidate: { kind: "graph", role: "patched" },
+    },
+    tasks: [{ id: "a" }, { id: "b" }],
+  };
+  const runIdentity = "two-arm-run";
+  const rows = gateRows().filter((row) => row.arm !== "main").map((row, index) => ({
+    ...row,
+    runIdentity,
+    runId: `run-${index}`,
+    repetition: 1,
+    grade: { correct: true },
+    answer: { answer: "x", symbols: ["x"], evidence: [], complete: true },
+  }));
+  const manifest = {
+    schemaVersion: 3,
+    runIdentity,
+    status: "complete",
+    selectedArmIds: ["files", "candidate"],
+    repetitions: 1,
+    schedule: rows.map((row) => ({ runId: row.runId, armId: row.arm })),
+  };
+  writeFileSync(join(output, "run-manifest.json"), JSON.stringify(manifest));
+  const report = generateReport({ suite, outputDir: output, rows });
+  assert.equal(report.executionValid, true);
+  assert.equal(report.runCount, 4);
+  assert.equal(report.expectedRunCount, 4);
+  assert.equal(report.requiredRepetitions, 3);
+  assert.equal(report.runRepetitions, 1);
+  assert.deepEqual(report.selectedArmIds, ["files", "candidate"]);
+  assert.deepEqual(Object.keys(report.byArm), ["files", "candidate"]);
+  assert.deepEqual([report.primaryPair.from, report.primaryPair.to], ["files", "candidate"]);
+  assert.equal(report.releasedPair, null);
+  assert.equal(report.gate.kind, "candidate-vs-files-gate");
+  assert.equal(report.gate.criteria.repetitions.required, 1);
+  assert.equal(report.gate.criteria.repetitions.expectedRuns, 4);
+  assert.equal(Object.hasOwn(report.gate.criteria, "fallbacksVsReleased"), false);
+  assert.deepEqual(Object.keys(report.finalCorrectness), ["files", "candidate"]);
+  assert.equal(report.decision.descriptivePilotOnly, true);
+  assert.equal(report.decision.releasedComparisonDescriptive, false);
+  for (const status of ["running", "aborted"]) {
+    writeFileSync(join(output, "run-manifest.json"), JSON.stringify({ ...manifest, status }));
+    assert.equal(generateReport({ suite, outputDir: output, rows }).executionValid, false, status);
+  }
+  writeFileSync(join(output, "run-manifest.json"), JSON.stringify(manifest));
+  assert.throws(() => generateReport({
+    suite, outputDir: output, rows, selectedArmIds: ["files", "main", "candidate"],
+  }), /does not match the run manifest/);
 });
 
 test("fake agent exercises success, failure, and timeout without model usage", { concurrency: false }, async () => {
@@ -95,6 +712,122 @@ test("fake agent exercises success, failure, and timeout without model usage", {
   }
 });
 
+test("Claude classifies rejected 429 limits as retryable without misclassifying warnings or schema errors", { concurrency: false }, async () => {
+  const task = { id: "fake", question: "Where?", expectedSymbols: ["FakeSymbol"] };
+  const originalMode = process.env.FAKE_CLAUDE_MODE;
+  const originalQuestion = process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+  try {
+    delete process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+    process.env.FAKE_CLAUDE_MODE = "allowed-warning";
+    const warning = await runSession({
+      agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+      armId: "grep", arm: ARMS.grep, armCommands: COMMANDS, timeoutMs: 2_000,
+    });
+    assert.equal(warning.valid, true);
+    assert.equal(warning.providerFailure, null);
+    assert.match(warning.transcript, /"status":"allowed_warning"/);
+
+    process.env.FAKE_CLAUDE_MODE = "schema-invalid";
+    const schemaInvalid = await runSession({
+      agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+      armId: "grep", arm: ARMS.grep, armCommands: COMMANDS, timeoutMs: 2_000,
+    });
+    assert.equal(schemaInvalid.valid, false);
+    assert.equal(schemaInvalid.providerFailure, null);
+    assert.match(schemaInvalid.violations.join("\n"), /answer must be a substantive string/);
+
+    process.env.FAKE_CLAUDE_MODE = "rate-limit";
+    const rejected = await runSession({
+      agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+      armId: "grep", arm: ARMS.grep, armCommands: COMMANDS, timeoutMs: 2_000,
+    });
+    assert.equal(rejected.valid, false);
+    assert.deepEqual(rejected.providerFailure, {
+      provider: "claude",
+      type: "rate_limit",
+      retryable: true,
+      rateLimitStatus: "rejected",
+      rateLimitType: "five_hour",
+      resetsAt: 1_787_160_600,
+      apiErrorStatus: 429,
+      terminalReason: "api_error",
+    });
+    assert.match(rejected.violations.join("\n"), /retryable claude provider rate_limit/);
+  } finally {
+    if (originalMode === undefined) delete process.env.FAKE_CLAUDE_MODE;
+    else process.env.FAKE_CLAUDE_MODE = originalMode;
+    if (originalQuestion === undefined) delete process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+    else process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION = originalQuestion;
+  }
+});
+
+test("runSession installs the isolated fail-closed Claude Bash guard", { concurrency: false }, async () => {
+  const task = { id: "fake", question: "Where?", expectedSymbols: ["FakeSymbol"] };
+  const original = process.env.FAKE_CLAUDE_MODE;
+  try {
+    process.env.FAKE_CLAUDE_MODE = "permission-config";
+    const result = await runSession({
+      agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+      armId: "patched", arm: ARMS.patched, armCommands: COMMANDS, timeoutMs: 2_000,
+    });
+    assert.equal(result.process.code, 0, result.process.stderr);
+    assert.equal(result.valid, true);
+    assert.equal(result.guardPreflight.valid, true);
+    assert.deepEqual(result.guardPreflight.probes, { allow: true, deny: true, malformed: true });
+    assert.equal(result.metrics.bashGuardLifecycle.valid, true);
+    assert.equal(result.metrics.bashGuardLifecycle.bashCalls, 1);
+    assert.equal(result.metrics.bashGuardLifecycle.complete, 1);
+    const lifecycle = result.transcript.split("\n").filter(Boolean).map((line) => JSON.parse(line))
+      .filter((event) => event.type === "system" && event.subtype.startsWith("hook_"));
+    assert.equal(lifecycle.length, 2);
+    assert.equal(lifecycle.every((event) => event.hook_name === "PreToolUse:Bash"), true);
+  } finally {
+    if (original === undefined) delete process.env.FAKE_CLAUDE_MODE; else process.env.FAKE_CLAUDE_MODE = original;
+  }
+});
+
+test("Claude sessions reject missing or failed Bash guard lifecycle evidence", { concurrency: false }, async () => {
+  const task = { id: "fake", question: "Where?", expectedSymbols: ["FakeSymbol"] };
+  const original = process.env.FAKE_CLAUDE_MODE;
+  try {
+    for (const mode of ["missing-hook-events", "guard-hook-error"]) {
+      process.env.FAKE_CLAUDE_MODE = mode;
+      const result = await runSession({
+        agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+        armId: "patched", arm: ARMS.patched, armCommands: COMMANDS, timeoutMs: 2_000,
+      });
+      assert.equal(result.valid, false, mode);
+      assert.equal(result.metrics.bashGuardLifecycle.valid, false, mode);
+      assert.match(result.violations.join("\n"), /Claude Bash guard lifecycle/, mode);
+    }
+  } finally {
+    if (original === undefined) delete process.env.FAKE_CLAUDE_MODE; else process.env.FAKE_CLAUDE_MODE = original;
+  }
+});
+
+test("a denied file-shell attempt can fall back to Read without invalidating the run", { concurrency: false }, async () => {
+  const task = { id: "fake", question: "Where?", expectedSymbols: ["FakeSymbol"] };
+  const original = process.env.FAKE_CLAUDE_MODE;
+  try {
+    process.env.FAKE_CLAUDE_MODE = "denied-file-shell";
+    const result = await runSession({
+      agentCommand: [process.execPath, FAKE], subjectRoot: tmpdir(), model: "fake", task,
+      armId: "patched", arm: ARMS.patched, armCommands: COMMANDS, timeoutMs: 2_000,
+    });
+    assert.equal(result.valid, true);
+    assert.equal(result.grade.correct, true);
+    assert.equal(result.metrics.permissionDenials, 1);
+    assert.equal(result.metrics.deniedFileShellAttempts, 1);
+    assert.equal(result.metrics.unexplainedPermissionDenials, 0);
+    assert.equal(result.metrics.fallbacks, 1);
+    const denied = JSON.parse(result.transcript.split("\n")
+      .find((line) => line.includes("tool-denied-file-shell") && line.includes("tool_use")));
+    assert.match(denied.message.content[0].input.command, /^cd \/repo && grep .* \| head/);
+  } finally {
+    if (original === undefined) delete process.env.FAKE_CLAUDE_MODE; else process.env.FAKE_CLAUDE_MODE = original;
+  }
+});
+
 test("fake Codex adapter runs headlessly with cached-token accounting", { concurrency: false }, async () => {
   const task = { id: "fake", question: "Where?", expectedSymbols: ["FakeSymbol"] };
   const result = await runSession({
@@ -110,7 +843,7 @@ test("fake Codex adapter runs headlessly with cached-token accounting", { concur
 test("stale manual review files cannot attach to a different run", () => {
   const output = mkdtempSync(join(tmpdir(), "mex-review-output-"));
   const suite = { id: "review", arms: ARMS, tasks: [{ id: "task" }] };
-  const baseMetrics = { newTokens: 1, uncachedInput: 1, cacheWrite: 0, cacheRead: 1, output: 0, reportedTotal: 2, costUsd: 0, uniqueToolResultChars: 0, uniqueToolResultTokens: 0, elapsedMs: 1, turns: 1, toolCalls: 1, graphCalls: 1, scopeCalls: 1, distinctScopeQueries: 1, vocabularyRetries: 0, fallbacks: 0, cacheUseRatio: 0.5, expectedSymbolInitialScopeRank: 1 };
+  const baseMetrics = { newTokens: 1, uncachedInput: 1, cacheWrite: 0, cacheRead: 1, output: 0, reportedTotal: 2, costUsd: 0, uniqueToolResultChars: 0, uniqueToolResultTokens: 0, elapsedMs: 1, turns: 1, toolCalls: 1, graphCalls: 1, scopeCalls: 1, distinctScopeQueries: 1, fallbacks: 0, cacheUseRatio: 0.5, expectedSymbolInitialScopeRank: 1 };
   const rows = Object.keys(ARMS).map((arm) => ({ runIdentity: "run-1", runId: `task-${arm}`, taskId: "task", repetition: 1, arm, valid: true, metrics: baseMetrics, answer: { answer: "x", symbols: ["x"], evidence: [], complete: true }, grade: { correct: true } }));
   writeFileSync(join(output, "run-manifest.json"), JSON.stringify({ runIdentity: "run-1", schedule: rows.map((row) => ({ runId: row.runId })) }));
   generateReport({ suite, outputDir: output, rows });
@@ -123,6 +856,253 @@ test("stale manual review files cannot attach to a different run", () => {
   assert.equal(report.manuallyScored, false);
 });
 
+test("two-arm runs persist selection in their identity and manifest", { concurrency: false }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-two-arm-root-"));
+  const output = mkdtempSync(join(tmpdir(), "mex-two-arm-output-"));
+  mkdirSync(join(root, ".mex"), { recursive: true });
+  const patchedIndex = join(output, "patched.db");
+  writeFileSync(patchedIndex, "fake-patched");
+  writeFileSync(join(output, "prepare.json"), JSON.stringify({
+    selectedArmIds: ["grep", "patched"],
+    indices: { patched: { path: patchedIndex } },
+  }));
+  const suite = {
+    id: "two-arm-run",
+    requiredRepetitions: 1,
+    arms: ARMS,
+    tasks: [{ id: "task", question: "Where?", expectedSymbols: ["FakeSymbol"] }],
+  };
+  const result = await runEvaluation({
+    suite,
+    subjectRoot: root,
+    outputDir: output,
+    armCommands: COMMANDS,
+    model: "fake",
+    timeoutMs: 2_000,
+    agentCommand: [process.execPath, FAKE],
+    selectedArmIds: ["grep", "patched"],
+  });
+  assert.equal(result.rows.length, 2);
+  assert.deepEqual([...new Set(result.rows.map((row) => row.arm))].sort(), ["grep", "patched"]);
+  assert.deepEqual(result.manifest.selectedArmIds, ["grep", "patched"]);
+  assert.equal(result.manifest.schedule.length, 2);
+  assert.equal(result.manifest.schedule.some((row) => row.armId === "baseline"), false);
+  assert.ok(result.manifest.runIdentity);
+});
+
+test("compare run preflight accepts a PATH-resolved Node launcher prepared with the same command", { concurrency: false }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-path-node-root-"));
+  const output = mkdtempSync(join(tmpdir(), "mex-path-node-output-"));
+  const bundle = mkdtempSync(join(tmpdir(), "mex-path-node-cli-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "fake.ts"), "export function FakeSymbol() {}\n");
+  for (const args of [["init", "-q"], ["config", "user.email", "eval@example.invalid"], ["config", "user.name", "Eval Test"], ["add", "src/fake.ts"], ["commit", "-qm", "fixture"]]) {
+    const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+  }
+  const graphCli = join(bundle, "fake-graph.mjs");
+  writeFileSync(graphCli, 'import { mkdirSync, writeFileSync } from "node:fs"; mkdirSync(".mex", { recursive: true }); writeFileSync(".mex/graph.db", "patched"); console.log("{}");\n');
+  const armCommands = { patched: ["node", graphCli] };
+  const suite = {
+    id: "path-node-run",
+    requiredRepetitions: 1,
+    subject: { name: "fixture" },
+    arms: ARMS,
+    tasks: [{ id: "task", question: "Where?", expectedSymbols: ["FakeSymbol"] }],
+  };
+  const selectedArmIds = ["grep", "patched"];
+  prepareEvaluation({
+    suite,
+    subjectRoot: root,
+    harnessRoot: resolve(HERE, "..", "..", ".."),
+    armCommands,
+    outputDir: output,
+    selectedArmIds,
+  });
+
+  const result = await runEvaluation({
+    suite,
+    subjectRoot: root,
+    outputDir: output,
+    armCommands,
+    model: "fake",
+    timeoutMs: 2_000,
+    agentCommand: [process.execPath, FAKE],
+    selectedArmIds,
+  });
+  assert.equal(result.manifest.status, "complete");
+  assert.equal(result.rows.length, 2);
+  assert.equal(result.rows.every((row) => row.valid), true);
+});
+
+test("compare schedules abort before persisting rows when source or CLI identity drifts", { concurrency: false }, async () => {
+  const previousPath = process.env.FAKE_CLAUDE_DRIFT_PATH;
+  const previousQuestion = process.env.FAKE_CLAUDE_DRIFT_QUESTION;
+  try {
+    for (const scenario of ["subject", "bundle"]) {
+      const root = mkdtempSync(join(tmpdir(), `mex-compare-${scenario}-drift-root-`));
+      const output = mkdtempSync(join(tmpdir(), `mex-compare-${scenario}-drift-output-`));
+      const bundle = mkdtempSync(join(tmpdir(), `mex-compare-${scenario}-drift-cli-`));
+      try {
+        mkdirSync(join(root, "src"), { recursive: true });
+        writeFileSync(join(root, "src", "fake.ts"), "export function FakeSymbol() {}\n");
+        for (const args of [["init", "-q"], ["config", "user.email", "eval@example.invalid"], ["config", "user.name", "Eval Test"], ["add", "src/fake.ts"], ["commit", "-qm", "fixture"]]) {
+          const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+          assert.equal(result.status, 0, result.stderr);
+        }
+        mkdirSync(join(root, ".mex"), { recursive: true });
+        writeFileSync(join(root, ".mex", "graph.db"), "original-graph");
+
+        const graphCli = join(bundle, "fake-graph.mjs");
+        writeFileSync(graphCli, [
+          'import { mkdirSync, writeFileSync } from "node:fs";',
+          'mkdirSync(".mex", { recursive: true });',
+          'writeFileSync(".mex/graph.db", "candidate-graph");',
+          'console.log("{}");',
+        ].join("\n"));
+        const armCommands = { patched: [process.execPath, graphCli] };
+        const suite = {
+          id: `compare-${scenario}-drift`,
+          requiredRepetitions: 1,
+          subject: { name: "fixture" },
+          arms: ARMS,
+          tasks: [
+            { id: "stable", question: "Stable question", expectedSymbols: ["FakeSymbol"] },
+            { id: "drift", question: "Trigger comparison drift", expectedSymbols: ["FakeSymbol"] },
+          ],
+        };
+        const selectedArmIds = ["grep", "patched"];
+        prepareEvaluation({
+          suite,
+          subjectRoot: root,
+          harnessRoot: root,
+          armCommands,
+          outputDir: output,
+          selectedArmIds,
+        });
+
+        process.env.FAKE_CLAUDE_DRIFT_QUESTION = "Trigger comparison drift";
+        process.env.FAKE_CLAUDE_DRIFT_PATH = scenario === "subject"
+          ? join(root, "src", "fake.ts")
+          : join(bundle, "drift-marker.txt");
+        await assert.rejects(
+          runEvaluation({
+            suite,
+            subjectRoot: root,
+            outputDir: output,
+            armCommands,
+            model: "fake",
+            timeoutMs: 2_000,
+            agentCommand: [process.execPath, FAKE],
+            selectedArmIds,
+          }),
+          scenario === "subject"
+            ? /identity drift after 02-drift-patched: subject repository no longer matches/
+            : /identity drift after 02-drift-patched: CLI bundle changed after prepare for patched/,
+        );
+
+        const manifest = JSON.parse(readFileSync(join(output, "run-manifest.json"), "utf8"));
+        assert.equal(manifest.status, "aborted");
+        assert.equal(manifest.failedRunId, "02-drift-patched");
+        assert.equal(manifest.resultCount, 2);
+        assert.match(manifest.error, scenario === "subject" ? /subject repository/ : /CLI bundle changed/);
+        assert.equal(existsSync(join(output, "runs", "01-stable-grep.json")), true);
+        assert.equal(existsSync(join(output, "runs", "01-stable-patched.json")), true);
+        assert.equal(existsSync(join(output, "transcripts", "02-drift-patched.jsonl")), true);
+        assert.equal(existsSync(join(output, "runs", "02-drift-patched.json")), false);
+        assert.equal(readFileSync(join(root, ".mex", "graph.db"), "utf8"), "original-graph");
+        assert.equal(generateReport({ suite, outputDir: output }).executionValid, false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+        rmSync(output, { recursive: true, force: true });
+        rmSync(bundle, { recursive: true, force: true });
+      }
+    }
+  } finally {
+    if (previousPath === undefined) delete process.env.FAKE_CLAUDE_DRIFT_PATH;
+    else process.env.FAKE_CLAUDE_DRIFT_PATH = previousPath;
+    if (previousQuestion === undefined) delete process.env.FAKE_CLAUDE_DRIFT_QUESTION;
+    else process.env.FAKE_CLAUDE_DRIFT_QUESTION = previousQuestion;
+  }
+});
+
+test("compare aborts on a provider rate limit without a failed row and resume retries missing work", { concurrency: false }, async () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-compare-rate-limit-root-"));
+  const output = mkdtempSync(join(tmpdir(), "mex-compare-rate-limit-output-"));
+  const originalMode = process.env.FAKE_CLAUDE_MODE;
+  const originalQuestion = process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+  try {
+    mkdirSync(join(root, ".mex"), { recursive: true });
+    writeFileSync(join(root, ".mex", "graph.db"), "original-graph");
+    const patchedIndex = join(output, "patched.db");
+    writeFileSync(patchedIndex, "fake-patched");
+    writeFileSync(join(output, "prepare.json"), JSON.stringify({
+      selectedArmIds: ["grep", "patched"],
+      indices: { patched: { path: patchedIndex } },
+    }));
+    const suite = {
+      id: "rate-limit-resume",
+      requiredRepetitions: 1,
+      arms: ARMS,
+      tasks: [
+        { id: "stable", question: "Stable question", expectedSymbols: ["FakeSymbol"] },
+        { id: "limited", question: "Trigger rate limit", expectedSymbols: ["FakeSymbol"] },
+      ],
+    };
+    const options = {
+      suite,
+      subjectRoot: root,
+      outputDir: output,
+      armCommands: COMMANDS,
+      model: "fake",
+      timeoutMs: 2_000,
+      agentCommand: [process.execPath, FAKE],
+      selectedArmIds: ["grep", "patched"],
+    };
+
+    process.env.FAKE_CLAUDE_MODE = "rate-limit";
+    process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION = "Trigger rate limit";
+    await assert.rejects(runEvaluation(options), /retryable claude provider rate limit \(429\)/);
+
+    const manifest = JSON.parse(readFileSync(join(output, "run-manifest.json"), "utf8"));
+    assert.equal(manifest.status, "aborted");
+    assert.equal(manifest.failedRunId, "02-limited-patched");
+    assert.equal(manifest.resultCount, 2);
+    assert.match(manifest.error, /resume after the provider limit resets/);
+    const priorPaths = [
+      join(output, "runs", "01-stable-grep.json"),
+      join(output, "runs", "01-stable-patched.json"),
+    ];
+    assert.equal(priorPaths.every(existsSync), true);
+    const priorRows = priorPaths.map((path) => readFileSync(path, "utf8"));
+    assert.equal(priorRows.every((row) => JSON.parse(row).valid), true);
+    const failedTranscript = join(output, "transcripts", "02-limited-patched.jsonl");
+    assert.equal(existsSync(failedTranscript), true);
+    assert.match(readFileSync(failedTranscript, "utf8"), /"status":"rejected"/);
+    assert.match(readFileSync(failedTranscript, "utf8"), /"api_error_status":429/);
+    assert.equal(existsSync(join(output, "runs", "02-limited-patched.json")), false);
+    assert.equal(existsSync(join(output, "runs", "02-limited-grep.json")), false);
+    assert.equal(readFileSync(join(root, ".mex", "graph.db"), "utf8"), "original-graph");
+
+    delete process.env.FAKE_CLAUDE_MODE;
+    delete process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+    const resumed = await runEvaluation({ ...options, resume: true });
+    assert.equal(resumed.manifest.status, "complete");
+    assert.equal(resumed.rows.length, 4);
+    assert.equal(resumed.rows.every((row) => row.valid), true);
+    assert.deepEqual(priorPaths.map((path) => readFileSync(path, "utf8")), priorRows);
+    assert.equal(existsSync(join(output, "runs", "02-limited-patched.json")), true);
+    assert.equal(existsSync(join(output, "runs", "02-limited-grep.json")), true);
+  } finally {
+    if (originalMode === undefined) delete process.env.FAKE_CLAUDE_MODE;
+    else process.env.FAKE_CLAUDE_MODE = originalMode;
+    if (originalQuestion === undefined) delete process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION;
+    else process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION = originalQuestion;
+    rmSync(root, { recursive: true, force: true });
+    rmSync(output, { recursive: true, force: true });
+  }
+});
+
 test("resume skips completed run IDs", { concurrency: false }, async () => {
   const root = mkdtempSync(join(tmpdir(), "mex-compare-root-"));
   const output = mkdtempSync(join(tmpdir(), "mex-compare-output-"));
@@ -132,9 +1112,10 @@ test("resume skips completed run IDs", { concurrency: false }, async () => {
     const path = join(output, `${armId}.db`); writeFileSync(path, `fake-${armId}`); indices[armId] = { path };
   }
   writeFileSync(join(output, "prepare.json"), JSON.stringify({ indices }));
-  const suite = { id: "fake", arms: ARMS, tasks: [{ id: "task", question: "Where?", expectedSymbols: ["FakeSymbol"] }] };
+  const suite = { id: "fake", requiredRepetitions: 2, arms: ARMS, tasks: [{ id: "task", question: "Where?", expectedSymbols: ["FakeSymbol"] }] };
   const first = await runEvaluation({ suite, subjectRoot: root, outputDir: output, armCommands: COMMANDS, model: "fake", timeoutMs: 2_000, agentCommand: [process.execPath, FAKE] });
-  assert.equal(first.rows.length, 3);
+  assert.equal(first.rows.length, 6);
+  assert.deepEqual([...new Set(first.rows.map((row) => row.repetition))], [1, 2]);
   process.env.FAKE_CLAUDE_MODE = "failure";
   try {
     const resumed = await runEvaluation({ suite, subjectRoot: root, outputDir: output, armCommands: COMMANDS, model: "fake", timeoutMs: 2_000, resume: true, agentCommand: [process.execPath, FAKE] });
@@ -164,4 +1145,19 @@ test("prepare verifies gold evidence, snapshots both graph indices, and restores
   assert.equal(readFileSync(manifest.indices.patched.path, "utf8"), "patched");
   assert.equal(manifest.goldEvidence[0].symbols[0].path, "src/fake.ts");
   assert.equal(manifest.goldEvidence[0].symbols[0].line, 1);
+
+  const twoArmOutput = mkdtempSync(join(tmpdir(), "mex-compare-prepare-two-arm-"));
+  const twoArm = prepareEvaluation({
+    suite,
+    subjectRoot: root,
+    harnessRoot,
+    armCommands,
+    outputDir: twoArmOutput,
+    selectedArmIds: ["grep", "patched"],
+  });
+  assert.deepEqual(twoArm.selectedArmIds, ["grep", "patched"]);
+  assert.deepEqual(Object.keys(twoArm.cli), ["patched"]);
+  assert.deepEqual(Object.keys(twoArm.indices), ["patched"]);
+  assert.deepEqual(Object.keys(twoArm.graphCoverage), ["grep", "patched"]);
+  assert.equal(readFileSync(join(root, ".mex", "graph.db"), "utf8"), "original");
 });

--- a/evaluate/compare/test/fixtures/fake-claude.mjs
+++ b/evaluate/compare/test/fixtures/fake-claude.mjs
@@ -1,18 +1,126 @@
+import { appendFileSync, readFileSync } from "node:fs";
+
 const mode = process.env.FAKE_CLAUDE_MODE ?? "ok";
 if (mode === "timeout") setTimeout(() => {}, 60_000);
 else if (mode === "failure") { process.stderr.write("fake failure\n"); process.exit(7); }
 else {
+  const valueAfter = (flag) => process.argv[process.argv.indexOf(flag) + 1];
+  const settingsPath = valueAfter("--settings");
+  const settings = settingsPath ? JSON.parse(readFileSync(settingsPath, "utf8")) : null;
+  const hook = settings?.hooks?.PreToolUse?.[0];
+  const hookCommand = hook?.hooks?.[0];
+  const emit = (event) => process.stdout.write(`${JSON.stringify(event)}\n`);
+  const emitGuardLifecycle = (toolId) => {
+    if (mode === "missing-hook-events") return;
+    const hookId = `hook-${toolId}`;
+    const common = {
+      type: "system",
+      hook_id: hookId,
+      hook_name: "PreToolUse:Bash",
+      hook_event: "PreToolUse",
+    };
+    emit({ ...common, subtype: "hook_started" });
+    emit({
+      ...common,
+      subtype: "hook_response",
+      output: mode === "guard-hook-error" ? "guard failed" : "{}\n",
+      stdout: mode === "guard-hook-error" ? "" : "{}\n",
+      stderr: mode === "guard-hook-error" ? "guard failed" : "",
+      exit_code: mode === "guard-hook-error" ? 2 : 0,
+      outcome: mode === "guard-hook-error" ? "error" : "success",
+    });
+  };
+  if (mode === "permission-config") {
+    const allowedIndex = process.argv.indexOf("--allowedTools");
+    const allowed = process.argv.slice(allowedIndex + 1).filter((value) => !value.startsWith("--"));
+    const valid = valueAfter("--permission-mode") === "dontAsk"
+      && valueAfter("--setting-sources") === ""
+      && valueAfter("--tools") === "Read,Grep,Glob,Bash"
+      && process.argv.includes("--strict-mcp-config")
+      && process.argv.includes("--no-chrome")
+      && process.argv.includes("--disable-slash-commands")
+      && process.argv.includes("--include-hook-events")
+      && !process.argv.includes("--safe-mode")
+      && allowed.includes("Read") && allowed.includes("Grep") && allowed.includes("Glob")
+      && ["graph scope *", "graph query *", "graph get *", "impact *"]
+        .every((suffix) => allowed.some((value) => value.startsWith("Bash(") && value.includes(suffix)))
+      && !allowed.includes("Bash")
+      && hook?.matcher === "Bash"
+      && hookCommand?.type === "command"
+      && hookCommand.command === "/bin/sh"
+      && Array.isArray(hookCommand.args)
+      && hookCommand.args[0] === "-c"
+      && hookCommand.args.some((value) => value.endsWith("/bash-guard.mjs"))
+      && hookCommand.args.some((value) => value.endsWith("/bash-guard.json"))
+      && hookCommand.statusMessage === "MEX eval Bash policy guard";
+    if (!valid) { process.stderr.write("unsafe Claude permission configuration\n"); process.exit(8); }
+  }
   const promptIndex = process.argv.indexOf("-p");
   const prompt = process.argv[promptIndex + 1] ?? "";
-  const graphPrefix = prompt.match(/Start with `(.+?) graph scope/);
-  const toolId = "tool-1";
-  if (graphPrefix) {
-    const command = `${graphPrefix[1]} graph scope "fake question"`;
-    process.stdout.write(`${JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: toolId, name: "Bash", input: { command } }] } })}\n`);
-    process.stdout.write(`${JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolId, content: '{"type":"fact","name":"FakeSymbol"}\n' }] } })}\n`);
-  } else {
-    process.stdout.write(`${JSON.stringify({ type: "assistant", message: { usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: toolId, name: "Grep", input: { pattern: "FakeSymbol" } }] } })}\n`);
-    process.stdout.write(`${JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolId, content: "src/fake.ts:1:function FakeSymbol() {}" }] } })}\n`);
+  if (process.env.FAKE_CLAUDE_DRIFT_PATH
+    && (!process.env.FAKE_CLAUDE_DRIFT_QUESTION
+      || prompt.includes(`Question: ${process.env.FAKE_CLAUDE_DRIFT_QUESTION}`))) {
+    appendFileSync(process.env.FAKE_CLAUDE_DRIFT_PATH, "\n// concurrent comparison drift\n");
   }
-  process.stdout.write(`${JSON.stringify({ type: "result", structured_output: { answer: "FakeSymbol does it.", symbols: ["FakeSymbol"], evidence: [{ path: "src/fake.ts", line: 1 }], complete: true }, total_cost_usd: 0.001, num_turns: 1, permission_denials: [] })}\n`);
+  const rateLimitApplies = ["allowed-warning", "rate-limit"].includes(mode)
+    && (!process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION
+      || prompt.includes(`Question: ${process.env.FAKE_CLAUDE_RATE_LIMIT_QUESTION}`));
+  if (rateLimitApplies) {
+    emit({
+      type: "rate_limit_event",
+      rate_limit_info: mode === "rate-limit"
+        ? { status: "rejected", resetsAt: 1_787_160_600, rateLimitType: "five_hour", overageStatus: "rejected" }
+        : { status: "allowed_warning", resetsAt: 1_787_160_600, rateLimitType: "five_hour", utilization: 0.94 },
+    });
+  }
+  if (rateLimitApplies && mode === "rate-limit") {
+    emit({
+      type: "assistant",
+      error: "rate_limit",
+      is_api_error_message: true,
+      message: {
+        id: "assistant-rate-limit",
+        usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 },
+        content: [{ type: "text", text: "You've hit your session limit" }],
+      },
+    });
+    emit({
+      type: "result",
+      subtype: "success",
+      is_error: true,
+      terminal_reason: "api_error",
+      api_error_status: 429,
+      result: "You've hit your session limit",
+      usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 },
+      total_cost_usd: 0,
+      num_turns: 1,
+      permission_denials: [],
+    });
+  } else {
+    const graphPrefix = prompt.match(/Start with `(.+?) graph scope/);
+    const toolId = "tool-1";
+    const permissionDenials = [];
+    if (graphPrefix) {
+      const command = `${graphPrefix[1]} graph scope "fake question"`;
+      emit({ type: "assistant", message: { id: "assistant-1", usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: toolId, name: "Bash", input: { command } }] } });
+      emitGuardLifecycle(toolId);
+      emit({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolId, content: '{"type":"meta","command":"graph scope"}\n{"type":"fact","id":"fake","name":"FakeSymbol","filePath":"src/fake.ts","startLine":1,"endLine":1}\n{"type":"source","filePath":"src/fake.ts","ranges":[{"startLine":1,"endLine":1,"content":"function FakeSymbol() {}"}]}\n{"type":"summary","status":"ok"}\n' }] } });
+      if (mode === "denied-file-shell") {
+        const deniedId = "tool-denied-file-shell";
+        const readId = "tool-read";
+        emit({ type: "assistant", message: { id: "assistant-2", usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 }, content: [{ type: "tool_use", id: deniedId, name: "Bash", input: { command: "cd /repo && grep -R FakeSymbol src | head -20" } }] } });
+        emitGuardLifecycle(deniedId);
+        emit({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: deniedId, content: "MEX_EVAL_BASH_DENIED: only the exact graph wrapper is allowed", is_error: true }] } });
+        emit({ type: "assistant", message: { id: "assistant-3", usage: { input_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, output_tokens: 0 }, content: [{ type: "tool_use", id: readId, name: "Read", input: { file_path: "/repo/src/fake.ts" } }] } });
+        emit({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: readId, content: "function FakeSymbol() {}" }] } });
+      }
+    } else {
+      emit({ type: "assistant", message: { id: "assistant-1", usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: toolId, name: "Grep", input: { pattern: "FakeSymbol" } }] } });
+      emit({ type: "user", message: { content: [{ type: "tool_result", tool_use_id: toolId, content: "src/fake.ts:1:function FakeSymbol() {}" }] } });
+    }
+    const structuredOutput = mode === "schema-invalid"
+      ? { answer: "test", symbols: ["FakeSymbol"], evidence: [{ path: "src/fake.ts", line: 1 }], complete: true }
+      : { answer: "FakeSymbol is declared in the cited source and implements the requested behavior.", symbols: ["FakeSymbol"], evidence: [{ path: "src/fake.ts", line: 1 }], complete: true };
+    emit({ type: "result", structured_output: structuredOutput, usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, total_cost_usd: 0.001, num_turns: 1, permission_denials: permissionDenials });
+  }
 }

--- a/evaluate/compare/test/fixtures/fake-codex.mjs
+++ b/evaluate/compare/test/fixtures/fake-codex.mjs
@@ -1,10 +1,10 @@
 const prompt = process.argv.at(-1) ?? "";
 const graphPrefix = prompt.match(/Start with `(.+?) graph scope/);
-const answer = { answer: "FakeSymbol does it.", symbols: ["FakeSymbol"], evidence: [{ path: "a", line: 1 }], complete: true };
+const answer = { answer: "FakeSymbol is declared in the cited source and implements the requested behavior.", symbols: ["FakeSymbol"], evidence: [{ path: "a", line: 1 }], complete: true };
 process.stdout.write(`${JSON.stringify({ type: "thread.started", thread_id: "fake" })}\n`);
 process.stdout.write(`${JSON.stringify({ type: "turn.started" })}\n`);
 const command = graphPrefix ? `${graphPrefix[1]} graph scope "fake question"` : "rg FakeSymbol .";
 process.stdout.write(`${JSON.stringify({ type: "item.started", item: { id: "c1", type: "command_execution", command, status: "in_progress" } })}\n`);
-process.stdout.write(`${JSON.stringify({ type: "item.completed", item: { id: "c1", type: "command_execution", command, aggregated_output: graphPrefix ? '{"type":"fact","name":"FakeSymbol"}\n' : "a:1:FakeSymbol", exit_code: 0, status: "completed" } })}\n`);
+process.stdout.write(`${JSON.stringify({ type: "item.completed", item: { id: "c1", type: "command_execution", command, aggregated_output: graphPrefix ? '{"type":"fact","name":"FakeSymbol"}\n{"type":"summary","status":"ok"}\n' : "a:1:FakeSymbol", exit_code: 0, status: "completed" } })}\n`);
 process.stdout.write(`${JSON.stringify({ type: "item.completed", item: { id: "a1", type: "agent_message", text: JSON.stringify(answer) } })}\n`);
 process.stdout.write(`${JSON.stringify({ type: "turn.completed", usage: { input_tokens: 100, cached_input_tokens: 60, output_tokens: 10, reasoning_output_tokens: 4 } })}\n`);

--- a/evaluate/core/artifacts.mjs
+++ b/evaluate/core/artifacts.mjs
@@ -112,3 +112,9 @@ export class GraphDbGuard {
     });
   }
 }
+
+/** Remove recovery scratch only after the guarded graph has been restored. */
+export function restoreGraphDbAndRemoveScratch(guard, scratchRoot) {
+  guard.restore();
+  rmSync(scratchRoot, { recursive: true, force: true });
+}

--- a/evaluate/core/evidence.mjs
+++ b/evaluate/core/evidence.mjs
@@ -1,0 +1,38 @@
+export function normalizeRepoPath(path) {
+  return typeof path === "string" ? path.replace(/^\.\//, "").replaceAll("\\", "/") : null;
+}
+
+export function evidenceSpan(value) {
+  const startLine = Number(value?.startLine ?? value?.lineStart ?? value?.line);
+  const endLine = Number(value?.endLine ?? value?.lineEnd ?? value?.line);
+  return Number.isInteger(startLine) && startLine > 0 && Number.isInteger(endLine) && endLine >= startLine
+    ? { startLine, endLine }
+    : null;
+}
+
+export function evidenceSymbol(value) {
+  return typeof value?.name === "string" ? value.name : typeof value?.symbol === "string" ? value.symbol : null;
+}
+
+export function evidencePath(value) {
+  return normalizeRepoPath(value?.filePath ?? value?.path ?? value?.file);
+}
+
+/** Node kind is intentionally advisory; source identity is path + symbol + span. */
+export function evidenceMatchesRecord(evidence, record) {
+  if (evidenceSymbol(evidence) !== evidenceSymbol(record) || evidencePath(evidence) !== evidencePath(record)) return false;
+  const expected = evidenceSpan(evidence);
+  const actual = evidenceSpan(record);
+  if (!expected) return true;
+  if (!actual) return false;
+  return actual.startLine <= expected.endLine && actual.endLine >= expected.startLine;
+}
+
+export function evidenceIdentity(evidence) {
+  const span = evidenceSpan(evidence);
+  return `${evidencePath(evidence)}\0${evidenceSymbol(evidence)}\0${span?.startLine ?? ""}:${span?.endLine ?? ""}`;
+}
+
+export function uniqueRequiredPaths(gold) {
+  return [...new Set((gold ?? []).map(evidencePath).filter(Boolean))];
+}

--- a/evaluate/core/hash.mjs
+++ b/evaluate/core/hash.mjs
@@ -56,9 +56,19 @@ function git(root, args, optional = false) {
   return result.code === 0 ? String(result.stdout).trim() : null;
 }
 
+const GRAPH_DB_PATHS = [".mex/graph.db", ".mex/graph.db-shm", ".mex/graph.db-wal"];
+
+function graphDbExclusionPathspecs() {
+  return GRAPH_DB_PATHS.map((path) => `:(exclude)${path}`);
+}
+
 export function gitTreeStateHash(root) {
-  const tracked = git(root, ["diff", "--binary", "HEAD"], true) ?? "";
-  const untracked = (git(root, ["ls-files", "--others", "--exclude-standard"], true) ?? "")
+  // GraphDbGuard intentionally swaps and opens these generated files while an
+  // evaluation is running. They are execution artifacts, not subject source,
+  // even when the target repository does not ignore `.mex/` itself.
+  const pathspec = ["--", ".", ...graphDbExclusionPathspecs()];
+  const tracked = git(root, ["diff", "--binary", "HEAD", ...pathspec], true) ?? "";
+  const untracked = (git(root, ["ls-files", "--others", "--exclude-standard", ...pathspec], true) ?? "")
     .split("\n").filter(Boolean).sort();
   const hash = createHash("sha256").update(tracked);
   for (const path of untracked) {
@@ -81,7 +91,7 @@ export function repositoryIdentity(root) {
       remote: null,
       dirty: null,
       dirtyEntries: [],
-      treeStateSha256: directoryHash(absolute, { exclude: [".mex/graph.db", ".mex/graph.db-shm", ".mex/graph.db-wal"] }),
+      treeStateSha256: directoryHash(absolute, { exclude: GRAPH_DB_PATHS }),
     };
   }
   const sha = git(absolute, ["rev-parse", "HEAD"], true);

--- a/evaluate/graders/retrieval.mjs
+++ b/evaluate/graders/retrieval.mjs
@@ -1,17 +1,22 @@
+import {
+  evidenceIdentity,
+  evidenceMatchesRecord,
+  evidencePath,
+  evidenceSpan,
+  evidenceSymbol,
+  normalizeRepoPath,
+  uniqueRequiredPaths,
+} from "../core/evidence.mjs";
 import { mean, round } from "../core/stats.mjs";
 
-export function normalizeRepoPath(path) {
-  return typeof path === "string" ? path.replace(/^\.\//, "").replaceAll("\\", "/") : null;
-}
+export { normalizeRepoPath };
 
 export function evidenceKey(evidence) {
-  return `${evidence.symbol}\0${evidence.kind}\0${normalizeRepoPath(evidence.path)}`;
+  return evidenceIdentity(evidence);
 }
 
 export function recordEvidenceKey(record) {
-  const symbol = typeof record.name === "string" ? record.name : typeof record.symbol === "string" ? record.symbol : null;
-  const path = normalizeRepoPath(record.filePath ?? record.path);
-  return symbol && typeof record.kind === "string" && path ? `${symbol}\0${record.kind}\0${path}` : null;
+  return evidenceSymbol(record) && evidencePath(record) ? evidenceIdentity(record) : null;
 }
 
 export function resultRecordsForTask(task, records) {
@@ -24,8 +29,7 @@ export function resultRecordsForTask(task, records) {
 }
 
 function rankEvidence(results, evidence) {
-  const key = evidenceKey(evidence);
-  const index = results.findIndex((record) => recordEvidenceKey(record) === key);
+  const index = results.findIndex((record) => evidenceMatchesRecord(evidence, record));
   return index < 0 ? null : index + 1;
 }
 
@@ -37,57 +41,224 @@ function dcg(relevance) {
   return relevance.reduce((total, value, index) => total + (value ? 1 / Math.log2(index + 2) : 0), 0);
 }
 
-function ndcgAt(results, relevantKeys, k) {
-  if (!relevantKeys.size) return null;
-  const relevance = results.slice(0, k).map((record) => Number(relevantKeys.has(recordEvidenceKey(record))));
+function ndcgAt(results, relevant, k) {
+  if (!relevant.length) return null;
+  const relevance = results.slice(0, k).map((record) => Number(relevant.some((evidence) => evidenceMatchesRecord(evidence, record))));
   while (relevance.length < k) relevance.push(0);
-  const ideal = Array.from({ length: k }, (_, index) => Number(index < Math.min(k, relevantKeys.size)));
+  const ideal = Array.from({ length: k }, (_, index) => Number(index < Math.min(k, relevant.length)));
   const idealDcg = dcg(ideal);
   return idealDcg ? dcg(relevance) / idealDcg : null;
 }
 
-export function gradeRetrieval(task, records, processResult = {}) {
+function filesInResponse(records) {
+  const files = [];
+  const seen = new Set();
+  const add = (value) => {
+    const path = evidencePath(value);
+    if (path && !seen.has(path)) { seen.add(path); files.push(path); }
+  };
+  for (const record of records) {
+    add(record);
+    for (const node of record.nodes ?? record.steps ?? []) if (node && typeof node === "object") add(node);
+    for (const range of record.ranges ?? []) add({ ...range, filePath: range.filePath ?? record.filePath });
+  }
+  return files;
+}
+
+function returnedSourceRanges(records) {
+  return records.flatMap((record) => {
+    if (record.type !== "source") return [];
+    const path = evidencePath(record);
+    if (!path) return [];
+    const ranges = Array.isArray(record.ranges) ? record.ranges : [record];
+    return ranges.flatMap((range) => {
+      const span = evidenceSpan(range);
+      return span ? [{ path, ...span, nodeIds: range.nodeIds ?? [] }] : [];
+    });
+  });
+}
+
+function sourceSpanCovered(evidence, ranges) {
+  const expected = evidenceSpan(evidence);
+  const path = evidencePath(evidence);
+  if (!expected || !path) return false;
+  const matching = ranges.filter((range) => range.path === path
+    && range.endLine >= expected.startLine && range.startLine <= expected.endLine)
+    .sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine);
+  let coveredThrough = expected.startLine - 1;
+  for (const range of matching) {
+    // Source planning may split one declaration across several JSONL records.
+    // Adjacent and overlapping intervals are equivalent to one returned span;
+    // an actual missing line must still fail the coverage check.
+    if (range.startLine > coveredThrough + 1) return false;
+    coveredThrough = Math.max(coveredThrough, range.endLine);
+    if (coveredThrough >= expected.endLine) return true;
+  }
+  return false;
+}
+
+function flowGraph(records) {
+  const nodes = new Map();
+  const edges = [];
+  const remember = (node) => {
+    if (!node || typeof node !== "object") return null;
+    const id = node.id ?? node.nodeId;
+    if (typeof id === "string") nodes.set(id, { ...(nodes.get(id) ?? {}), ...node });
+    return typeof id === "string" ? id : null;
+  };
+  for (const record of records) {
+    remember(record);
+    for (const node of record.nodes ?? []) remember(node);
+    const steps = Array.isArray(record.steps) ? record.steps : [];
+    const stepIds = [];
+    for (const step of steps) {
+      if (step && typeof step === "object" && ("source" in step || "target" in step)) {
+        const source = typeof step.source === "string" ? step.source : remember(step.source);
+        const target = typeof step.target === "string" ? step.target : remember(step.target);
+        if (source && target) edges.push({ ...step, source, target });
+        continue;
+      }
+      const id = typeof step === "string" ? step : remember(step);
+      if (id) stepIds.push(id);
+    }
+    // Protocol v1/v2 fixtures represented a flow as an ordered list of node
+    // ids (or node objects). Keep that compatibility path alongside protocol
+    // v3, whose `flow.steps` entries are already directed edge objects.
+    for (let index = 1; index < stepIds.length; index++) edges.push({ source: stepIds[index - 1], target: stepIds[index], kind: "flow" });
+    if (record.type === "edge" && typeof record.source === "string" && typeof record.target === "string") edges.push(record);
+    for (const edge of record.edges ?? []) {
+      const source = typeof edge.source === "string" ? edge.source : remember(edge.source);
+      const target = typeof edge.target === "string" ? edge.target : remember(edge.target);
+      if (source && target) edges.push({ ...edge, source, target });
+    }
+  }
+  return { nodes, edges };
+}
+
+function directedFlowCovered(required, graph) {
+  const starts = [...graph.nodes].filter(([, node]) => evidenceMatchesRecord(required.from, node)).map(([id]) => id);
+  const targets = new Set([...graph.nodes].filter(([, node]) => evidenceMatchesRecord(required.to, node)).map(([id]) => id));
+  if (!starts.length || !targets.size) return false;
+  const adjacency = new Map();
+  for (const edge of graph.edges) {
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, []);
+    adjacency.get(edge.source).push(edge);
+  }
+  const queue = starts.map((id) => ({ id, depth: 0, unnamedBridges: 0 }));
+  const visited = new Set(queue.map((entry) => `${entry.id}\0${entry.unnamedBridges}`));
+  while (queue.length) {
+    const current = queue.shift();
+    if (targets.has(current.id)) return true;
+    if (current.depth >= 7) continue;
+    for (const edge of adjacency.get(current.id) ?? []) {
+      const target = graph.nodes.get(edge.target);
+      const callbackBridge = edge.kind === "contains" && isUnnamedFlowNode(target);
+      if (required.kinds?.length && !required.kinds.includes(edge.kind) && !callbackBridge) continue;
+      const unnamedBridges = current.unnamedBridges + Number(isUnnamedFlowNode(target));
+      if (unnamedBridges > 1) continue;
+      const key = `${edge.target}\0${unnamedBridges}`;
+      if (visited.has(key)) continue;
+      visited.add(key);
+      queue.push({ id: edge.target, depth: current.depth + 1, unnamedBridges });
+    }
+  }
+  return false;
+}
+
+function isUnnamedFlowNode(node) {
+  const name = typeof node?.name === "string" ? node.name : "";
+  return name.length === 0 || /^<.*>$/.test(name) || name.startsWith("<callback:");
+}
+
+export function firstResponseMetrics(task, records) {
+  const gold = task.gold ?? [];
+  const files = filesInResponse(records);
+  const requiredPaths = uniqueRequiredPaths(gold);
+  const requiredFileRanks = requiredPaths.map((path) => ({ path, rank: files.includes(path) ? files.indexOf(path) + 1 : null }));
+  const sourceRanges = returnedSourceRanges(records);
+  const sourceSpans = gold.map((evidence) => ({
+    symbol: evidence.symbol,
+    path: evidencePath(evidence),
+    span: evidenceSpan(evidence),
+    covered: sourceSpanCovered(evidence, sourceRanges),
+  }));
+  const requiredFlows = task.requiredFlows ?? [];
+  const graph = flowGraph(records);
+  const flows = requiredFlows.map((flow) => ({ ...flow, covered: directedFlowCovered(flow, graph) }));
+  const firstRelevantFileRank = requiredFileRanks.map((entry) => entry.rank).filter(Number.isFinite).sort((a, b) => a - b)[0] ?? null;
+  return {
+    returnedFiles: files,
+    requiredFileRanks,
+    firstRelevantFileRank,
+    fileRecallAt5: requiredFileRanks.length ? round(requiredFileRanks.filter((entry) => entry.rank !== null && entry.rank <= 5).length / requiredFileRanks.length) : null,
+    fileHitAt5: requiredFileRanks.length ? requiredFileRanks.every((entry) => entry.rank !== null && entry.rank <= 5) : null,
+    fileReciprocalRank: firstRelevantFileRank ? round(1 / firstRelevantFileRank) : 0,
+    returnedSourceRanges: sourceRanges,
+    sourceSpans,
+    returnedSourceSpanRecall: sourceSpans.length ? round(sourceSpans.filter((entry) => entry.covered).length / sourceSpans.length) : null,
+    requiredFlows: flows,
+    directedFlowCoverage: flows.length ? round(flows.filter((entry) => entry.covered).length / flows.length) : null,
+  };
+}
+
+function coveredGold(task, coverage) {
+  if (!coverage?.evidence) return { eligible: task.gold ?? [], missing: [] };
+  const eligible = [];
+  const missing = [];
+  for (const evidence of task.gold ?? []) {
+    const coverageEntry = coverage.evidence.find((entry) => evidenceMatchesRecord(evidence, entry));
+    const covered = coverageEntry?.covered;
+    (covered === false ? missing : eligible).push(evidence);
+  }
+  return { eligible, missing };
+}
+
+export function gradeRetrieval(task, records, processResult = {}, graphCoverage = null) {
   const results = resultRecordsForTask(task, records);
   const gold = task.gold ?? [];
+  const { eligible: retrievalGold, missing: constructionMissing } = coveredGold(task, graphCoverage);
   const alternates = task.acceptableAlternates ?? [];
   const prohibited = task.mustNotReturn ?? [];
-  const goldRanks = gold.map((evidence) => ({ ...evidence, rank: rankEvidence(results, evidence) }));
+  const goldRanks = gold.map((evidence) => ({ ...evidence, graphCovered: !constructionMissing.some((missing) => evidenceMatchesRecord(evidence, missing)), rank: rankEvidence(results, evidence) }));
+  const retrievalGoldRanks = goldRanks.filter((entry) => entry.graphCovered);
   const alternateRanks = alternates.map((evidence) => ({ ...evidence, rank: rankEvidence(results, evidence) }));
   const prohibitedRanks = prohibited.map((evidence) => ({ ...evidence, rank: rankEvidence(results, evidence) }));
-  const ranks = goldRanks.map((entry) => entry.rank);
-  const firstRelevantRank = [...goldRanks, ...alternateRanks].map((entry) => entry.rank).filter(Number.isFinite).sort((a, b) => a - b)[0] ?? null;
-  const relevantKeys = new Set([...gold, ...alternates].map(evidenceKey));
-  const relevantTop5 = results.slice(0, 5).filter((record) => relevantKeys.has(recordEvidenceKey(record))).length;
+  const ranks = retrievalGoldRanks.map((entry) => entry.rank);
+  const firstRelevantRank = [...retrievalGoldRanks, ...alternateRanks].map((entry) => entry.rank).filter(Number.isFinite).sort((a, b) => a - b)[0] ?? null;
+  const relevant = [...retrievalGold, ...alternates];
+  const relevantTop5 = results.slice(0, 5).filter((record) => relevant.some((evidence) => evidenceMatchesRecord(evidence, record))).length;
   const errorCodes = records.filter((record) => record.type === "error").map((record) => record.code ?? "UNKNOWN");
   const expectedErrorCodes = task.expect?.errorCodes ?? [];
   const noResultExpected = task.expect?.noResult === true;
-  // errorCodes is an allowlist for implementations that represent a negative
-  // outcome as an error record. A clean not-found response need not emit one.
   const unexpectedErrorCodes = errorCodes.filter((code) => !expectedErrorCodes.includes(code));
   const errorExpectationMet = unexpectedErrorCodes.length === 0;
   const noResultCorrect = noResultExpected ? results.length === 0 && errorExpectationMet : null;
-  const completeEvidence = noResultExpected ? noResultCorrect : ranks.every(Number.isFinite);
+  const completeEvidence = noResultExpected ? noResultCorrect : ranks.length > 0 && ranks.every(Number.isFinite);
   const prohibitedHit = prohibitedRanks.some((entry) => Number.isFinite(entry.rank));
   const summary = records.findLast((record) => record.type === "summary") ?? null;
   const outputChars = String(processResult.stdout ?? "").length;
   const outputTokensApprox = Math.ceil(outputChars / 4);
   const maxOutputTokens = Number(summary?.maxOutputTokens ?? task.options?.maxOutputTokens ?? NaN);
   const estimatedOutputTokens = Number(summary?.estimatedOutputTokens ?? NaN);
-  const budgetCompliant = Number.isFinite(maxOutputTokens) && Number.isFinite(estimatedOutputTokens)
-    ? estimatedOutputTokens <= maxOutputTokens
-    : null;
-  const relevantReturned = results.filter((record) => relevantKeys.has(recordEvidenceKey(record))).length;
+  const budgetCompliant = Number.isFinite(maxOutputTokens) && Number.isFinite(estimatedOutputTokens) ? estimatedOutputTokens <= maxOutputTokens : null;
+  const relevantReturned = results.filter((record) => relevant.some((evidence) => evidenceMatchesRecord(evidence, record))).length;
+  const firstResponse = firstResponseMetrics(task, records);
   return {
     returned: results.length,
-    goldCount: gold.length,
+    goldCount: retrievalGold.length,
+    sourceGoldCount: gold.length,
+    graphCoveredGold: retrievalGold.length,
+    constructionMissingGold: constructionMissing,
+    graphEvidenceCoverage: graphCoverage?.evidenceCoverage ?? null,
     goldRanks,
+    retrievalGoldRanks,
     alternateRanks,
     prohibitedRanks,
     recallAt1: round(recallAt(ranks, 1)),
     recallAt5: round(recallAt(ranks, 5)),
     recallAt10: round(recallAt(ranks, 10)),
     reciprocalRank: firstRelevantRank ? round(1 / firstRelevantRank) : 0,
-    ndcgAt10: round(ndcgAt(results, relevantKeys, 10)),
+    ndcgAt10: round(ndcgAt(results, relevant, 10)),
     precisionAt5: round(relevantTop5 / 5),
     precisionAmongReturnedAt5: round(results.length ? relevantTop5 / Math.min(5, results.length) : 0),
     irrelevantRate: round(results.length ? (results.length - relevantReturned) / results.length : 0),
@@ -95,7 +266,8 @@ export function gradeRetrieval(task, records, processResult = {}) {
     noResultCorrect,
     prohibitedHit,
     firstRelevantRank,
-    miss: !noResultExpected && firstRelevantRank === null,
+    miss: !noResultExpected && retrievalGold.length > 0 && firstRelevantRank === null,
+    ...firstResponse,
     errorCodes,
     unexpectedErrorCodes,
     errorExpectationMet,
@@ -111,9 +283,19 @@ export function gradeRetrieval(task, records, processResult = {}) {
 export function summarizeRetrievalRows(rows) {
   const valid = rows.filter((row) => row.valid);
   const positive = valid.filter((row) => row.task.expect?.noResult !== true);
+  // Source-bearing first-response gates apply to Scope. Exact query/impact are
+  // intentionally narrow structural tools and do not promise source payloads.
+  const scopePositive = positive.filter((row) => row.task.operation === "scope");
   const negative = valid.filter((row) => row.task.expect?.noResult === true);
   const evidenceCount = positive.reduce((total, row) => total + row.metrics.goldCount, 0);
-  const evidenceAt = (k) => positive.reduce((total, row) => total + row.metrics.goldRanks.filter((entry) => entry.rank !== null && entry.rank <= k).length, 0);
+  const evidenceAt = (k) => positive.reduce((total, row) => total + row.metrics.retrievalGoldRanks.filter((entry) => entry.rank !== null && entry.rank <= k).length, 0);
+  const sourceEvidenceCount = scopePositive.reduce((total, row) => total + row.metrics.sourceGoldCount, 0);
+  const sourceEvidenceCovered = scopePositive.reduce((total, row) => total + row.metrics.sourceSpans.filter((entry) => entry.covered).length, 0);
+  const fileTasks = scopePositive.filter((row) => row.metrics.requiredFileRanks.length > 0);
+  const flowTasks = positive.filter((row) => Number.isFinite(row.metrics.directedFlowCoverage));
+  const constructionRows = positive.filter((row) => Number.isFinite(row.metrics.graphEvidenceCoverage));
+  const constructionTotal = constructionRows.reduce((total, row) => total + row.metrics.sourceGoldCount, 0);
+  const constructionCovered = constructionRows.reduce((total, row) => total + row.metrics.graphCoveredGold, 0);
   return {
     runs: rows.length,
     validRuns: valid.length,
@@ -122,6 +304,12 @@ export function summarizeRetrievalRows(rows) {
     recallAt5: evidenceCount ? round(evidenceAt(5) / evidenceCount) : null,
     recallAt10: evidenceCount ? round(evidenceAt(10) / evidenceCount) : null,
     mrr: round(mean(positive.map((row) => row.metrics.reciprocalRank))),
+    topFiveFileHitRate: fileTasks.length ? round(fileTasks.filter((row) => row.metrics.fileHitAt5).length / fileTasks.length) : null,
+    fileMrr: round(mean(fileTasks.map((row) => row.metrics.fileReciprocalRank))),
+    returnedRequiredSourceSpanRecall: sourceEvidenceCount ? round(sourceEvidenceCovered / sourceEvidenceCount) : null,
+    meanDirectedFlowCoverage: flowTasks.length ? round(mean(flowTasks.map((row) => row.metrics.directedFlowCoverage))) : null,
+    graphEvidenceCoverage: constructionTotal ? round(constructionCovered / constructionTotal) : null,
+    graphConstructionMisses: constructionTotal ? constructionTotal - constructionCovered : null,
     meanNdcgAt10: round(mean(positive.map((row) => row.metrics.ndcgAt10).filter(Number.isFinite))),
     completeEvidenceRate: positive.length ? round(positive.filter((row) => row.metrics.completeEvidence).length / positive.length) : null,
     missRate: positive.length ? round(positive.filter((row) => row.metrics.miss).length / positive.length) : null,

--- a/evaluate/graph/lib/coverage.mjs
+++ b/evaluate/graph/lib/coverage.mjs
@@ -1,0 +1,170 @@
+import { createRequire } from "node:module";
+import { evidenceMatchesRecord, evidencePath, evidenceSpan, evidenceSymbol } from "../../core/evidence.mjs";
+import { round } from "../../core/stats.mjs";
+
+const require = createRequire(import.meta.url);
+const originalEmitWarning = process.emitWarning.bind(process);
+process.emitWarning = ((warning, ...rest) => {
+  const message = typeof warning === "string" ? warning : warning?.message;
+  if (typeof message === "string" && /SQLite is an experimental feature/i.test(message)) return;
+  return originalEmitWarning(warning, ...rest);
+});
+const { DatabaseSync } = require("node:sqlite");
+
+function tableColumns(db, table) {
+  try { return new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((row) => row.name)); }
+  catch { return new Set(); }
+}
+
+function selectorMatches(selector, node) {
+  const symbol = evidenceSymbol(selector);
+  const path = evidencePath(selector);
+  if (path !== evidencePath(node)) return false;
+  const qualified = String(node.qualifiedName ?? "");
+  const symbolMatches = evidenceSymbol(node) === symbol
+    || qualified === symbol
+    || qualified.endsWith(`.${symbol}`)
+    || qualified.endsWith(`::${symbol}`);
+  if (!symbolMatches) return false;
+  const span = evidenceSpan(selector);
+  return !span || evidenceMatchesRecord({ ...selector, symbol: evidenceSymbol(node) }, node);
+}
+
+function isUnnamedFlowNode(node) {
+  const name = typeof node?.name === "string" ? node.name : "";
+  return name.length === 0 || /^<.*>$/.test(name) || name.startsWith("<callback:");
+}
+
+function directedPaths(sourceIds, targetIds, kinds, nodesById, edges) {
+  const adjacency = new Map();
+  for (const edge of edges) {
+    if (edge.confidence !== null && edge.confidence < 0.8) continue;
+    if (!adjacency.has(edge.source)) adjacency.set(edge.source, []);
+    adjacency.get(edge.source).push(edge);
+  }
+  const paths = [];
+  for (const source of sourceIds) {
+    const queue = [{ id: source, path: [], unnamedBridges: 0 }];
+    const visited = new Set([`${source}\0${0}`]);
+    while (queue.length) {
+      const current = queue.shift();
+      if (targetIds.has(current.id) && current.path.length > 0) {
+        paths.push(current.path);
+        break;
+      }
+      if (current.path.length >= 7) continue;
+      for (const edge of adjacency.get(current.id) ?? []) {
+        const target = nodesById.get(edge.target);
+        const callbackBridge = edge.kind === "contains" && isUnnamedFlowNode(target);
+        if (kinds?.length && !kinds.includes(edge.kind) && !callbackBridge) continue;
+        const unnamedBridges = current.unnamedBridges + Number(isUnnamedFlowNode(target));
+        if (unnamedBridges > 1) continue;
+        const key = `${edge.target}\0${unnamedBridges}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
+        queue.push({ id: edge.target, path: [...current.path, edge], unnamedBridges });
+      }
+    }
+  }
+  return paths;
+}
+
+function taskCoverage(task, nodes, edges) {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const evidence = (task.gold ?? []).map((gold) => {
+    const matches = nodes.filter((node) => selectorMatches(gold, node));
+    return {
+      symbol: gold.symbol,
+      path: evidencePath(gold),
+      startLine: evidenceSpan(gold)?.startLine ?? null,
+      endLine: evidenceSpan(gold)?.endLine ?? null,
+      advisoryKind: gold.kind ?? null,
+      covered: matches.length > 0,
+      matches: matches.map((node) => ({
+        id: node.id,
+        kind: node.kind,
+        qualifiedName: node.qualifiedName,
+        startLine: node.startLine,
+        endLine: node.endLine,
+        kindAgrees: gold.kind === undefined ? null : gold.kind === node.kind,
+      })),
+    };
+  });
+  const requiredFlows = (task.requiredFlows ?? []).map((flow) => {
+    const sources = nodes.filter((node) => selectorMatches(flow.from, node));
+    const targets = nodes.filter((node) => selectorMatches(flow.to, node));
+    const sourceIds = new Set(sources.map((node) => node.id));
+    const targetIds = new Set(targets.map((node) => node.id));
+    const paths = directedPaths(sourceIds, targetIds, flow.kinds, nodesById, edges);
+    return { ...flow, covered: paths.length > 0, matches: paths.flat(), paths };
+  });
+  const covered = evidence.filter((entry) => entry.covered).length;
+  const coveredFlows = requiredFlows.filter((entry) => entry.covered).length;
+  return {
+    taskId: task.id,
+    evidence,
+    totalEvidence: evidence.length,
+    coveredEvidence: covered,
+    missingEvidence: evidence.length - covered,
+    evidenceCoverage: evidence.length ? round(covered / evidence.length) : null,
+    requiredFlows,
+    totalRequiredFlows: requiredFlows.length,
+    coveredRequiredFlows: coveredFlows,
+    directedFlowCoverage: requiredFlows.length ? round(coveredFlows / requiredFlows.length) : null,
+  };
+}
+
+/** Snapshot structural coverage before retrieval so construction loss is never scored as a retrieval miss. */
+export function inspectGoldCoverage(path, tasks) {
+  const db = new DatabaseSync(path, { readOnly: true });
+  try {
+    const nodeColumns = tableColumns(db, "nodes");
+    const requiredNodeColumns = ["id", "name", "qualified_name", "file_path", "kind", "start_line", "end_line"];
+    if (requiredNodeColumns.some((column) => !nodeColumns.has(column))) {
+      return { status: "unavailable", reason: "nodes table lacks coverage columns", tasks: [] };
+    }
+    const nodes = db.prepare("SELECT id, name, qualified_name, file_path, kind, start_line, end_line FROM nodes").all().map((row) => ({
+      id: row.id,
+      name: row.name,
+      qualifiedName: row.qualified_name,
+      filePath: row.file_path,
+      kind: row.kind,
+      startLine: Number(row.start_line),
+      endLine: Number(row.end_line),
+    }));
+    const edgeColumns = tableColumns(db, "edges");
+    const confidence = edgeColumns.has("confidence") ? "confidence" : "NULL AS confidence";
+    const edges = edgeColumns.has("source") && edgeColumns.has("target") && edgeColumns.has("kind")
+      ? db.prepare(`SELECT source, target, kind, ${confidence} FROM edges`).all().map((edge) => ({
+        source: edge.source,
+        target: edge.target,
+        kind: edge.kind,
+        confidence: edge.confidence !== null && edge.confidence !== undefined && Number.isFinite(Number(edge.confidence))
+          ? Number(edge.confidence)
+          : null,
+      }))
+      : [];
+    const coverageTasks = tasks.map((task) => taskCoverage(task, nodes, edges));
+    const totalEvidence = coverageTasks.reduce((sum, task) => sum + task.totalEvidence, 0);
+    const coveredEvidence = coverageTasks.reduce((sum, task) => sum + task.coveredEvidence, 0);
+    const totalRequiredFlows = coverageTasks.reduce((sum, task) => sum + task.totalRequiredFlows, 0);
+    const coveredRequiredFlows = coverageTasks.reduce((sum, task) => sum + task.coveredRequiredFlows, 0);
+    return {
+      status: "ok",
+      totalEvidence,
+      coveredEvidence,
+      missingEvidence: totalEvidence - coveredEvidence,
+      evidenceCoverage: totalEvidence ? round(coveredEvidence / totalEvidence) : null,
+      totalRequiredFlows,
+      coveredRequiredFlows,
+      directedFlowCoverage: totalRequiredFlows ? round(coveredRequiredFlows / totalRequiredFlows) : null,
+      tasks: coverageTasks,
+    };
+  } finally {
+    db.close();
+  }
+}
+
+export function coverageForTask(coverage, taskId) {
+  return coverage?.tasks?.find((task) => task.taskId === taskId) ?? null;
+}

--- a/evaluate/graph/lib/fixture.mjs
+++ b/evaluate/graph/lib/fixture.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
 import { repositoryIdentity } from "../../core/hash.mjs";
@@ -6,22 +7,17 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function declarationPattern(evidence) {
-  const name = escapeRegExp(evidence.symbol);
-  switch (evidence.kind) {
-    case "function": return new RegExp(`\\b(?:export\\s+)?(?:default\\s+)?(?:async\\s+)?(?:function|def|fn|func)\\s+${name}\\b`);
-    case "class": return new RegExp(`\\b(?:export\\s+)?(?:default\\s+)?class\\s+${name}\\b`);
-    case "interface": return new RegExp(`\\b(?:export\\s+)?interface\\s+${name}\\b`);
-    case "struct": return new RegExp(`\\b(?:pub(?:\\([^)]*\\))?\\s+)?struct\\s+${name}\\b`);
-    case "trait": return new RegExp(`\\b(?:pub\\s+)?trait\\s+${name}\\b`);
-    case "enum": return new RegExp(`\\b(?:export\\s+)?(?:pub\\s+)?enum\\s+${name}\\b`);
-    case "type_alias": return new RegExp(`\\b(?:export\\s+)?(?:pub\\s+)?type\\s+${name}\\b`);
-    case "constant": return new RegExp(`\\b(?:export\\s+)?(?:pub\\s+)?(?:const|static)\\s+${name}\\b`);
-    case "variable": return new RegExp(`\\b(?:export\\s+)?(?:const|let|var)\\s+${name}\\b`);
-    case "method": return new RegExp(`^\\s*(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?${name}\\s*(?:<[^>]*>)?\\s*\\(`);
-    case "component": return new RegExp(`\\b(?:function|class|const)\\s+${name}\\b`);
-    default: return new RegExp(`\\b${name}\\b`);
-  }
+function symbolPattern(symbol) {
+  const name = escapeRegExp(symbol);
+  return new RegExp(`(^|[^A-Za-z0-9_$#])${name}(?![A-Za-z0-9_$#])`);
+}
+
+function declarationPattern(symbol) {
+  const name = escapeRegExp(symbol);
+  return new RegExp(
+    `(?:\\b(?:function|class|interface|type|enum|const|let|var|def|fn|func|struct|trait|module|sub|proc)\\s+${name}(?![A-Za-z0-9_$#]))`
+      + `|(?:^\\s*(?:pub(?:\\([^)]*\\))?\\s+)?(?:async\\s+)?${name}\\s*(?:<[^>]*>)?\\s*(?:\\(|[:=]))`,
+  );
 }
 
 function insideRoot(root, path) {
@@ -35,20 +31,43 @@ export function validateEvidenceInSource(root, evidence, label = "evidence") {
   if (!insideRoot(absoluteRoot, absolute)) throw new Error(`${label}.path escapes the subject repository: ${evidence.path}`);
   if (!existsSync(absolute)) throw new Error(`${label}.path does not exist: ${evidence.path}`);
   const lines = readFileSync(absolute, "utf8").split(/\r?\n/);
-  const pattern = declarationPattern(evidence);
-  const matches = [];
-  lines.forEach((line, index) => { if (pattern.test(line)) matches.push(index + 1); });
-  if (evidence.line !== undefined) {
-    if (!matches.includes(evidence.line)) {
-      throw new Error(`${label} declaration ${evidence.kind} ${evidence.symbol} was not found at ${evidence.path}:${evidence.line}`);
+  const exactSymbol = symbolPattern(evidence.symbol);
+  const explicitStart = evidence.startLine ?? evidence.line;
+  const explicitEnd = evidence.endLine ?? explicitStart;
+  if (explicitStart !== undefined) {
+    if (!Number.isInteger(explicitStart) || explicitStart < 1 || !Number.isInteger(explicitEnd) || explicitEnd < explicitStart || explicitEnd > lines.length) {
+      throw new Error(`${label} has an invalid source span ${evidence.path}:${explicitStart}-${explicitEnd}`);
     }
-    return { ...evidence, line: evidence.line };
+    const spanText = lines.slice(explicitStart - 1, explicitEnd).join("\n");
+    if (!exactSymbol.test(spanText)) {
+      throw new Error(`${label} symbol ${evidence.symbol} was not found in source span ${evidence.path}:${explicitStart}-${explicitEnd}`);
+    }
+    return {
+      ...evidence,
+      line: explicitStart,
+      startLine: explicitStart,
+      endLine: explicitEnd,
+      sourceSpanSha256: createHash("sha256").update(spanText).digest("hex"),
+      sourceValidated: true,
+    };
   }
-  if (matches.length === 0) throw new Error(`${label} declaration ${evidence.kind} ${evidence.symbol} was not found in ${evidence.path}`);
+  const declaration = declarationPattern(evidence.symbol);
+  let matches = [];
+  lines.forEach((line, index) => { if (declaration.test(line)) matches.push(index + 1); });
+  if (matches.length === 0) lines.forEach((line, index) => { if (exactSymbol.test(line)) matches.push(index + 1); });
+  if (matches.length === 0) throw new Error(`${label} symbol ${evidence.symbol} was not found in ${evidence.path}`);
   if (matches.length > 1) {
-    throw new Error(`${label} declaration ${evidence.kind} ${evidence.symbol} is ambiguous in ${evidence.path}; add line (${matches.join(", ")})`);
+    throw new Error(`${label} symbol ${evidence.symbol} is ambiguous in ${evidence.path}; add a source span (${matches.join(", ")})`);
   }
-  return { ...evidence, line: matches[0] };
+  const line = matches[0];
+  return {
+    ...evidence,
+    line,
+    startLine: line,
+    endLine: line,
+    sourceSpanSha256: createHash("sha256").update(lines[line - 1]).digest("hex"),
+    sourceValidated: true,
+  };
 }
 
 export function validateSubjectFixture(suite, subjectRoot) {

--- a/evaluate/graph/lib/integrity.mjs
+++ b/evaluate/graph/lib/integrity.mjs
@@ -12,81 +12,404 @@ process.emitWarning = ((warning, ...rest) => {
 });
 const { DatabaseSync } = require("node:sqlite");
 
+const NORMALIZED_TABLES = [
+  {
+    name: "nodes",
+    columns: [
+      "id", "kind", "name", "qualified_name", "container_id", "identity_key", "file_path", "language",
+      "start_line", "end_line", "start_column", "end_column", "docstring", "signature", "visibility",
+      "is_exported", "is_async", "is_static", "is_abstract", "decorators", "type_parameters", "return_type", "body_hash",
+    ],
+    order: ["id"],
+  },
+  {
+    name: "edges",
+    columns: [
+      "source", "target", "kind", "line", "col", "confidence", "resolution_method", "provenance", "metadata", "evidence",
+    ],
+    order: ["source", "target", "kind", "line", "col", "resolution_method", "provenance"],
+  },
+  {
+    name: "files",
+    columns: [
+      "path", "content_hash", "language", "size", "node_count", "errors", "parse_status", "diagnostic_count",
+      "missing_count", "error_coverage", "extractor_version",
+    ],
+    order: ["path"],
+  },
+  {
+    name: "unresolved_refs",
+    columns: [
+      "ref_key", "from_node_id", "reference_name", "reference_kind", "line", "col", "file_path", "language",
+      "receiver", "qualifier", "import_source", "candidates", "metadata", "status", "target_id", "confidence", "resolver",
+    ],
+    order: ["ref_key", "from_node_id", "file_path", "line", "col", "reference_name", "reference_kind"],
+  },
+  {
+    name: "import_bindings",
+    columns: [
+      "binding_key", "file_path", "local_name", "imported_name", "module_specifier", "resolved_file_path", "target_id",
+      "is_type_only", "metadata",
+    ],
+    order: ["binding_key", "file_path", "local_name"],
+  },
+  {
+    name: "node_aliases",
+    columns: ["alias_id", "canonical_node_id", "match_method", "confidence"],
+    order: ["alias_id"],
+  },
+  {
+    name: "source_chunks",
+    columns: ["file_path", "start_line", "end_line", "content_hash", "path_terms", "identifier_terms", "comment_terms"],
+    order: ["file_path", "start_line", "end_line"],
+  },
+  {
+    name: "project_metadata",
+    columns: ["key", "value"],
+    order: ["key"],
+  },
+  {
+    name: "node_fingerprints",
+    columns: ["node_id", "minhash", "neighbors", "token_count"],
+    order: ["node_id"],
+  },
+  {
+    name: "lsh_buckets",
+    columns: ["band", "band_hash", "node_id"],
+    order: ["band", "band_hash", "node_id"],
+  },
+];
+
+function identifier(value) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) throw new Error(`unsafe SQLite identifier: ${value}`);
+  return `"${value}"`;
+}
+
 function scalar(db, sql, params = []) {
   const row = db.prepare(sql).get(...params);
   return Number(row?.value ?? 0);
 }
 
-function rows(db, sql) {
-  return db.prepare(sql).all().map((row) => ({ ...row }));
+function rows(db, sql, params = []) {
+  return db.prepare(sql).all(...params).map((row) => ({ ...row }));
 }
 
-function duplicateExcess(db, columns) {
-  return scalar(db, `SELECT COALESCE(SUM(count - 1), 0) AS value FROM (SELECT COUNT(*) AS count FROM nodes GROUP BY ${columns} HAVING COUNT(*) > 1)`);
+function tableExists(db, table) {
+  return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type IN ('table','view') AND name = ?").get(table));
+}
+
+function tableColumns(db, table) {
+  if (!tableExists(db, table)) return new Set();
+  return new Set(rows(db, `PRAGMA table_info(${identifier(table)})`).map((row) => row.name));
+}
+
+function hasColumns(db, table, required) {
+  const available = tableColumns(db, table);
+  return required.every((column) => available.has(column));
+}
+
+function tableCount(db, table) {
+  return tableExists(db, table) ? scalar(db, `SELECT COUNT(*) AS value FROM ${identifier(table)}`) : 0;
+}
+
+function duplicateExcess(db, table, columns) {
+  if (!hasColumns(db, table, columns)) return null;
+  const group = columns.map(identifier).join(", ");
+  return scalar(db, `SELECT COALESCE(SUM(count - 1), 0) AS value FROM (
+    SELECT COUNT(*) AS count FROM ${identifier(table)} GROUP BY ${group} HAVING COUNT(*) > 1
+  )`);
+}
+
+function groupedCounts(db, table, column, where = null) {
+  if (!hasColumns(db, table, [column])) return {};
+  const result = rows(db, `SELECT ${identifier(column)} AS key, COUNT(*) AS count FROM ${identifier(table)}
+    ${where ? `WHERE ${where}` : ""} GROUP BY ${identifier(column)} ORDER BY ${identifier(column)}`);
+  return Object.fromEntries(result.map((row) => [row.key ?? "<null>", Number(row.count)]));
+}
+
+function normalizedRows(db, spec) {
+  const available = tableColumns(db, spec.name);
+  if (!available.size) return null;
+  const columns = spec.columns.filter((column) => available.has(column));
+  if (!columns.length) return [];
+  const order = spec.order.filter((column) => available.has(column));
+  const sql = `SELECT ${columns.map(identifier).join(", ")} FROM ${identifier(spec.name)}${order.length ? ` ORDER BY ${order.map(identifier).join(", ")}` : ""}`;
+  return rows(db, sql);
 }
 
 function normalizedGraphHash(db) {
   const hash = createHash("sha256");
-  const tables = [
-    ["nodes", `SELECT id, kind, name, qualified_name, file_path, language, start_line, end_line, start_column, end_column,
-      docstring, signature, visibility, is_exported, is_async, is_static, is_abstract, decorators, type_parameters,
-      return_type, body_hash FROM nodes ORDER BY id`],
-    ["edges", "SELECT source, target, kind, metadata, line, col, provenance FROM edges ORDER BY source, target, kind, line, col"],
-    ["files", "SELECT path, content_hash, language, size, node_count, errors FROM files ORDER BY path"],
-    ["unresolved_refs", `SELECT from_node_id, reference_name, reference_kind, line, col, candidates, file_path, language
-      FROM unresolved_refs ORDER BY from_node_id, reference_name, reference_kind, line, col`],
-  ];
-  for (const [name, sql] of tables) {
-    hash.update(`${name}\0`);
-    for (const row of rows(db, sql)) hash.update(`${stableJson(row)}\n`);
+  for (const spec of NORMALIZED_TABLES) {
+    hash.update(`${spec.name}\0`);
+    const tableRows = normalizedRows(db, spec);
+    if (tableRows === null) {
+      hash.update("<absent>\n");
+      continue;
+    }
+    for (const row of tableRows) hash.update(`${stableJson(row)}\n`);
   }
   return hash.digest("hex");
+}
+
+function graphSchemaVersion(db) {
+  if (!hasColumns(db, "schema_versions", ["version"])) return null;
+  const row = db.prepare("SELECT MAX(version) AS version FROM schema_versions").get();
+  return row?.version !== null && row?.version !== undefined && Number.isFinite(Number(row.version)) ? Number(row.version) : null;
+}
+
+function fileHealth(db, files) {
+  const hasV2Health = hasColumns(db, "files", ["parse_status", "diagnostic_count", "missing_count", "error_coverage"]);
+  const filesWithExtractionErrors = hasColumns(db, "files", ["errors"])
+    ? scalar(db, "SELECT COUNT(*) AS value FROM files WHERE errors IS NOT NULL AND errors NOT IN ('', '[]')")
+    : 0;
+  if (!hasV2Health) {
+    return {
+      healthAvailable: false,
+      parseStatusCounts: { unknown: files },
+      okFiles: null,
+      partialFiles: null,
+      failedFiles: null,
+      unknownHealthFiles: files,
+      totalDiagnostics: null,
+      totalMissingNodes: null,
+      meanErrorCoverage: null,
+      maxErrorCoverage: null,
+      failedFilePaths: [],
+      filesWithExtractionErrors,
+    };
+  }
+  const aggregate = db.prepare(`SELECT
+    COALESCE(SUM(diagnostic_count), 0) AS diagnostics,
+    COALESCE(SUM(missing_count), 0) AS missing,
+    COALESCE(AVG(error_coverage), 0) AS mean_coverage,
+    COALESCE(MAX(error_coverage), 0) AS max_coverage
+    FROM files`).get();
+  const parseStatusCounts = groupedCounts(db, "files", "parse_status");
+  return {
+    healthAvailable: true,
+    parseStatusCounts,
+    okFiles: parseStatusCounts.ok ?? 0,
+    partialFiles: parseStatusCounts.partial ?? 0,
+    failedFiles: parseStatusCounts.failed ?? 0,
+    unknownHealthFiles: files - Object.values(parseStatusCounts).reduce((sum, count) => sum + count, 0),
+    totalDiagnostics: Number(aggregate.diagnostics),
+    totalMissingNodes: Number(aggregate.missing),
+    meanErrorCoverage: round(Number(aggregate.mean_coverage)),
+    maxErrorCoverage: round(Number(aggregate.max_coverage)),
+    failedFilePaths: rows(db, "SELECT path FROM files WHERE parse_status = 'failed' ORDER BY path").map((row) => row.path),
+    filesWithExtractionErrors: scalar(db, `SELECT COUNT(*) AS value FROM files
+      WHERE diagnostic_count > 0 OR (errors IS NOT NULL AND errors NOT IN ('', '[]'))`),
+  };
+}
+
+function referenceHealth(db) {
+  const total = tableCount(db, "unresolved_refs");
+  const hasStatus = hasColumns(db, "unresolved_refs", ["status"]);
+  const statuses = hasStatus ? groupedCounts(db, "unresolved_refs", "status") : { unresolved: total };
+  const unresolvedReferences = hasStatus
+    ? (statuses.pending ?? 0) + (statuses.unresolved ?? 0) + (statuses.ambiguous ?? 0)
+    : total;
+  const callPredicate = "reference_kind IN ('calls', 'function_ref', 'instantiates')";
+  const unresolvedCalls = hasColumns(db, "unresolved_refs", ["reference_kind"])
+    ? scalar(db, `SELECT COUNT(*) AS value FROM unresolved_refs WHERE ${callPredicate}${hasStatus ? " AND status != 'resolved'" : ""}`)
+    : 0;
+  return {
+    references: total,
+    referenceStatuses: statuses,
+    resolvedReferences: statuses.resolved ?? 0,
+    unresolvedReferences,
+    ambiguousReferences: statuses.ambiguous ?? 0,
+    pendingReferences: statuses.pending ?? 0,
+    unresolvedCalls,
+    danglingUnresolvedSources: hasColumns(db, "unresolved_refs", ["from_node_id"])
+      ? scalar(db, "SELECT COUNT(*) AS value FROM unresolved_refs r LEFT JOIN nodes n ON n.id = r.from_node_id WHERE n.id IS NULL")
+      : 0,
+    danglingResolvedTargets: hasColumns(db, "unresolved_refs", ["target_id"])
+      ? scalar(db, `SELECT COUNT(*) AS value FROM unresolved_refs r LEFT JOIN nodes n ON n.id = r.target_id
+        WHERE r.target_id IS NOT NULL AND n.id IS NULL`)
+      : 0,
+    referenceResolvers: hasColumns(db, "unresolved_refs", ["resolver"])
+      ? groupedCounts(db, "unresolved_refs", "resolver")
+      : {},
+  };
+}
+
+function edgeHealth(db, edges) {
+  const hasConfidence = hasColumns(db, "edges", ["confidence"]);
+  const confidence = hasConfidence ? db.prepare(`SELECT
+    COALESCE(MIN(confidence), 0) AS minimum,
+    COALESCE(AVG(confidence), 0) AS average,
+    SUM(CASE WHEN confidence >= 0.8 THEN 1 ELSE 0 END) AS traversable,
+    SUM(CASE WHEN confidence < 0.8 THEN 1 ELSE 0 END) AS below_threshold,
+    SUM(CASE WHEN confidence < 0 OR confidence > 1 THEN 1 ELSE 0 END) AS invalid
+    FROM edges`).get() : null;
+  return {
+    duplicateEdges: duplicateExcess(db, "edges", ["source", "target", "kind", "line", "col"]),
+    edgeKinds: groupedCounts(db, "edges", "kind"),
+    edgeProvenance: groupedCounts(db, "edges", "provenance"),
+    edgeResolutionMethods: groupedCounts(db, "edges", "resolution_method"),
+    edgeConfidenceAvailable: hasConfidence,
+    traversableEdges: confidence ? Number(confidence.traversable) : edges,
+    belowFlowThresholdEdges: confidence ? Number(confidence.below_threshold) : null,
+    invalidConfidenceEdges: confidence ? Number(confidence.invalid) : null,
+    minimumEdgeConfidence: confidence ? round(Number(confidence.minimum)) : null,
+    meanEdgeConfidence: confidence ? round(Number(confidence.average)) : null,
+  };
+}
+
+function isLowValuePath(filePath) {
+  const path = String(filePath ?? "").toLowerCase();
+  return /(^|\/)(__tests?__|tests?|specs?|fixtures?|examples?|samples?|benchmarks?|demos?|mocks?|testdata|integration)(\/|$)/.test(path)
+    || /\.(test|spec)\.[^/]+$/.test(path)
+    || /(^|\/)test_[^/]+\.[^/]+$/.test(path)
+    || /_test\.[^/]+$/.test(path)
+    || /(^|\/)(generated|vendor)\//.test(path);
+}
+
+function hasCompilerProvenCallbackBinding(edge) {
+  if (edge.resolution_method !== "typescript-callback-parameter"
+    || edge.provenance !== "callback-synthesis"
+    || Number(edge.confidence) < 0.8
+    || !Number.isInteger(Number(edge.line))) return false;
+  try {
+    const evidence = JSON.parse(edge.evidence ?? "[]");
+    return Array.isArray(evidence) && evidence.some((item) => item
+      && Number.isInteger(item.argumentIndex)
+      && typeof item.parameterName === "string" && item.parameterName.length > 0
+      && typeof item.wiringSite === "string" && item.wiringSite.length > 0);
+  } catch {
+    return false;
+  }
+}
+
+/** Production-to-test edges require an explicit import/use or callback binding. */
+function productionTestEdgeHealth(db) {
+  if (!hasColumns(db, "edges", ["source", "target", "kind"])
+    || !hasColumns(db, "nodes", ["id", "file_path"])) {
+    return { suspiciousProductionToTestEdges: null, suspiciousProductionToTestEdgeSamples: [] };
+  }
+  const bindings = hasColumns(db, "import_bindings", ["file_path", "resolved_file_path", "target_id"])
+    ? rows(db, "SELECT file_path, resolved_file_path, target_id FROM import_bindings")
+    : [];
+  const proven = new Set(bindings.flatMap((binding) => [
+    binding.target_id ? `${binding.file_path}\0id:${binding.target_id}` : null,
+    binding.resolved_file_path ? `${binding.file_path}\0path:${binding.resolved_file_path}` : null,
+  ].filter(Boolean)));
+  const resolutionMethod = hasColumns(db, "edges", ["resolution_method"])
+    ? "e.resolution_method"
+    : "NULL AS resolution_method";
+  const provenance = hasColumns(db, "edges", ["provenance"]) ? "e.provenance" : "NULL AS provenance";
+  const confidence = hasColumns(db, "edges", ["confidence"]) ? "e.confidence" : "NULL AS confidence";
+  const evidence = hasColumns(db, "edges", ["evidence"]) ? "e.evidence" : "NULL AS evidence";
+  const line = hasColumns(db, "edges", ["line"]) ? "e.line" : "NULL AS line";
+  const candidates = rows(db, `SELECT e.source, e.target, e.kind, ${resolutionMethod},
+      ${provenance}, ${confidence}, ${evidence}, ${line},
+      source.file_path AS source_path, target.file_path AS target_path
+    FROM edges e JOIN nodes source ON source.id = e.source JOIN nodes target ON target.id = e.target
+    WHERE source.file_path != target.file_path`);
+  const suspicious = candidates.filter((edge) => !isLowValuePath(edge.source_path)
+    && isLowValuePath(edge.target_path)
+    && !proven.has(`${edge.source_path}\0id:${edge.target}`)
+    && !proven.has(`${edge.source_path}\0path:${edge.target_path}`)
+    && !hasCompilerProvenCallbackBinding(edge));
+  return {
+    suspiciousProductionToTestEdges: suspicious.length,
+    suspiciousProductionToTestEdgeSamples: suspicious.slice(0, 20),
+  };
 }
 
 export function inspectGraphDatabase(path, buildSummary = null) {
   const db = new DatabaseSync(path, { readOnly: true });
   try {
-    const nodes = scalar(db, "SELECT COUNT(*) AS value FROM nodes");
-    const files = scalar(db, "SELECT COUNT(*) AS value FROM files");
-    const extractedFileNodes = scalar(db, "SELECT COALESCE(SUM(node_count), 0) AS value FROM files");
-    const storedFileNodes = scalar(db, "SELECT COUNT(*) AS value FROM nodes INNER JOIN files ON files.path = nodes.file_path");
-    const edges = scalar(db, "SELECT COUNT(*) AS value FROM edges");
-    const callEdges = scalar(db, "SELECT COUNT(*) AS value FROM edges WHERE kind = 'calls'");
-    const unresolvedReferences = scalar(db, "SELECT COUNT(*) AS value FROM unresolved_refs");
-    const unresolvedCalls = scalar(db, "SELECT COUNT(*) AS value FROM unresolved_refs WHERE reference_kind IN ('calls', 'function_ref', 'instantiates')");
-    const callableNodes = scalar(db, "SELECT COUNT(*) AS value FROM nodes WHERE kind IN ('function', 'method', 'route', 'component')");
-    const noIncomingCalls = scalar(db, `SELECT COUNT(*) AS value FROM nodes n WHERE n.kind IN ('function', 'method', 'route', 'component')
-      AND NOT EXISTS (SELECT 1 FROM edges e WHERE e.kind = 'calls' AND e.target = n.id)`);
-    const noOutgoingCalls = scalar(db, `SELECT COUNT(*) AS value FROM nodes n WHERE n.kind IN ('function', 'method', 'route', 'component')
-      AND NOT EXISTS (SELECT 1 FROM edges e WHERE e.kind = 'calls' AND e.source = n.id)`);
+    const nodes = tableCount(db, "nodes");
+    const files = tableCount(db, "files");
+    const edges = tableCount(db, "edges");
+    const callEdges = hasColumns(db, "edges", ["kind"])
+      ? scalar(db, "SELECT COUNT(*) AS value FROM edges WHERE kind = 'calls'")
+      : 0;
+    const extractedFileNodes = hasColumns(db, "files", ["node_count"])
+      ? scalar(db, "SELECT COALESCE(SUM(node_count), 0) AS value FROM files")
+      : null;
+    const storedFileNodes = hasColumns(db, "nodes", ["file_path"]) && hasColumns(db, "files", ["path"])
+      ? scalar(db, "SELECT COUNT(*) AS value FROM nodes INNER JOIN files ON files.path = nodes.file_path")
+      : null;
+    const references = referenceHealth(db);
+    const callableNodes = hasColumns(db, "nodes", ["kind"])
+      ? scalar(db, "SELECT COUNT(*) AS value FROM nodes WHERE kind IN ('function', 'method', 'route', 'component')")
+      : 0;
+    const noIncomingCalls = hasColumns(db, "nodes", ["id", "kind"]) && hasColumns(db, "edges", ["target", "kind"])
+      ? scalar(db, `SELECT COUNT(*) AS value FROM nodes n WHERE n.kind IN ('function', 'method', 'route', 'component')
+        AND NOT EXISTS (SELECT 1 FROM edges e WHERE e.kind = 'calls' AND e.target = n.id)`)
+      : 0;
+    const noOutgoingCalls = hasColumns(db, "nodes", ["id", "kind"]) && hasColumns(db, "edges", ["source", "kind"])
+      ? scalar(db, `SELECT COUNT(*) AS value FROM nodes n WHERE n.kind IN ('function', 'method', 'route', 'component')
+        AND NOT EXISTS (SELECT 1 FROM edges e WHERE e.kind = 'calls' AND e.source = n.id)`)
+      : 0;
+    const sourceChunks = tableCount(db, "source_chunks");
+    const imports = tableCount(db, "import_bindings");
+    const aliases = tableCount(db, "node_aliases");
+    const buildNodeCount = Number(buildSummary?.nodesCreated ?? NaN);
+    const health = fileHealth(db, files);
+    const edgeMetrics = edgeHealth(db, edges);
     const integrity = {
+      schemaVersion: graphSchemaVersion(db),
       files,
       nodes,
       extractedFileNodes,
       storedFileNodes,
-      extractedToStoredLoss: Math.max(0, extractedFileNodes - storedFileNodes),
-      nonFileOrFrameworkNodes: Math.max(0, nodes - storedFileNodes),
-      buildNodesCreated: Number(buildSummary?.nodesCreated ?? NaN),
-      buildToStoredDelta: Number.isFinite(Number(buildSummary?.nodesCreated)) ? nodes - Number(buildSummary.nodesCreated) : null,
+      extractedToStoredLoss: extractedFileNodes !== null && storedFileNodes !== null ? Math.max(0, extractedFileNodes - storedFileNodes) : null,
+      nonFileOrFrameworkNodes: storedFileNodes !== null ? Math.max(0, nodes - storedFileNodes) : null,
+      buildNodesCreated: buildNodeCount,
+      buildToStoredDelta: Number.isFinite(buildNodeCount) ? nodes - buildNodeCount : null,
       edges,
       callEdges,
-      unresolvedReferences,
-      unresolvedCalls,
-      unresolvedCallRate: callEdges + unresolvedCalls ? round(unresolvedCalls / (callEdges + unresolvedCalls)) : 0,
-      danglingEdges: scalar(db, `SELECT COUNT(*) AS value FROM edges e LEFT JOIN nodes s ON s.id = e.source
-        LEFT JOIN nodes t ON t.id = e.target WHERE s.id IS NULL OR t.id IS NULL`),
-      danglingUnresolvedSources: scalar(db, "SELECT COUNT(*) AS value FROM unresolved_refs r LEFT JOIN nodes n ON n.id = r.from_node_id WHERE n.id IS NULL"),
-      duplicateFileKindName: duplicateExcess(db, "file_path, kind, name"),
-      duplicateQualifiedIdentity: duplicateExcess(db, "file_path, kind, qualified_name"),
-      ftsRowDelta: scalar(db, "SELECT COUNT(*) AS value FROM nodes_fts") - nodes,
-      filesWithExtractionErrors: scalar(db, "SELECT COUNT(*) AS value FROM files WHERE errors IS NOT NULL AND errors NOT IN ('', '[]')"),
+      ...references,
+      unresolvedCallRate: callEdges + references.unresolvedCalls
+        ? round(references.unresolvedCalls / (callEdges + references.unresolvedCalls))
+        : 0,
+      danglingEdges: hasColumns(db, "edges", ["source", "target"]) && hasColumns(db, "nodes", ["id"])
+        ? scalar(db, `SELECT COUNT(*) AS value FROM edges e LEFT JOIN nodes s ON s.id = e.source
+          LEFT JOIN nodes t ON t.id = e.target WHERE s.id IS NULL OR t.id IS NULL`)
+        : 0,
+      danglingContainers: hasColumns(db, "nodes", ["container_id"])
+        ? scalar(db, `SELECT COUNT(*) AS value FROM nodes child LEFT JOIN nodes parent ON parent.id = child.container_id
+          WHERE child.container_id IS NOT NULL AND parent.id IS NULL`)
+        : null,
+      duplicateFileKindName: duplicateExcess(db, "nodes", ["file_path", "kind", "name"]),
+      duplicateQualifiedIdentity: duplicateExcess(db, "nodes", ["file_path", "kind", "qualified_name"]),
+      duplicateIdentityKeys: duplicateExcess(db, "nodes", ["identity_key"]),
+      missingIdentityKeys: hasColumns(db, "nodes", ["identity_key"])
+        ? scalar(db, "SELECT COUNT(*) AS value FROM nodes WHERE identity_key IS NULL OR identity_key = ''")
+        : null,
+      ftsRowDelta: tableExists(db, "nodes_fts") ? tableCount(db, "nodes_fts") - nodes : null,
+      sourceChunks,
+      sourceChunkFtsRowDelta: tableExists(db, "source_chunks_fts") ? tableCount(db, "source_chunks_fts") - sourceChunks : null,
+      importBindings: imports,
+      unresolvedImportBindings: hasColumns(db, "import_bindings", ["resolved_file_path", "target_id"])
+        ? scalar(db, "SELECT COUNT(*) AS value FROM import_bindings WHERE resolved_file_path IS NULL AND target_id IS NULL")
+        : null,
+      danglingImportTargets: hasColumns(db, "import_bindings", ["target_id"])
+        ? scalar(db, `SELECT COUNT(*) AS value FROM import_bindings b LEFT JOIN nodes n ON n.id = b.target_id
+          WHERE b.target_id IS NOT NULL AND n.id IS NULL`)
+        : null,
+      nodeAliases: aliases,
+      danglingAliases: hasColumns(db, "node_aliases", ["canonical_node_id"])
+        ? scalar(db, `SELECT COUNT(*) AS value FROM node_aliases a LEFT JOIN nodes n ON n.id = a.canonical_node_id WHERE n.id IS NULL`)
+        : null,
       callableNodes,
       noIncomingCalls,
       noIncomingCallRate: callableNodes ? round(noIncomingCalls / callableNodes) : 0,
       noOutgoingCalls,
       noOutgoingCallRate: callableNodes ? round(noOutgoingCalls / callableNodes) : 0,
-      edgeKinds: Object.fromEntries(rows(db, "SELECT kind, COUNT(*) AS count FROM edges GROUP BY kind ORDER BY kind").map((row) => [row.kind, Number(row.count)])),
-      unresolvedKinds: Object.fromEntries(rows(db, "SELECT reference_kind AS kind, COUNT(*) AS count FROM unresolved_refs GROUP BY reference_kind ORDER BY reference_kind").map((row) => [row.kind, Number(row.count)])),
+      unresolvedKinds: hasColumns(db, "unresolved_refs", ["reference_kind"])
+        ? groupedCounts(db, "unresolved_refs", "reference_kind", hasColumns(db, "unresolved_refs", ["status"]) ? "status != 'resolved'" : null)
+        : {},
+      ...productionTestEdgeHealth(db),
+      ...health,
+      ...edgeMetrics,
+      projectMetadata: hasColumns(db, "project_metadata", ["key", "value"])
+        ? Object.fromEntries(rows(db, "SELECT key, value FROM project_metadata ORDER BY key").map((row) => [row.key, row.value]))
+        : {},
       normalizedGraphSha256: normalizedGraphHash(db),
     };
     return integrity;

--- a/evaluate/graph/lib/prepare.mjs
+++ b/evaluate/graph/lib/prepare.mjs
@@ -6,6 +6,7 @@ import { GraphDbGuard } from "../../core/artifacts.mjs";
 import { assertProcessSucceeded, runProcessSync } from "../../core/process.mjs";
 import { validateSubjectFixture } from "./fixture.mjs";
 import { inspectGraphDatabase } from "./integrity.mjs";
+import { inspectGoldCoverage } from "./coverage.mjs";
 
 function parseBuildSummary(stdout, systemId) {
   try {
@@ -75,6 +76,12 @@ export function prepareGraphEvaluation({ suite, subjectRoot, harnessRoot, output
         index: { path: snapshot, sha256: fileHash(snapshot), normalizedSha256: normalizedHashes.at(-1) },
         rebuilds,
         deterministic: new Set(normalizedHashes).size === 1,
+        goldCoverage: inspectGoldCoverage(snapshot, fixture.tasks.map((task) => ({
+          ...suite.tasks.find((entry) => entry.id === task.taskId),
+          gold: task.gold,
+          acceptableAlternates: task.acceptableAlternates,
+          mustNotReturn: task.mustNotReturn,
+        }))),
       };
     }
   } finally {
@@ -82,7 +89,7 @@ export function prepareGraphEvaluation({ suite, subjectRoot, harnessRoot, output
     rmSync(scratch, { recursive: true, force: true });
   }
   const identity = {
-    schemaVersion: 2,
+    schemaVersion: 3,
     suiteId: suite.id,
     suiteSha256,
     subject: fixture.subject,
@@ -102,6 +109,7 @@ export function prepareGraphEvaluation({ suite, subjectRoot, harnessRoot, output
     runIdentity: objectHash(identity),
     preparedAt: new Date().toISOString(),
     goldEvidence: fixture.tasks,
+    graphCoverage: Object.fromEntries(Object.entries(systems).map(([id, system]) => [id, system.goldCoverage])),
     systems,
   };
   writeFileSync(join(outputDir, "prepare.json"), `${JSON.stringify(manifest, null, 2)}\n`);

--- a/evaluate/graph/lib/report.mjs
+++ b/evaluate/graph/lib/report.mjs
@@ -53,7 +53,10 @@ function paraphraseSummary(rows) {
   }));
 }
 
-const PAIRED_METRICS = ["recallAt5", "reciprocalRank", "ndcgAt10", "completeEvidence", "outputTokensApprox", "elapsedMs", "returned"];
+const PAIRED_METRICS = [
+  "fileRecallAt5", "fileReciprocalRank", "returnedSourceSpanRecall", "directedFlowCoverage",
+  "recallAt5", "reciprocalRank", "ndcgAt10", "completeEvidence", "outputTokensApprox", "elapsedMs", "returned",
+];
 
 function pairedComparisons(rows, systemIds) {
   const byTask = groupBy(rows, (row) => row.taskId);
@@ -87,6 +90,18 @@ function pairedComparisons(rows, systemIds) {
   return comparisons;
 }
 
+function integrityMetric(prepared, systemId, metric) {
+  const integrity = prepared.systems[systemId]?.rebuilds?.at(-1)?.integrity;
+  if (!integrity || !Object.prototype.hasOwnProperty.call(integrity, metric)) {
+    return { valid: false, failure: `integrity:${systemId}:${metric} is missing from final prepared rebuild` };
+  }
+  const value = integrity[metric];
+  if (!Number.isFinite(value)) {
+    return { valid: false, failure: `integrity:${systemId}:${metric}=${String(value)} is not finite` };
+  }
+  return { valid: true, value };
+}
+
 function gateReport(suite, rows, bySystem, byCategory, prepared, runManifest, executionIdentityValid) {
   const failures = [];
   const expectedRuns = suite.tasks.length * Object.keys(suite.systems).length;
@@ -107,6 +122,16 @@ function gateReport(suite, rows, bySystem, byCategory, prepared, runManifest, ex
     }
     for (const [metric, ceiling] of Object.entries(gates.ceilings ?? {})) {
       if (!Number.isFinite(summary[metric]) || summary[metric] > ceiling) failures.push(`quality:${systemId}:${metric} ${summary[metric]} > ${ceiling}`);
+    }
+    for (const [metric, floor] of Object.entries(gates.integrityFloors ?? {})) {
+      const measured = integrityMetric(prepared, systemId, metric);
+      if (!measured.valid) failures.push(measured.failure);
+      else if (measured.value < floor) failures.push(`integrity:${systemId}:${metric} ${measured.value} < floor ${floor}`);
+    }
+    for (const [metric, ceiling] of Object.entries(gates.integrityCeilings ?? {})) {
+      const measured = integrityMetric(prepared, systemId, metric);
+      if (!measured.valid) failures.push(measured.failure);
+      else if (measured.value > ceiling) failures.push(`integrity:${systemId}:${metric} ${measured.value} > ceiling ${ceiling}`);
     }
     for (const [category, floors] of Object.entries(gates.categoryFloors ?? {})) {
       const categoryRow = byCategory[systemId]?.[category];
@@ -175,11 +200,11 @@ function markdownReport(report) {
     "",
     `Gate: **${report.gate.passed ? "PASS" : "FAIL"}**`,
     "",
-    "| system | valid | R@1 | R@5 | R@10 | MRR | complete | miss | negative | p50 tokens | p95 ms |",
+    "| system | valid | file@5 | source span | flow | graph coverage | R@5 | MRR | p50 tokens | p95 ms |",
     "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
   ];
   for (const [systemId, row] of Object.entries(report.bySystem)) {
-    lines.push(`| ${systemId} | ${row.validRuns}/${row.runs} | ${row.recallAt1 ?? "-"} | ${row.recallAt5 ?? "-"} | ${row.recallAt10 ?? "-"} | ${row.mrr ?? "-"} | ${row.completeEvidenceRate ?? "-"} | ${row.missRate ?? "-"} | ${row.negativeAccuracy ?? "-"} | ${row.outputTokensApprox.p50 ?? "-"} | ${row.latencyMs.p95 ?? "-"} |`);
+    lines.push(`| ${systemId} | ${row.validRuns}/${row.runs} | ${row.topFiveFileHitRate ?? "-"} | ${row.returnedRequiredSourceSpanRecall ?? "-"} | ${row.meanDirectedFlowCoverage ?? "-"} | ${row.graphEvidenceCoverage ?? "-"} | ${row.recallAt5 ?? "-"} | ${row.mrr ?? "-"} | ${row.outputTokensApprox.p50 ?? "-"} | ${row.latencyMs.p95 ?? "-"} |`);
   }
   if (report.gate.failures.length) {
     lines.push("", "## Gate failures", "");
@@ -224,8 +249,8 @@ export function generateGraphReport({ suite, outputDir, suppliedRows = null }) {
   report.gate = gateReport(suite, rows, bySystem, byCategory, prepared, runManifest, executionIdentityValid);
   writeFileSync(join(outputDir, "report.json"), `${JSON.stringify(report, null, 2)}\n`);
   writeFileSync(join(outputDir, "report.md"), markdownReport(report));
-  const header = ["runId", "system", "taskId", "category", "valid", "recallAt1", "recallAt5", "recallAt10", "reciprocalRank", "completeEvidence", "firstRelevantRank", "returned", "outputTokensApprox", "elapsedMs", "violations"];
-  const csvRows = rows.map((row) => [row.runId, row.system, row.taskId, row.task.category, row.valid, row.metrics.recallAt1, row.metrics.recallAt5, row.metrics.recallAt10, row.metrics.reciprocalRank, row.metrics.completeEvidence, row.metrics.firstRelevantRank, row.metrics.returned, row.metrics.outputTokensApprox, row.metrics.elapsedMs, row.violations.join("; ")]);
+  const header = ["runId", "system", "taskId", "category", "valid", "fileRecallAt5", "returnedSourceSpanRecall", "directedFlowCoverage", "graphEvidenceCoverage", "recallAt5", "reciprocalRank", "returned", "outputTokensApprox", "elapsedMs", "violations"];
+  const csvRows = rows.map((row) => [row.runId, row.system, row.taskId, row.task.category, row.valid, row.metrics.fileRecallAt5, row.metrics.returnedSourceSpanRecall, row.metrics.directedFlowCoverage, row.metrics.graphEvidenceCoverage, row.metrics.recallAt5, row.metrics.reciprocalRank, row.metrics.returned, row.metrics.outputTokensApprox, row.metrics.elapsedMs, row.violations.join("; ")]);
   writeFileSync(join(outputDir, "rows.csv"), `${[header, ...csvRows].map((line) => line.map(csv).join(",")).join("\n")}\n`);
   return report;
 }

--- a/evaluate/graph/lib/runner.mjs
+++ b/evaluate/graph/lib/runner.mjs
@@ -1,15 +1,36 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { GraphDbGuard } from "../../core/artifacts.mjs";
+import { GraphDbGuard, restoreGraphDbAndRemoveScratch } from "../../core/artifacts.mjs";
 import { commandBundleIdentity, fileHash, objectHash, repositoryIdentity } from "../../core/hash.mjs";
 import { parseJsonLines, validateGraphResponse } from "../../core/jsonl.mjs";
 import { runProcess } from "../../core/process.mjs";
 import { gradeRetrieval } from "../../graders/retrieval.mjs";
 import { expectedGraphCommand, graphSuiteHash, graphTaskArgs } from "../../schemas/graph-suite.mjs";
 import { loadPreparedGraphEvaluation } from "./prepare.mjs";
+import { coverageForTask } from "./coverage.mjs";
 
 function safeId(value) {
   return value.replace(/[^a-zA-Z0-9_-]+/g, "-");
+}
+
+function preparedRunIdentity(prepared) {
+  const systems = Object.fromEntries(Object.entries(prepared.systems ?? {}).map(([id, system]) => [id, {
+    command: system.command,
+    bundleSha256: system.cli?.bundleSha256 ?? null,
+    indexSha256: system.index?.sha256 ?? null,
+    normalizedIndexSha256: system.index?.normalizedSha256 ?? null,
+  }]));
+  return objectHash({
+    schemaVersion: prepared.schemaVersion,
+    suiteId: prepared.suiteId,
+    suiteSha256: prepared.suiteSha256,
+    subject: prepared.subject,
+    harness: prepared.harness,
+    systems,
+    runtime: prepared.runtime,
+    environment: prepared.environment,
+    invocation: prepared.invocation,
+  });
 }
 
 export function buildGraphSchedule(suite) {
@@ -27,11 +48,33 @@ export function buildGraphSchedule(suite) {
   });
 }
 
-function assertPreparedIdentity({ suite, subjectRoot, systemCommands, prepared }) {
+function assertPreparedIdentity({
+  suite, subjectRoot, systemCommands, prepared, preparePath, prepareSha256,
+  runManifestPath, runningManifestSha256,
+}) {
+  if (prepared.schemaVersion === 3 && prepared.runIdentity
+    && preparedRunIdentity(prepared) !== prepared.runIdentity) {
+    throw new Error("prepared run identity is invalid");
+  }
+  if (preparePath && prepareSha256
+    && (!existsSync(preparePath) || fileHash(preparePath) !== prepareSha256)) {
+    throw new Error("prepared run manifest changed during graph evaluation");
+  }
+  if (runManifestPath && runningManifestSha256
+    && (!existsSync(runManifestPath) || fileHash(runManifestPath) !== runningManifestSha256)) {
+    throw new Error("active run manifest changed during graph evaluation");
+  }
   if (graphSuiteHash(suite) !== prepared.suiteSha256) throw new Error("suite or task fixture changed after preparation");
   const subject = repositoryIdentity(subjectRoot);
   if (subject.sha !== prepared.subject.sha || subject.treeStateSha256 !== prepared.subject.treeStateSha256) {
     throw new Error("subject repository changed after preparation");
+  }
+  if (prepared.harness?.root) {
+    const harness = repositoryIdentity(prepared.harness.root);
+    if (harness.sha !== prepared.harness.sha
+      || harness.treeStateSha256 !== prepared.harness.treeStateSha256) {
+      throw new Error("evaluation harness changed after preparation");
+    }
   }
   for (const [systemId, command] of Object.entries(systemCommands)) {
     const system = prepared.systems?.[systemId];
@@ -42,6 +85,15 @@ function assertPreparedIdentity({ suite, subjectRoot, systemCommands, prepared }
     if (!existsSync(system.index.path) || fileHash(system.index.path) !== system.index.sha256) {
       throw new Error(`system ${systemId} graph snapshot changed after preparation`);
     }
+  }
+}
+
+function assertScheduleIdentity(context, checkpoint) {
+  try {
+    assertPreparedIdentity(context);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`graph evaluation identity drift ${checkpoint}: ${message}`, { cause: error });
   }
 }
 
@@ -62,8 +114,13 @@ export async function runGraphEvaluation({
   maxOutputBytes = 32 * 1024 * 1024,
   resume = false,
 }) {
+  const preparePath = join(outputDir, "prepare.json");
+  const prepareSha256 = fileHash(preparePath);
   const prepared = loadPreparedGraphEvaluation(outputDir);
-  assertPreparedIdentity({ suite, subjectRoot, systemCommands, prepared });
+  const identityContext = {
+    suite, subjectRoot, systemCommands, prepared, preparePath, prepareSha256,
+  };
+  assertPreparedIdentity(identityContext);
   const schedule = buildGraphSchedule(suite);
   const runConfig = { timeoutMs, maxOutputBytes };
   const runIdentity = objectHash({ preparedRunIdentity: prepared.runIdentity, runConfig, schedule: schedule.map(({ runId, taskIndex, orderIndex, systemId }) => ({ runId, taskIndex, orderIndex, systemId })) });
@@ -90,70 +147,111 @@ export async function runGraphEvaluation({
     schedule: schedule.map(({ runId, taskIndex, orderIndex, systemId }) => ({ runId, taskIndex, orderIndex, systemId })),
   };
   writeFileSync(manifestPath, `${JSON.stringify(baseManifest, null, 2)}\n`);
+  const runningManifestSha256 = fileHash(manifestPath);
+  const scheduleIdentityContext = {
+    ...identityContext, runManifestPath: manifestPath, runningManifestSha256,
+  };
   const guard = new GraphDbGuard(subjectRoot, scratch);
   const rows = [];
+  let activeRunId = null;
   try {
-    for (const item of schedule) {
-      const resultPath = join(runsDir, `${item.runId}.json`);
-      const expectedIdentity = { runIdentity, runId: item.runId, taskId: item.task.id, system: item.systemId };
-      if (existsSync(resultPath)) {
-        if (!resume) throw new Error(`result already exists: ${resultPath}`);
-        const rawStdout = join(rawDir, `${item.runId}.stdout.jsonl`);
-        const rawStderr = join(rawDir, `${item.runId}.stderr.txt`);
-        if (!existsSync(rawStdout) || !existsSync(rawStderr)) throw new Error(`resume result is missing raw output: ${item.runId}`);
-        rows.push(existingResult(resultPath, expectedIdentity));
-        continue;
+    try {
+      for (const item of schedule) {
+        activeRunId = item.runId;
+        assertScheduleIdentity(scheduleIdentityContext, `before ${item.runId}`);
+        const resultPath = join(runsDir, `${item.runId}.json`);
+        const expectedIdentity = { runIdentity, runId: item.runId, taskId: item.task.id, system: item.systemId };
+        if (existsSync(resultPath)) {
+          if (!resume) throw new Error(`result already exists: ${resultPath}`);
+          const rawStdout = join(rawDir, `${item.runId}.stdout.jsonl`);
+          const rawStderr = join(rawDir, `${item.runId}.stderr.txt`);
+          if (!existsSync(rawStdout) || !existsSync(rawStderr)) throw new Error(`resume result is missing raw output: ${item.runId}`);
+          rows.push(existingResult(resultPath, expectedIdentity));
+          assertScheduleIdentity(scheduleIdentityContext, `after ${item.runId}`);
+          continue;
+        }
+        const preparedSystem = prepared.systems[item.systemId];
+        guard.activate(preparedSystem.index.path);
+        const command = systemCommands[item.systemId];
+        const args = [...command.slice(1), ...graphTaskArgs(item.task)];
+        process.stderr.write(`[eval:graph] ${item.runId}\n`);
+        const processResult = await runProcess(command[0], args, { cwd: subjectRoot, timeoutMs, maxOutputBytes });
+        writeFileSync(join(rawDir, `${item.runId}.stdout.jsonl`), processResult.stdout);
+        writeFileSync(join(rawDir, `${item.runId}.stderr.txt`), processResult.stderr);
+        // A subject can be nested below the harness repository. Restore the
+        // original graph before hashing either tree so the evaluator's own
+        // temporary DB swap cannot appear as harness/source drift.
+        guard.restore();
+        // A query may overlap an editor/build process. Preserve its raw output
+        // for diagnosis, but never grade it against a source tree, CLI bundle,
+        // prepared snapshot, or run manifest that changed while it executed.
+        assertScheduleIdentity(scheduleIdentityContext, `after ${item.runId}`);
+        const parsed = parseJsonLines(processResult.stdout, item.runId);
+        const allowError = item.task.expect?.noResult === true || (item.task.expect?.errorCodes?.length ?? 0) > 0;
+        const violations = [...parsed.errors];
+        if (processResult.timedOut) violations.push("command timed out");
+        if (processResult.error) violations.push(`command error: ${processResult.error.message}`);
+        if (processResult.code !== 0) violations.push(`command exited ${processResult.code}`);
+        violations.push(...validateGraphResponse(parsed.records, expectedGraphCommand(item.task), {
+          allowErrorRecords: allowError,
+          allowTerminalError: allowError,
+        }));
+        const preparedGold = prepared.goldEvidence?.find((entry) => entry.taskId === item.task.id);
+        const evaluatedTask = preparedGold ? {
+          ...item.task,
+          gold: preparedGold.gold,
+          acceptableAlternates: preparedGold.acceptableAlternates,
+          mustNotReturn: preparedGold.mustNotReturn,
+        } : item.task;
+        const graphCoverage = coverageForTask(prepared.graphCoverage?.[item.systemId] ?? preparedSystem.goldCoverage, item.task.id);
+        const metrics = gradeRetrieval(evaluatedTask, parsed.records, processResult, graphCoverage);
+        if (!metrics.errorExpectationMet) {
+          violations.push(
+            `unexpected error code(s) ${metrics.unexpectedErrorCodes.join(", ")}; allowed codes are `
+            + `${(item.task.expect?.errorCodes ?? []).join(", ") || "none"}`,
+          );
+        }
+        const row = {
+          schemaVersion: 2,
+          ...expectedIdentity,
+          taskIndex: item.taskIndex,
+          orderIndex: item.orderIndex,
+          task: evaluatedTask,
+          graphCoverage,
+          command: processResult.command,
+          process: {
+            code: processResult.code,
+            signal: processResult.signal,
+            timedOut: processResult.timedOut,
+            elapsedMs: processResult.elapsedMs,
+            stdoutBytes: processResult.stdoutBytes,
+            stderrBytes: processResult.stderrBytes,
+          },
+          metrics,
+          valid: violations.length === 0,
+          violations,
+        };
+        writeFileSync(resultPath, `${JSON.stringify(row, null, 2)}\n`);
+        rows.push(row);
       }
-      const preparedSystem = prepared.systems[item.systemId];
-      guard.activate(preparedSystem.index.path);
-      const command = systemCommands[item.systemId];
-      const args = [...command.slice(1), ...graphTaskArgs(item.task)];
-      process.stderr.write(`[eval:graph] ${item.runId}\n`);
-      const processResult = await runProcess(command[0], args, { cwd: subjectRoot, timeoutMs, maxOutputBytes });
-      writeFileSync(join(rawDir, `${item.runId}.stdout.jsonl`), processResult.stdout);
-      writeFileSync(join(rawDir, `${item.runId}.stderr.txt`), processResult.stderr);
-      const parsed = parseJsonLines(processResult.stdout, item.runId);
-      const allowError = item.task.expect?.noResult === true || (item.task.expect?.errorCodes?.length ?? 0) > 0;
-      const violations = [...parsed.errors];
-      if (processResult.timedOut) violations.push("command timed out");
-      if (processResult.error) violations.push(`command error: ${processResult.error.message}`);
-      if (processResult.code !== 0) violations.push(`command exited ${processResult.code}`);
-      violations.push(...validateGraphResponse(parsed.records, expectedGraphCommand(item.task), {
-        allowErrorRecords: allowError,
-        allowTerminalError: allowError,
-      }));
-      const metrics = gradeRetrieval(item.task, parsed.records, processResult);
-      if (!metrics.errorExpectationMet) {
-        violations.push(
-          `unexpected error code(s) ${metrics.unexpectedErrorCodes.join(", ")}; allowed codes are `
-          + `${(item.task.expect?.errorCodes ?? []).join(", ") || "none"}`,
-        );
-      }
-      const row = {
-        schemaVersion: 2,
-        ...expectedIdentity,
-        taskIndex: item.taskIndex,
-        orderIndex: item.orderIndex,
-        task: item.task,
-        command: processResult.command,
-        process: {
-          code: processResult.code,
-          signal: processResult.signal,
-          timedOut: processResult.timedOut,
-          elapsedMs: processResult.elapsedMs,
-          stdoutBytes: processResult.stdoutBytes,
-          stderrBytes: processResult.stderrBytes,
-        },
-        metrics,
-        valid: violations.length === 0,
-        violations,
-      };
-      writeFileSync(resultPath, `${JSON.stringify(row, null, 2)}\n`);
-      rows.push(row);
+      activeRunId = null;
+      assertScheduleIdentity(scheduleIdentityContext, "after schedule");
+    } finally {
+      restoreGraphDbAndRemoveScratch(guard, scratch);
     }
-  } finally {
-    guard.restore();
-    rmSync(scratch, { recursive: true, force: true });
+    assertScheduleIdentity(scheduleIdentityContext, "before completion");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const manifest = {
+      ...baseManifest,
+      status: "aborted",
+      completedAt: new Date().toISOString(),
+      resultCount: rows.length,
+      ...(activeRunId ? { failedRunId: activeRunId } : {}),
+      error: message,
+    };
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    throw error;
   }
   const manifest = { ...baseManifest, status: "complete", completedAt: new Date().toISOString(), resultCount: rows.length };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/evaluate/graph/test/agent-adapters.test.mjs
+++ b/evaluate/graph/test/agent-adapters.test.mjs
@@ -9,14 +9,16 @@ const task = {
   gold: [{ symbol: "TargetSymbol", kind: "function", path: "src/subject.ts" }],
   expectedSymbols: ["TargetSymbol"],
 };
-const answer = { answer: "TargetSymbol implements it.", symbols: ["TargetSymbol"], evidence: [{ path: "src/subject.ts", line: 1 }], complete: true };
+const answer = { answer: "TargetSymbol is declared in the cited source and implements the requested behavior.", symbols: ["TargetSymbol"], evidence: [{ path: "src/subject.ts", line: 1 }], complete: true };
 const fact = '{"type":"fact","name":"TargetSymbol","kind":"function","filePath":"src/subject.ts"}\n';
 
 test("Claude adapter keeps cache composition and computes new-token work", () => {
   const raw = [
-    { type: "assistant", message: { usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: 'node mex.js graph scope "question"' } }] } },
+    { type: "assistant", message: { id: "m1", usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: 'node mex.js graph scope "question"' } }] } },
+    { type: "system", subtype: "hook_started", hook_id: "h1", hook_name: "PreToolUse:Bash", hook_event: "PreToolUse" },
+    { type: "system", subtype: "hook_response", hook_id: "h1", hook_name: "PreToolUse:Bash", hook_event: "PreToolUse", output: "{}\n", stdout: "{}\n", stderr: "", exit_code: 0, outcome: "success" },
     { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "t1", content: fact }] } },
-    { type: "result", structured_output: answer, total_cost_usd: 0.25, num_turns: 1, permission_denials: [] },
+    { type: "result", structured_output: answer, usage: { input_tokens: 11, cache_creation_input_tokens: 12, cache_read_input_tokens: 13, output_tokens: 14 }, total_cost_usd: 0.25, num_turns: 1, permission_denials: [] },
   ].map(JSON.stringify).join("\n");
   const parsed = claudeAdapter.parseTranscript(raw, task);
   assert.deepEqual({
@@ -28,7 +30,50 @@ test("Claude adapter keeps cache composition and computes new-token work", () =>
     newTokens: parsed.usage.newTokens,
   }, { uncachedInput: 11, cacheWrite: 12, cacheRead: 13, output: 14, reportedTotal: 50, newTokens: 37 });
   assert.equal(parsed.graph.initialScopeRank, 1);
+  assert.equal(parsed.usage.accountingValid, true);
+  assert.equal(parsed.bashGuardLifecycle.valid, true);
+  assert.equal(parsed.bashGuardLifecycle.complete, 1);
   assert.equal(parsed.structured.ok, true);
+});
+
+test("Claude adapter deduplicates terminal permission denials by tool_use_id", () => {
+  const denial = { tool_name: "Bash", tool_use_id: "denied-1", reason: "blocked by eval guard" };
+  const raw = [
+    { type: "assistant", message: { id: "m-denied", usage: { input_tokens: 2, cache_creation_input_tokens: 3, cache_read_input_tokens: 5, output_tokens: 7 }, content: [{ type: "tool_use", id: "denied-1", name: "Bash", input: { command: "git status" } }] } },
+    { type: "system", subtype: "hook_started", hook_id: "h-denied", hook_name: "PreToolUse:Bash", hook_event: "PreToolUse" },
+    { type: "system", subtype: "hook_response", hook_id: "h-denied", hook_name: "PreToolUse:Bash", hook_event: "PreToolUse", output: "denied", stdout: "denied", stderr: "", exit_code: 0, outcome: "success" },
+    { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "denied-1", content: "MEX_EVAL_BASH_DENIED: unrelated Bash command", is_error: true }] } },
+    { type: "result", structured_output: answer, usage: { input_tokens: 2, cache_creation_input_tokens: 3, cache_read_input_tokens: 5, output_tokens: 7 }, permission_denials: [denial, { ...denial }] },
+  ].map(JSON.stringify).join("\n");
+  const parsed = claudeAdapter.parseTranscript(raw, task);
+  assert.equal(parsed.permissionDenials, 1);
+  assert.equal(parsed.permissionDenialDetails.length, 1);
+  assert.equal(parsed.duplicatePermissionDenials, 1);
+  assert.equal(parsed.unmatchedPermissionDenials, 0);
+  assert.equal(parsed.toolCalls[0].status, "denied");
+  assert.equal(parsed.bashGuardLifecycle.valid, true);
+});
+
+test("Claude adapter deduplicates repeated assistant message IDs and rejects terminal mismatches", () => {
+  const assistant = { type: "assistant", message: { id: "same", usage: { input_tokens: 2, cache_creation_input_tokens: 3, cache_read_input_tokens: 5, output_tokens: 7 }, content: [] } };
+  const valid = claudeAdapter.parseTranscript([
+    assistant,
+    assistant,
+    { type: "result", structured_output: answer, usage: { input_tokens: 2, cache_creation: 3, cache_read: 5, output_tokens: 7 } },
+  ].map(JSON.stringify).join("\n"), task);
+  assert.equal(valid.usage.accountingValid, true);
+  assert.equal(valid.usage.perMessage.uniqueMessageCount, 1);
+  assert.equal(valid.usage.perMessage.duplicateEventCount, 1);
+  assert.equal(valid.usage.reportedTotal, 17);
+
+  const invalid = claudeAdapter.parseTranscript([
+    assistant,
+    { type: "result", structured_output: answer, usage: { input_tokens: 99, cache_creation: 3, cache_read: 5, output_tokens: 7 } },
+  ].map(JSON.stringify).join("\n"), task);
+  assert.equal(invalid.usage.accountingValid, false);
+  assert.equal(invalid.usage.newTokens, null);
+  assert.equal(invalid.usage.terminal.inputTokens, 99);
+  assert.equal(invalid.usage.perMessage.inputTokens, 2);
 });
 
 test("Codex adapter subtracts cached input while preserving the raw usage event", () => {
@@ -55,9 +100,26 @@ test("Codex adapter subtracts cached input while preserving the raw usage event"
 });
 
 test("headless invocations are ephemeral and use local CLI authentication paths", () => {
-  const claude = claudeAdapter.buildInvocation({ prompt: "p", model: "m", schema: ANSWER_SCHEMA, subjectRoot: "/repo" });
+  const claude = claudeAdapter.buildInvocation({
+    prompt: "p", model: "m", schema: ANSWER_SCHEMA, subjectRoot: "/repo",
+    tools: "Read,Grep,Glob,Bash",
+    allowedTools: ["Read", "Grep", "Glob", "Bash(node /tmp/graph-command.mjs graph *)"],
+    settingsPath: "/tmp/claude-settings.json",
+  });
   assert.equal(claude.command, "claude");
   assert.equal(claude.args.includes("--no-session-persistence"), true);
+  assert.equal(claude.args.includes("--safe-mode"), false);
+  assert.equal(claude.args[claude.args.indexOf("--settings") + 1], "/tmp/claude-settings.json");
+  assert.equal(claude.args[claude.args.indexOf("--setting-sources") + 1], "");
+  assert.equal(claude.args[claude.args.indexOf("--permission-mode") + 1], "dontAsk");
+  assert.equal(claude.args[claude.args.indexOf("--tools") + 1], "Read,Grep,Glob,Bash");
+  assert.deepEqual(claude.args.slice(claude.args.indexOf("--allowedTools") + 1), [
+    "Read", "Grep", "Glob", "Bash(node /tmp/graph-command.mjs graph *)",
+  ]);
+  assert.equal(claude.args.includes("--strict-mcp-config"), true);
+  assert.equal(claude.args.includes("--no-chrome"), true);
+  assert.equal(claude.args.includes("--disable-slash-commands"), true);
+  assert.equal(claude.args.includes("--include-hook-events"), true);
   const codex = codexAdapter.buildInvocation({ prompt: "p", model: "m", schemaPath: "/tmp/schema.json", subjectRoot: "/repo" });
   assert.equal(codex.command, "codex");
   assert.equal(codex.args.slice(0, 2).join(" "), "exec --ephemeral");

--- a/evaluate/graph/test/fixtures/fake-graph.mjs
+++ b/evaluate/graph/test/fixtures/fake-graph.mjs
@@ -1,4 +1,5 @@
-import { mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -42,6 +43,17 @@ else if (mode === "failure") {
 } else if (mode === "malformed") {
   process.stdout.write("not-json\n");
 } else if (args[0] === "graph" && args[1] === "scope") {
+  const mutateThisQuery = !process.env.FAKE_GRAPH_MUTATE_QUERY
+    || process.env.FAKE_GRAPH_MUTATE_QUERY === args[2];
+  if (mutateThisQuery && process.env.FAKE_GRAPH_MUTATE_SUBJECT === "1") {
+    appendFileSync(join("src", "subject.ts"), "// concurrent source drift\n");
+  }
+  if (mutateThisQuery && process.env.FAKE_GRAPH_MUTATE_BUNDLE === "1") {
+    appendFileSync(fileURLToPath(import.meta.url), "\n// concurrent bundle drift\n");
+  }
+  if (mutateThisQuery && process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH) {
+    appendFileSync(process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH, "\n// concurrent evaluator drift\n");
+  }
   emit({ type: "meta", schemaVersion: 1, command: "graph scope", task: args[2], detail: "minimal", maxNodes: 10, maxOutputTokens: 1_000 });
   if (mode !== "miss") emit({ type: "fact", id: "function:target", kind: "function", name: "TargetSymbol", qualifiedName: "TargetSymbol", filePath: "src/subject.ts", language: "typescript", startLine: 1, endLine: 1 });
   emit({ type: "summary", matchedNodes: mode === "miss" ? 0 : 1, returnedNodes: mode === "miss" ? 0 : 1, returnedEdges: 0, maxOutputTokens: 1_000, truncated: false, suggestedNextCommands: [], estimatedOutputTokens: 100 });

--- a/evaluate/graph/test/graph-eval.test.mjs
+++ b/evaluate/graph/test/graph-eval.test.mjs
@@ -1,20 +1,26 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
-import { assertGraphOutputIsolation } from "../../core/artifacts.mjs";
-import { commandBundleIdentity } from "../../core/hash.mjs";
+import { assertGraphOutputIsolation, restoreGraphDbAndRemoveScratch } from "../../core/artifacts.mjs";
+import { commandBundleIdentity, repositoryIdentity } from "../../core/hash.mjs";
 import { parseJsonLines, validateGraphResponse } from "../../core/jsonl.mjs";
 import { gradeRetrieval, summarizeRetrievalRows } from "../../graders/retrieval.mjs";
-import { loadGraphSuite, validateGraphSuite } from "../../schemas/graph-suite.mjs";
+import { graphTaskArgs, loadGraphSuite, validateGraphSuite } from "../../schemas/graph-suite.mjs";
 import { validateEvidenceInSource } from "../lib/fixture.mjs";
+import { inspectGoldCoverage } from "../lib/coverage.mjs";
+import { inspectGraphDatabase } from "../lib/integrity.mjs";
 import { prepareGraphEvaluation } from "../lib/prepare.mjs";
 import { generateGraphReport } from "../lib/report.mjs";
 import { runGraphEvaluation } from "../lib/runner.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const { DatabaseSync } = require("node:sqlite");
 const HARNESS_ROOT = resolve(HERE, "..", "..", "..");
 const FAKE = join(HERE, "fixtures", "fake-graph.mjs");
 
@@ -40,12 +46,14 @@ function positiveTask() {
   };
 }
 
-function fixture() {
+function fixture(gates = null) {
   const subjectRoot = mkdtempSync(join(tmpdir(), "mex-graph-subject-"));
   mkdirSync(join(subjectRoot, "src"), { recursive: true });
   writeFileSync(join(subjectRoot, "src", "subject.ts"), "export function TargetSymbol() {}\nexport function OtherSymbol() {}\n");
   const suitePath = join(subjectRoot, "suite.json");
-  writeFileSync(suitePath, `${JSON.stringify(rawSuite([positiveTask()]), null, 2)}\n`);
+  const suite = rawSuite([positiveTask()]);
+  if (gates) suite.gates = gates;
+  writeFileSync(suitePath, `${JSON.stringify(suite, null, 2)}\n`);
   return { subjectRoot, suite: loadGraphSuite(suitePath), outputDir: mkdtempSync(join(tmpdir(), "mex-graph-output-")) };
 }
 
@@ -55,6 +63,120 @@ test("suite schema rejects empty, duplicate, and underspecified task fixtures", 
   assert.throws(() => validateGraphSuite(duplicate), /duplicated/);
   const noGold = rawSuite([{ id: "bad", category: "scope", operation: "scope", query: "x", gold: [] }]);
   assert.throws(() => validateGraphSuite(noGold), /at least 1 evidence/);
+});
+
+test("suite scope options validate and forward maxFiles", () => {
+  const task = { ...positiveTask(), options: { maxFiles: 7 } };
+  assert.doesNotThrow(() => validateGraphSuite(rawSuite([task])));
+  assert.deepEqual(graphTaskArgs(task).slice(-2), ["--max-files", "7"]);
+  assert.throws(() => validateGraphSuite(rawSuite([{ ...positiveTask(), options: { maxFiles: 0 } }])), /positive integer/);
+});
+
+test("suite integrity thresholds must be finite numeric metric maps", () => {
+  const nonfinite = rawSuite([positiveTask()]);
+  nonfinite.gates.integrityFloors = { nodes: Number.NaN };
+  assert.throws(() => validateGraphSuite(nonfinite), /gates\.integrityFloors\.nodes must be a finite number/);
+
+  const wrongShape = rawSuite([positiveTask()]);
+  wrongShape.gates.integrityCeilings = [];
+  assert.throws(() => validateGraphSuite(wrongShape), /gates\.integrityCeilings must be an object/);
+});
+
+test("v2 integrity hashing includes semantic metadata but ignores timestamps", () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-integrity-v2-"));
+  const path = join(root, "graph.db");
+  const db = new DatabaseSync(path);
+  db.exec(readFileSync(join(HARNESS_ROOT, "src", "graph", "schema.sql"), "utf8"));
+  db.prepare(`INSERT INTO files (
+    path, content_hash, language, size, modified_at, indexed_at, node_count, errors,
+    parse_status, diagnostic_count, missing_count, error_coverage, extractor_version
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "src/a.ts", "file-hash", "typescript", 100, 1, 2, 1, "[]", "partial", 2, 1, 0.1, "typescript-5.9.3",
+  );
+  db.prepare(`INSERT INTO nodes (
+    id, kind, name, qualified_name, container_id, identity_key, file_path, language,
+    start_line, end_line, start_column, end_column, body_hash, updated_at
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "node:a", "function", "a", "a", null, "identity:a", "src/a.ts", "typescript", 1, 3, 0, 1, "body", 3,
+  );
+  db.prepare(`INSERT INTO edges (
+    source, target, kind, line, col, provenance, confidence, resolution_method, evidence
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "node:a", "node:a", "calls", 2, 1, "compiler", 0.85, "typescript-symbol", "{\"site\":\"direct\"}",
+  );
+  db.prepare(`INSERT INTO unresolved_refs (
+    ref_key, from_node_id, reference_name, reference_kind, line, col, file_path, language,
+    status, target_id, confidence, resolver
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "ref:a", "node:a", "a", "calls", 2, 1, "src/a.ts", "typescript", "resolved", "node:a", 1, "typescript-symbol",
+  );
+  db.prepare(`INSERT INTO import_bindings (
+    binding_key, file_path, local_name, imported_name, module_specifier, resolved_file_path, target_id, is_type_only
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "binding:a", "src/a.ts", "a", "a", "./a", "src/a.ts", "node:a", 0,
+  );
+  db.prepare("INSERT INTO node_aliases VALUES (?, ?, ?, ?, ?)").run("old:a", "node:a", "qualified-name", 1, 4);
+  db.prepare(`INSERT INTO source_chunks (
+    file_path, start_line, end_line, content_hash, path_terms, identifier_terms, comment_terms
+  ) VALUES (?, ?, ?, ?, ?, ?, ?)`).run("src/a.ts", 1, 3, "file-hash", "src a ts", "a", "");
+  db.prepare(`INSERT INTO source_chunks_fts (
+    rowid, path_terms, identifier_terms, comment_terms, source_text
+  ) VALUES (?, ?, ?, ?, ?)`).run(1, "src a ts", "a", "", "function a() {}");
+  db.prepare("INSERT INTO project_metadata VALUES (?, ?, ?)").run("compiler_version", "5.9.3", 5);
+  db.close();
+
+  const first = inspectGraphDatabase(path, { nodesCreated: 1 });
+  assert.equal(first.schemaVersion, 2);
+  assert.deepEqual(first.parseStatusCounts, { partial: 1 });
+  assert.equal(first.totalDiagnostics, 2);
+  assert.equal(first.resolvedReferences, 1);
+  assert.equal(first.unresolvedReferences, 0);
+  assert.equal(first.traversableEdges, 1);
+  assert.deepEqual(first.edgeProvenance, { compiler: 1 });
+  assert.equal(first.sourceChunkFtsRowDelta, 0);
+  assert.equal(first.danglingAliases, 0);
+
+  const timestamps = new DatabaseSync(path);
+  timestamps.exec("UPDATE files SET modified_at = 100, indexed_at = 200; UPDATE nodes SET updated_at = 300; UPDATE project_metadata SET updated_at = 400; UPDATE node_aliases SET created_at = 500");
+  timestamps.close();
+  assert.equal(inspectGraphDatabase(path).normalizedGraphSha256, first.normalizedGraphSha256);
+
+  const semantic = new DatabaseSync(path);
+  semantic.exec("UPDATE edges SET confidence = 0.75");
+  semantic.close();
+  const changed = inspectGraphDatabase(path);
+  assert.notEqual(changed.normalizedGraphSha256, first.normalizedGraphSha256);
+  assert.equal(changed.belowFlowThresholdEdges, 1);
+});
+
+test("production-to-test integrity permits proven callback wiring but rejects unsupported edges", () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-prod-test-"));
+  const path = join(root, "graph.db");
+  const db = new DatabaseSync(path);
+  db.exec(readFileSync(join(HARNESS_ROOT, "src", "graph", "schema.sql"), "utf8"));
+  const insertFile = db.prepare(`INSERT INTO files (
+    path, content_hash, language, size, modified_at, indexed_at, node_count
+  ) VALUES (?, ?, 'typescript', 1, 1, 1, ?)`);
+  insertFile.run("src/subject.ts", "prod", 1);
+  insertFile.run("src/subject.test.ts", "test", 2);
+  const insertNode = db.prepare(`INSERT INTO nodes (
+    id, kind, name, qualified_name, identity_key, file_path, language,
+    start_line, end_line, start_column, end_column, updated_at
+  ) VALUES (?, 'function', ?, ?, ?, ?, 'typescript', 1, 1, 0, 1, 1)`);
+  insertNode.run("prod", "invoke", "invoke", "identity:prod", "src/subject.ts");
+  insertNode.run("callback", "<callback:invoke[0]>", "test::<callback:invoke[0]>", "identity:callback", "src/subject.test.ts");
+  insertNode.run("unsupported", "unrelated", "test::unrelated", "identity:unsupported", "src/subject.test.ts");
+  db.prepare(`INSERT INTO edges (
+    source, target, kind, line, col, provenance, confidence, resolution_method, evidence
+  ) VALUES ('prod', 'callback', 'calls', 10, 1, 'callback-synthesis', 0.85, 'typescript-callback-parameter', ?)`)
+    .run(JSON.stringify([{ argumentIndex: 0, parameterName: "callback", wiringSite: "invoke(() => work())" }]));
+  db.prepare(`INSERT INTO edges (
+    source, target, kind, line, col, provenance, confidence, resolution_method, evidence
+  ) VALUES ('prod', 'unsupported', 'calls', 11, 1, 'typescript-compiler', 1, 'typescript-symbol', '[]')`).run();
+  db.close();
+  const integrity = inspectGraphDatabase(path);
+  assert.equal(integrity.suspiciousProductionToTestEdges, 1);
+  assert.equal(integrity.suspiciousProductionToTestEdgeSamples[0].target, "unsupported");
 });
 
 test("graph outputs cannot place source artifacts in the indexed subject", () => {
@@ -70,6 +192,40 @@ test("CLI provenance recognizes PATH-resolved Node launchers", () => {
   assert.match(identity.bundleSha256, /^[a-f0-9]{64}$/);
 });
 
+test("repository identity ignores only GraphDbGuard artifacts in repositories that do not ignore .mex", () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-identity-graph-db-"));
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "src", "subject.ts"), "export const subject = true;\n");
+  for (const args of [["init", "-q"], ["config", "user.email", "eval@example.invalid"], ["config", "user.name", "Eval Test"], ["add", "src/subject.ts"], ["commit", "-qm", "fixture"]]) {
+    const result = spawnSync("git", args, { cwd: root, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+  }
+
+  const baseline = repositoryIdentity(root).treeStateSha256;
+  mkdirSync(join(root, ".mex"), { recursive: true });
+  for (const name of ["graph.db", "graph.db-shm", "graph.db-wal"]) {
+    writeFileSync(join(root, ".mex", name), `generated-${name}`);
+  }
+  assert.equal(repositoryIdentity(root).treeStateSha256, baseline);
+
+  writeFileSync(join(root, ".mex", "other-generated.txt"), "must remain visible");
+  assert.notEqual(repositoryIdentity(root).treeStateSha256, baseline);
+});
+
+test("graph restore cleanup retains recovery scratch when restore throws", () => {
+  const scratch = mkdtempSync(join(tmpdir(), "mex-graph-restore-scratch-"));
+  const backup = join(scratch, "original.graph.db");
+  writeFileSync(backup, "recoverable");
+  try {
+    assert.throws(() => restoreGraphDbAndRemoveScratch({
+      restore() { throw new Error("restore failed"); },
+    }, scratch), /restore failed/);
+    assert.equal(readFileSync(backup, "utf8"), "recoverable");
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+});
+
 test("source evidence validation rejects stale, escaping, and ambiguous declarations", () => {
   const root = mkdtempSync(join(tmpdir(), "mex-gold-"));
   mkdirSync(join(root, "src"));
@@ -79,7 +235,7 @@ test("source evidence validation rejects stale, escaping, and ambiguous declarat
   assert.throws(() => validateEvidenceInSource(root, { symbol: "Same", kind: "function", path: "../outside.ts" }), /escapes/);
 });
 
-test("retrieval grading requires exact symbol, kind, and path and keeps misses in MRR", () => {
+test("retrieval grading keys on symbol, path, and source span while treating kind as advisory", () => {
   const task = {
     ...positiveTask(),
     gold: [
@@ -88,16 +244,199 @@ test("retrieval grading requires exact symbol, kind, and path and keeps misses i
     ],
   };
   const wrongSubstring = { type: "fact", name: "TargetSymbolHelper", kind: "function", filePath: "src/subject.ts" };
-  const exact = { type: "fact", name: "TargetSymbol", kind: "function", filePath: "src/subject.ts" };
-  const metrics = gradeRetrieval(task, [wrongSubstring, exact], { stdout: "x", elapsedMs: 1 });
-  assert.equal(metrics.goldRanks[0].rank, 2);
+  const wrongSpan = { type: "fact", name: "TargetSymbol", kind: "class", filePath: "src/subject.ts", startLine: 20, endLine: 30 };
+  const exact = { type: "fact", name: "TargetSymbol", kind: "class", filePath: "src/subject.ts", startLine: 1, endLine: 2 };
+  task.gold[0].startLine = 1;
+  task.gold[0].endLine = 1;
+  const metrics = gradeRetrieval(task, [wrongSubstring, wrongSpan, exact], { stdout: "x", elapsedMs: 1 });
+  assert.equal(metrics.goldRanks[0].rank, 3);
   assert.equal(metrics.goldRanks[1].rank, null);
   assert.equal(metrics.completeEvidence, false);
   const rows = [
     { valid: true, task, metrics },
     { valid: true, task, metrics: { ...metrics, reciprocalRank: 0, goldRanks: metrics.goldRanks.map((entry) => ({ ...entry, rank: null })) } },
   ];
-  assert.equal(summarizeRetrievalRows(rows).mrr, 0.25);
+  assert.equal(summarizeRetrievalRows(rows).mrr, 0.1666);
+});
+
+test("first-response file and source aggregates apply only to source-bearing Scope", () => {
+  const evidence = [{ ...positiveTask().gold[0], startLine: 1, endLine: 1 }];
+  const scopeTask = { ...positiveTask(), operation: "scope", gold: evidence };
+  const queryTask = { ...positiveTask(), id: "query", operation: "query", relation: "where-defined", gold: evidence };
+  const covered = gradeRetrieval(scopeTask, [
+    { type: "fact", name: "TargetSymbol", filePath: "src/subject.ts", startLine: 1, endLine: 1 },
+    { type: "source", filePath: "src/subject.ts", ranges: [{ startLine: 1, endLine: 1, content: "x" }] },
+  ]);
+  const intentionallySourceless = gradeRetrieval(queryTask, [
+    { type: "fact", name: "TargetSymbol", filePath: "src/subject.ts", startLine: 1, endLine: 1 },
+  ]);
+  const summary = summarizeRetrievalRows([
+    { valid: true, task: scopeTask, metrics: covered },
+    { valid: true, task: queryTask, metrics: intentionallySourceless },
+  ]);
+  assert.equal(summary.topFiveFileHitRate, 1);
+  assert.equal(summary.returnedRequiredSourceSpanRecall, 1);
+});
+
+test("source-span grading unions adjacent ranges on one path but rejects a line gap", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [{ ...positiveTask().gold[0], startLine: 10, endLine: 20 }],
+  };
+  const adjacent = gradeRetrieval(task, [
+    { type: "source", filePath: "src/subject.ts", ranges: [{ startLine: 10, endLine: 14 }] },
+    { type: "source", filePath: "./src/subject.ts", ranges: [{ startLine: 15, endLine: 20 }] },
+  ]);
+  assert.equal(adjacent.returnedSourceSpanRecall, 1);
+  assert.equal(adjacent.sourceSpans[0].covered, true);
+
+  const gapped = gradeRetrieval(task, [
+    { type: "source", filePath: "src/subject.ts", ranges: [{ startLine: 10, endLine: 14 }] },
+    { type: "source", filePath: "src/other.ts", ranges: [{ startLine: 15, endLine: 15 }] },
+    { type: "source", filePath: "src/subject.ts", ranges: [{ startLine: 16, endLine: 20 }] },
+  ]);
+  assert.equal(gapped.returnedSourceSpanRecall, 0);
+  assert.equal(gapped.sourceSpans[0].covered, false);
+});
+
+test("first-response grading measures file rank, source spans, and protocol-v3 directed flow", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [
+      { symbol: "Caller", path: "src/a.ts", startLine: 10, endLine: 20 },
+      { symbol: "Callee", path: "src/b.ts", startLine: 30, endLine: 35 },
+    ],
+    requiredFlows: [
+      { from: { symbol: "Caller", path: "src/a.ts" }, to: { symbol: "Callee", path: "src/b.ts" }, kinds: ["calls"] },
+      { from: { symbol: "Callee", path: "src/b.ts" }, to: { symbol: "Caller", path: "src/a.ts" }, kinds: ["calls"] },
+    ],
+  };
+  const records = [
+    { type: "fact", id: "other", name: "Other", filePath: "src/other.ts", startLine: 1, endLine: 2 },
+    { type: "fact", id: "caller", name: "Caller", kind: "method", filePath: "src/a.ts", startLine: 10, endLine: 20 },
+    { type: "fact", id: "callee", name: "Callee", kind: "variable", filePath: "src/b.ts", startLine: 30, endLine: 35 },
+    { type: "flow", steps: [{ source: "caller", target: "callee", kind: "calls", confidence: 1 }] },
+    { type: "source", filePath: "src/a.ts", ranges: [{ startLine: 8, endLine: 22, content: "..." }] },
+    { type: "source", filePath: "src/b.ts", ranges: [{ startLine: 32, endLine: 40, content: "..." }] },
+  ];
+  const metrics = gradeRetrieval(task, records, { stdout: records.map(JSON.stringify).join("\n") });
+  assert.equal(metrics.firstRelevantFileRank, 2);
+  assert.equal(metrics.fileHitAt5, true);
+  assert.equal(metrics.returnedSourceSpanRecall, 0.5);
+  assert.deepEqual(metrics.requiredFlows.map((flow) => flow.covered), [true, false]);
+  assert.equal(metrics.directedFlowCoverage, 0.5);
+});
+
+test("first-response flow grading retains legacy edge and ordered-step support", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [
+      { symbol: "Caller", path: "src/a.ts" },
+      { symbol: "Callee", path: "src/b.ts" },
+    ],
+    requiredFlows: [{ from: { symbol: "Caller", path: "src/a.ts" }, to: { symbol: "Callee", path: "src/b.ts" }, kinds: ["calls"] }],
+  };
+  const nodes = [
+    { type: "fact", id: "caller", name: "Caller", filePath: "src/a.ts" },
+    { type: "fact", id: "callee", name: "Callee", filePath: "src/b.ts" },
+  ];
+  assert.equal(gradeRetrieval(task, [...nodes, { type: "edge", source: "caller", target: "callee", kind: "calls" }]).directedFlowCoverage, 1);
+  const orderedTask = { ...task, requiredFlows: [{ ...task.requiredFlows[0], kinds: ["flow"] }] };
+  assert.equal(gradeRetrieval(orderedTask, [...nodes, { type: "flow", steps: ["caller", "callee"] }]).directedFlowCoverage, 1);
+});
+
+test("protocol-v3 flow endpoint metadata grades without budget-dependent fact records", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [
+      { symbol: "Caller", path: "src/a.ts" },
+      { symbol: "Callee", path: "src/b.ts" },
+    ],
+    requiredFlows: [{ from: { symbol: "Caller", path: "src/a.ts" }, to: { symbol: "Callee", path: "src/b.ts" }, kinds: ["calls"] }],
+  };
+  const records = [{
+    type: "flow",
+    nodes: [
+      { id: "caller", name: "Caller", qualifiedName: "App::Caller", filePath: "src/a.ts" },
+      { id: "callee", name: "Callee", qualifiedName: "App::Callee", filePath: "src/b.ts" },
+    ],
+    steps: [{ source: "caller", target: "callee", kind: "calls", confidence: 1 }],
+  }];
+  assert.equal(gradeRetrieval(task, records).directedFlowCoverage, 1);
+});
+
+test("directed-flow grading permits one transparent anonymous callback containment bridge", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [
+      { symbol: "outer", path: "src/a.ts" },
+      { symbol: "target", path: "src/b.ts" },
+    ],
+    requiredFlows: [{ from: { symbol: "outer", path: "src/a.ts" }, to: { symbol: "target", path: "src/b.ts" }, kinds: ["calls"] }],
+  };
+  const records = [{
+    type: "flow",
+    nodes: [
+      { id: "outer", name: "outer", filePath: "src/a.ts" },
+      { id: "callback", name: "<callback:ReturnStatement>", filePath: "src/a.ts" },
+      { id: "target", name: "target", filePath: "src/b.ts" },
+    ],
+    steps: [
+      { source: "outer", target: "callback", kind: "contains", confidence: 1 },
+      { source: "callback", target: "target", kind: "calls", confidence: 1 },
+    ],
+  }];
+  assert.equal(gradeRetrieval(task, records).directedFlowCoverage, 1);
+});
+
+test("construction coverage recognizes a bounded callback-mediated directed path", () => {
+  const root = mkdtempSync(join(tmpdir(), "mex-flow-coverage-"));
+  const path = join(root, "graph.db");
+  const db = new DatabaseSync(path);
+  db.exec(readFileSync(join(HARNESS_ROOT, "src", "graph", "schema.sql"), "utf8"));
+  const insertNode = db.prepare(`INSERT INTO nodes (
+    id, kind, name, qualified_name, identity_key, file_path, language,
+    start_line, end_line, start_column, end_column, updated_at
+  ) VALUES (?, 'function', ?, ?, ?, ?, 'typescript', ?, ?, 0, 1, 1)`);
+  insertNode.run("outer", "outer", "outer", "identity:outer", "src/a.ts", 1, 10);
+  insertNode.run("callback", "<callback:ReturnStatement>", "outer::<callback:ReturnStatement>", "identity:callback", "src/a.ts", 2, 9);
+  insertNode.run("target", "target", "target", "identity:target", "src/b.ts", 1, 2);
+  db.prepare("INSERT INTO edges (source, target, kind, confidence) VALUES (?, ?, ?, 1)").run("outer", "callback", "contains");
+  db.prepare("INSERT INTO edges (source, target, kind, confidence) VALUES (?, ?, ?, 1)").run("callback", "target", "calls");
+  db.close();
+  const task = {
+    id: "callback-flow",
+    gold: [
+      { symbol: "outer", path: "src/a.ts" },
+      { symbol: "target", path: "src/b.ts" },
+    ],
+    requiredFlows: [{ from: { symbol: "outer", path: "src/a.ts" }, to: { symbol: "target", path: "src/b.ts" }, kinds: ["calls"] }],
+  };
+  const coverage = inspectGoldCoverage(path, [task]);
+  assert.equal(coverage.directedFlowCoverage, 1);
+  assert.deepEqual(coverage.tasks[0].requiredFlows[0].paths[0].map((edge) => edge.kind), ["contains", "calls"]);
+});
+
+test("construction misses are reported separately and excluded from retrieval recall", () => {
+  const task = {
+    ...positiveTask(),
+    gold: [
+      { symbol: "Present", path: "src/a.ts", startLine: 1, endLine: 2 },
+      { symbol: "LostDuringBuild", path: "src/b.ts", startLine: 4, endLine: 5 },
+    ],
+  };
+  const coverage = {
+    evidenceCoverage: 0.5,
+    evidence: [
+      { symbol: "Present", path: "src/a.ts", startLine: 1, endLine: 2, covered: true },
+      { symbol: "LostDuringBuild", path: "src/b.ts", startLine: 4, endLine: 5, covered: false },
+    ],
+  };
+  const metrics = gradeRetrieval(task, [{ type: "fact", name: "Present", filePath: "src/a.ts", startLine: 1, endLine: 2 }], {}, coverage);
+  assert.equal(metrics.goldCount, 1);
+  assert.equal(metrics.recallAt1, 1);
+  assert.equal(metrics.constructionMissingGold.length, 1);
+  assert.equal(metrics.graphEvidenceCoverage, 0.5);
 });
 
 test("negative error codes are an allowlist, not a required response shape", () => {
@@ -134,12 +473,74 @@ test("prepared runs capture graph loss and successful exact retrieval", { concur
   const prepared = prepareGraphEvaluation({ suite, subjectRoot, harnessRoot: HARNESS_ROOT, outputDir, systemCommands: commands });
   assert.equal(prepared.systems.fake.deterministic, true);
   assert.equal(prepared.systems.fake.rebuilds[0].integrity.extractedToStoredLoss, 1);
+  assert.equal(prepared.systems.fake.goldCoverage.evidenceCoverage, 1);
   const result = await runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 });
   assert.equal(result.rows[0].valid, true);
   assert.equal(result.rows[0].metrics.recallAt1, 1);
   const report = generateGraphReport({ suite, outputDir, suppliedRows: result.rows });
   assert.equal(report.gate.passed, true);
   assert.equal(readFileSync(join(outputDir, "raw", "queries", "001-target--fake.stdout.jsonl"), "utf8").includes("TargetSymbol"), true);
+});
+
+test("native identity checks ignore the owned graph swap for a subject nested below the harness", { concurrency: false }, async () => {
+  const harnessRoot = mkdtempSync(join(tmpdir(), "mex-graph-nested-harness-"));
+  const subjectRoot = join(harnessRoot, "fixtures", "subject");
+  mkdirSync(join(subjectRoot, "src"), { recursive: true });
+  writeFileSync(join(subjectRoot, "src", "subject.ts"), "export function TargetSymbol() {}\n");
+  const suitePath = join(subjectRoot, "suite.json");
+  writeFileSync(suitePath, `${JSON.stringify(rawSuite([positiveTask()]), null, 2)}\n`);
+  const suite = loadGraphSuite(suitePath);
+  const outputDir = mkdtempSync(join(tmpdir(), "mex-graph-nested-output-"));
+  const commands = { fake: [process.execPath, FAKE] };
+
+  prepareGraphEvaluation({ suite, subjectRoot, harnessRoot, outputDir, systemCommands: commands });
+  const result = await runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 });
+
+  assert.equal(result.manifest.status, "complete");
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0].valid, true);
+  assert.equal(existsSync(join(subjectRoot, ".mex", "graph.db")), false);
+});
+
+test("integrity gates use the final rebuild and fail closed for exceeded, missing, and non-finite metrics", { concurrency: false }, async () => {
+  const gates = {
+    floors: { budgetComplianceRate: 1 },
+    ceilings: { invalidRuns: 0 },
+    integrityFloors: { nodes: 1 },
+    integrityCeilings: { extractedToStoredLoss: 1 },
+  };
+  const { subjectRoot, suite, outputDir } = fixture(gates);
+  const commands = { fake: [process.execPath, FAKE] };
+  prepareGraphEvaluation({ suite, subjectRoot, harnessRoot: HARNESS_ROOT, outputDir, systemCommands: commands });
+  const result = await runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 });
+  const preparePath = join(outputDir, "prepare.json");
+  const prepared = JSON.parse(readFileSync(preparePath, "utf8"));
+
+  prepared.systems.fake.rebuilds[0].integrity.extractedToStoredLoss = 999;
+  writeFileSync(preparePath, `${JSON.stringify(prepared, null, 2)}\n`);
+  assert.equal(generateGraphReport({ suite, outputDir, suppliedRows: result.rows }).gate.passed, true);
+
+  prepared.systems.fake.rebuilds.at(-1).integrity.extractedToStoredLoss = 2;
+  writeFileSync(preparePath, `${JSON.stringify(prepared, null, 2)}\n`);
+  let report = generateGraphReport({ suite, outputDir, suppliedRows: result.rows });
+  assert.equal(report.gate.passed, false);
+  assert.ok(report.gate.failures.includes("integrity:fake:extractedToStoredLoss 2 > ceiling 1"));
+
+  prepared.systems.fake.rebuilds.at(-1).integrity.extractedToStoredLoss = 1;
+  prepared.systems.fake.rebuilds.at(-1).integrity.nodes = 0;
+  writeFileSync(preparePath, `${JSON.stringify(prepared, null, 2)}\n`);
+  report = generateGraphReport({ suite, outputDir, suppliedRows: result.rows });
+  assert.ok(report.gate.failures.includes("integrity:fake:nodes 0 < floor 1"));
+
+  delete prepared.systems.fake.rebuilds.at(-1).integrity.nodes;
+  writeFileSync(preparePath, `${JSON.stringify(prepared, null, 2)}\n`);
+  report = generateGraphReport({ suite, outputDir, suppliedRows: result.rows });
+  assert.ok(report.gate.failures.includes("integrity:fake:nodes is missing from final prepared rebuild"));
+
+  prepared.systems.fake.rebuilds.at(-1).integrity.nodes = "NaN";
+  writeFileSync(preparePath, `${JSON.stringify(prepared, null, 2)}\n`);
+  report = generateGraphReport({ suite, outputDir, suppliedRows: result.rows });
+  assert.ok(report.gate.failures.includes("integrity:fake:nodes=NaN is not finite"));
 });
 
 test("nonzero CLI exits are invalid and cannot become empty successful retrievals", { concurrency: false }, async () => {
@@ -156,6 +557,100 @@ test("nonzero CLI exits are invalid and cannot become empty successful retrieval
     if (previous === undefined) delete process.env.FAKE_GRAPH_QUERY_MODE;
     else process.env.FAKE_GRAPH_QUERY_MODE = previous;
   }
+});
+
+test("native schedules abort when the subject changes during a query", { concurrency: false }, async () => {
+  const { subjectRoot, suite, outputDir } = fixture();
+  const driftQuery = "Trigger concurrent identity drift";
+  suite.tasks.push({ ...positiveTask(), id: "drift", query: driftQuery });
+  const commands = { fake: [process.execPath, FAKE] };
+  prepareGraphEvaluation({ suite, subjectRoot, harnessRoot: HARNESS_ROOT, outputDir, systemCommands: commands });
+  const previous = process.env.FAKE_GRAPH_MUTATE_SUBJECT;
+  const previousQuery = process.env.FAKE_GRAPH_MUTATE_QUERY;
+  process.env.FAKE_GRAPH_MUTATE_SUBJECT = "1";
+  process.env.FAKE_GRAPH_MUTATE_QUERY = driftQuery;
+  try {
+    await assert.rejects(
+      runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 }),
+      /identity drift after 002-drift--fake: subject repository changed after preparation/,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.FAKE_GRAPH_MUTATE_SUBJECT;
+    else process.env.FAKE_GRAPH_MUTATE_SUBJECT = previous;
+    if (previousQuery === undefined) delete process.env.FAKE_GRAPH_MUTATE_QUERY;
+    else process.env.FAKE_GRAPH_MUTATE_QUERY = previousQuery;
+  }
+  const manifest = JSON.parse(readFileSync(join(outputDir, "run-manifest.json"), "utf8"));
+  assert.equal(manifest.status, "aborted");
+  assert.equal(manifest.failedRunId, "002-drift--fake");
+  assert.equal(manifest.resultCount, 1);
+  assert.match(manifest.error, /subject repository changed/);
+  assert.equal(existsSync(join(outputDir, "runs", "001-target--fake.json")), true);
+  assert.equal(existsSync(join(outputDir, "runs", "002-drift--fake.json")), false);
+  assert.equal(existsSync(join(outputDir, "raw", "queries", "002-drift--fake.stdout.jsonl")), true);
+  assert.equal(existsSync(join(subjectRoot, ".mex", "graph.db")), false);
+});
+
+test("native schedules abort when a command bundle changes during a query", { concurrency: false }, async () => {
+  const { subjectRoot, suite, outputDir } = fixture();
+  const driftQuery = "Trigger concurrent identity drift";
+  suite.tasks.push({ ...positiveTask(), id: "drift", query: driftQuery });
+  const bundleDir = mkdtempSync(join(tmpdir(), "mex-graph-mutable-bundle-"));
+  const mutableFake = join(bundleDir, "fake-graph.mjs");
+  copyFileSync(FAKE, mutableFake);
+  const commands = { fake: [process.execPath, mutableFake] };
+  prepareGraphEvaluation({ suite, subjectRoot, harnessRoot: HARNESS_ROOT, outputDir, systemCommands: commands });
+  const previous = process.env.FAKE_GRAPH_MUTATE_BUNDLE;
+  const previousQuery = process.env.FAKE_GRAPH_MUTATE_QUERY;
+  process.env.FAKE_GRAPH_MUTATE_BUNDLE = "1";
+  process.env.FAKE_GRAPH_MUTATE_QUERY = driftQuery;
+  try {
+    await assert.rejects(
+      runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 }),
+      /identity drift after 002-drift--fake: system fake CLI bundle changed after preparation/,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.FAKE_GRAPH_MUTATE_BUNDLE;
+    else process.env.FAKE_GRAPH_MUTATE_BUNDLE = previous;
+    if (previousQuery === undefined) delete process.env.FAKE_GRAPH_MUTATE_QUERY;
+    else process.env.FAKE_GRAPH_MUTATE_QUERY = previousQuery;
+  }
+  const manifest = JSON.parse(readFileSync(join(outputDir, "run-manifest.json"), "utf8"));
+  assert.equal(manifest.status, "aborted");
+  assert.equal(manifest.failedRunId, "002-drift--fake");
+  assert.equal(manifest.resultCount, 1);
+  assert.match(manifest.error, /CLI bundle changed/);
+  assert.equal(existsSync(join(outputDir, "runs", "001-target--fake.json")), true);
+  assert.equal(existsSync(join(outputDir, "runs", "002-drift--fake.json")), false);
+  assert.equal(existsSync(join(subjectRoot, ".mex", "graph.db")), false);
+});
+
+test("native schedules abort when the evaluation harness changes during a query", { concurrency: false }, async () => {
+  const { subjectRoot, suite, outputDir } = fixture();
+  const harnessRoot = mkdtempSync(join(tmpdir(), "mex-graph-mutable-harness-"));
+  const harnessFile = join(harnessRoot, "evaluator.mjs");
+  writeFileSync(harnessFile, "export const evaluator = true;\n");
+  const commands = { fake: [process.execPath, FAKE] };
+  prepareGraphEvaluation({ suite, subjectRoot, harnessRoot, outputDir, systemCommands: commands });
+  const previous = process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH;
+  process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH = harnessFile;
+  try {
+    await assert.rejects(
+      runGraphEvaluation({ suite, subjectRoot, outputDir, systemCommands: commands, timeoutMs: 2_000 }),
+      /identity drift after 001-target--fake: evaluation harness changed after preparation/,
+    );
+  } finally {
+    if (previous === undefined) delete process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH;
+    else process.env.FAKE_GRAPH_MUTATE_HARNESS_PATH = previous;
+  }
+  const manifest = JSON.parse(readFileSync(join(outputDir, "run-manifest.json"), "utf8"));
+  assert.equal(manifest.status, "aborted");
+  assert.equal(manifest.failedRunId, "001-target--fake");
+  assert.equal(manifest.resultCount, 0);
+  assert.match(manifest.error, /evaluation harness changed/);
+  assert.equal(existsSync(join(outputDir, "runs", "001-target--fake.json")), false);
+  assert.equal(existsSync(join(outputDir, "raw", "queries", "001-target--fake.stdout.jsonl")), true);
+  assert.equal(existsSync(join(subjectRoot, ".mex", "graph.db")), false);
 });
 
 test("resume rejects a changed run identity", { concurrency: false }, async () => {

--- a/evaluate/graph/test/native-holdout.test.mjs
+++ b/evaluate/graph/test/native-holdout.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { loadGraphSuite } from "../../schemas/graph-suite.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HARNESS_ROOT = resolve(HERE, "..", "..", "..");
+const compare = JSON.parse(readFileSync(join(HARNESS_ROOT, "evaluate", "compare", "suites", "typescript.json"), "utf8"));
+const native = loadGraphSuite(join(HARNESS_ROOT, "evaluate", "suites", "native", "graph", "typescript.json"));
+
+test("native TypeScript holdout preserves the frozen questions and expected symbols", () => {
+  assert.equal(native.subject.name, compare.subject.name);
+  assert.equal(native.subject.repository, compare.subject.repository);
+  assert.equal(native.subject.revision, compare.subject.revision);
+  assert.deepEqual(native.tasks.map((task) => task.id), compare.tasks.map((task) => task.id));
+  assert.deepEqual(native.tasks.map((task) => task.query), compare.tasks.map((task) => task.question));
+  assert.deepEqual(
+    native.tasks.map((task) => task.gold.map((evidence) => evidence.symbol)),
+    compare.tasks.map((task) => task.expectedSymbols),
+  );
+  assert.equal(native.gates.floors.topFiveFileHitRate, 0.9);
+  assert.equal(native.gates.floors.returnedRequiredSourceSpanRecall, 0.8);
+});

--- a/evaluate/schemas/graph-suite.mjs
+++ b/evaluate/schemas/graph-suite.mjs
@@ -6,9 +6,6 @@ export const GRAPH_SUITE_SCHEMA_VERSION = 2;
 const OPERATIONS = new Set(["scope", "query", "impact"]);
 const RELATIONS = new Set(["where-defined", "who-calls", "what-calls"]);
 const DETAIL_LEVELS = new Set(["minimal", "standard", "source"]);
-const EVIDENCE_KINDS = new Set([
-  "class", "struct", "interface", "trait", "function", "variable", "constant", "enum", "type_alias", "component",
-]);
 
 function object(value, label) {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
@@ -36,19 +33,48 @@ function commandArray(value, label) {
   return stringArray(value, label, 1);
 }
 
+function finiteMetricMap(value, label) {
+  if (value === undefined) return;
+  object(value, label);
+  for (const [metric, threshold] of Object.entries(value)) {
+    string(metric, `${label} metric`);
+    if (!Number.isFinite(threshold)) throw new Error(`${label}.${metric} must be a finite number`);
+  }
+}
+
 function validateEvidence(value, label) {
   object(value, label);
   string(value.symbol, `${label}.symbol`);
-  string(value.kind, `${label}.kind`);
-  if (!EVIDENCE_KINDS.has(value.kind)) throw new Error(`${label}.kind is unsupported: ${value.kind}`);
+  if (value.kind !== undefined) string(value.kind, `${label}.kind`);
   string(value.path, `${label}.path`);
   if (isAbsolute(value.path)) throw new Error(`${label}.path must be repository-relative`);
   if (value.line !== undefined && (!Number.isInteger(value.line) || value.line < 1)) {
     throw new Error(`${label}.line must be a positive integer`);
   }
-  const allowed = new Set(["symbol", "kind", "path", "line"]);
+  if (value.startLine !== undefined && (!Number.isInteger(value.startLine) || value.startLine < 1)) {
+    throw new Error(`${label}.startLine must be a positive integer`);
+  }
+  if (value.endLine !== undefined && (!Number.isInteger(value.endLine) || value.endLine < (value.startLine ?? value.line ?? 1))) {
+    throw new Error(`${label}.endLine must not precede its source span`);
+  }
+  const allowed = new Set(["symbol", "kind", "path", "line", "startLine", "endLine"]);
   for (const key of Object.keys(value)) if (!allowed.has(key)) throw new Error(`${label}.${key} is not supported`);
   return value;
+}
+
+function validateFlows(value, label) {
+  if (value === undefined) return;
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  value.forEach((flow, index) => {
+    object(flow, `${label}[${index}]`);
+    for (const endpoint of ["from", "to"]) {
+      const selector = object(flow[endpoint], `${label}[${index}].${endpoint}`);
+      string(selector.symbol, `${label}[${index}].${endpoint}.symbol`);
+      string(selector.path, `${label}[${index}].${endpoint}.path`);
+      if (isAbsolute(selector.path)) throw new Error(`${label}[${index}].${endpoint}.path must be repository-relative`);
+    }
+    if (flow.kinds !== undefined) stringArray(flow.kinds, `${label}[${index}].kinds`, 1);
+  });
 }
 
 function evidenceArray(value, label, min = 0) {
@@ -56,7 +82,7 @@ function evidenceArray(value, label, min = 0) {
   const keys = new Set();
   value.forEach((entry, index) => {
     validateEvidence(entry, `${label}[${index}]`);
-    const key = `${entry.symbol}\0${entry.kind}\0${entry.path}\0${entry.line ?? ""}`;
+    const key = `${entry.symbol}\0${entry.path}\0${entry.startLine ?? entry.line ?? ""}\0${entry.endLine ?? entry.line ?? ""}`;
     if (keys.has(key)) throw new Error(`${label}[${index}] duplicates evidence ${entry.symbol} in ${entry.path}`);
     keys.add(key);
   });
@@ -66,11 +92,11 @@ function evidenceArray(value, label, min = 0) {
 function validateOptions(value, label) {
   if (value === undefined) return;
   object(value, label);
-  const allowed = new Set(["detail", "maxNodes", "maxOutputTokens", "maxSourceLines", "depth", "fingerprint"]);
+  const allowed = new Set(["detail", "maxNodes", "maxFiles", "maxOutputTokens", "maxSourceLines", "depth", "fingerprint"]);
   for (const [key, option] of Object.entries(value)) {
     if (!allowed.has(key)) throw new Error(`${label}.${key} is not supported`);
     if (key === "detail" && !DETAIL_LEVELS.has(option)) throw new Error(`${label}.detail is invalid`);
-    if (["maxNodes", "maxOutputTokens", "maxSourceLines", "depth"].includes(key) && (!Number.isInteger(option) || option < 1)) {
+    if (["maxNodes", "maxFiles", "maxOutputTokens", "maxSourceLines", "depth"].includes(key) && (!Number.isInteger(option) || option < 1)) {
       throw new Error(`${label}.${key} must be a positive integer`);
     }
     if (key === "fingerprint") boolean(option, `${label}.fingerprint`);
@@ -98,6 +124,14 @@ function validateTask(task, label) {
   evidenceArray(task.gold ?? [], `${label}.gold`, noResult ? 0 : 1);
   evidenceArray(task.acceptableAlternates ?? [], `${label}.acceptableAlternates`);
   evidenceArray(task.mustNotReturn ?? [], `${label}.mustNotReturn`);
+  validateFlows(task.requiredFlows, `${label}.requiredFlows`);
+  for (const [flowIndex, flow] of (task.requiredFlows ?? []).entries()) {
+    for (const endpoint of ["from", "to"]) {
+      if (!(task.gold ?? []).some((entry) => entry.symbol === flow[endpoint].symbol && entry.path === flow[endpoint].path)) {
+        throw new Error(`${label}.requiredFlows[${flowIndex}].${endpoint} must identify task gold evidence`);
+      }
+    }
+  }
   if (noResult && (task.gold?.length ?? 0) > 0) throw new Error(`${label} cannot combine expect.noResult with gold evidence`);
   if (task.operation === "scope" && expectation.errorCodes?.length) {
     throw new Error(`${label}.expect.errorCodes is not supported for scope tasks`);
@@ -153,7 +187,11 @@ export function validateGraphSuite(raw, source = "graph suite") {
     if (taskIds.has(task.id)) throw new Error(`${source}.tasks[${index}].id is duplicated: ${task.id}`);
     taskIds.add(task.id);
   });
-  if (raw.gates !== undefined) object(raw.gates, `${source}.gates`);
+  if (raw.gates !== undefined) {
+    const gates = object(raw.gates, `${source}.gates`);
+    finiteMetricMap(gates.integrityFloors, `${source}.gates.integrityFloors`);
+    finiteMetricMap(gates.integrityCeilings, `${source}.gates.integrityCeilings`);
+  }
   return raw;
 }
 
@@ -216,6 +254,7 @@ export function graphTaskArgs(task) {
   const options = task.options ?? {};
   if (options.detail) args.push("--detail", options.detail);
   if (options.maxNodes) args.push("--max-nodes", String(options.maxNodes));
+  if (options.maxFiles) args.push("--max-files", String(options.maxFiles));
   if (options.maxOutputTokens) args.push("--max-output-tokens", String(options.maxOutputTokens));
   if (options.maxSourceLines) args.push("--max-source-lines", String(options.maxSourceLines));
   if (options.depth) args.push("--depth", String(options.depth));

--- a/evaluate/suites/native/graph/hono.json
+++ b/evaluate/suites/native/graph/hono.json
@@ -1,0 +1,133 @@
+{
+  "schemaVersion": 2,
+  "id": "hono-native-graph",
+  "description": "Pinned Hono construction, first-response file, source-span, flow, and budget gate.",
+  "subject": {
+    "name": "honojs/hono",
+    "repository": "https://github.com/honojs/hono.git",
+    "revision": "0293343dbf8f0bca52b210a98bcef31cc61395ee",
+    "requireClean": false
+  },
+  "determinismRebuilds": 2,
+  "systems": {
+    "current": {
+      "role": "candidate",
+      "label": "active checkout",
+      "command": ["node", "{harnessRoot}/dist/cli.js"]
+    }
+  },
+  "tasks": [
+    {
+      "id": "request-dispatch",
+      "category": "natural-language-flow",
+      "critical": true,
+      "operation": "scope",
+      "query": "How does an incoming Request enter a Hono application, get matched to routes, and dispatch through one or multiple handlers?",
+      "gold": [
+        { "symbol": "#dispatch", "kind": "method", "path": "src/hono-base.ts", "startLine": 407, "endLine": 467 },
+        { "symbol": "fetch", "kind": "property", "path": "src/hono-base.ts", "startLine": 480, "endLine": 486 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "fetch", "path": "src/hono-base.ts" }, "to": { "symbol": "#dispatch", "path": "src/hono-base.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "smart-router-selection",
+      "category": "natural-language-symbol",
+      "critical": true,
+      "operation": "scope",
+      "query": "How does Hono's smart router choose the first router that supports all registered paths and then reuse it for later matches?",
+      "gold": [
+        { "symbol": "SmartRouter", "kind": "class", "path": "src/router/smart-router/router.ts", "startLine": 4, "endLine": 70 },
+        { "symbol": "match", "kind": "method", "path": "src/router/smart-router/router.ts", "startLine": 21, "endLine": 61 }
+      ]
+    },
+    {
+      "id": "middleware-composition",
+      "category": "natural-language-flow",
+      "critical": true,
+      "operation": "scope",
+      "query": "How are Hono middleware handlers composed so next advances exactly once while errors and not-found responses are handled?",
+      "gold": [
+        { "symbol": "compose", "kind": "variable", "path": "src/compose.ts", "startLine": 15, "endLine": 73 },
+        { "symbol": "dispatch", "kind": "function", "path": "src/compose.ts", "startLine": 32, "endLine": 71 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "compose", "path": "src/compose.ts" }, "to": { "symbol": "dispatch", "path": "src/compose.ts" }, "kinds": ["calls", "references", "contains"] }
+      ]
+    },
+    {
+      "id": "request-validation",
+      "category": "natural-language-flow",
+      "critical": true,
+      "operation": "scope",
+      "query": "How does request validation extract JSON, form, query, parameter, header, or cookie input and make the validated value available to later handlers?",
+      "gold": [
+        { "symbol": "validator", "kind": "variable", "path": "src/validator/validator.ts", "startLine": 46, "endLine": 172 },
+        { "symbol": "addValidatedData", "kind": "method", "path": "src/request.ts", "startLine": 335, "endLine": 337 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "validator", "path": "src/validator/validator.ts" }, "to": { "symbol": "addValidatedData", "path": "src/request.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "context-response-construction",
+      "category": "natural-language-flow",
+      "critical": true,
+      "operation": "scope",
+      "query": "How does a Hono Context construct a Response while combining prepared headers, explicit headers, cookies, and status values?",
+      "gold": [
+        { "symbol": "Context", "kind": "class", "path": "src/context.ts", "startLine": 293, "endLine": 293 },
+        { "symbol": "#newResponse", "kind": "method", "path": "src/context.ts", "startLine": 608, "endLine": 656 },
+        { "symbol": "createResponseInstance", "kind": "variable", "path": "src/context.ts", "startLine": 288, "endLine": 291 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "#newResponse", "path": "src/context.ts" }, "to": { "symbol": "createResponseInstance", "path": "src/context.ts" }, "kinds": ["calls", "references"] }
+      ]
+    },
+    {
+      "id": "query-cache-key",
+      "category": "natural-language-flow",
+      "critical": true,
+      "operation": "scope",
+      "query": "How does Hono build safe cache keys for QUERY requests using a bounded body digest, representation metadata, and Vary headers?",
+      "gold": [
+        { "symbol": "cache", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 183, "endLine": 324 },
+        { "symbol": "createQueryDigest", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 95, "endLine": 153 },
+        { "symbol": "createCacheKey", "kind": "variable", "path": "src/middleware/cache/index.ts", "startLine": 51, "endLine": 70 }
+      ],
+      "requiredFlows": [
+        { "from": { "symbol": "cache", "path": "src/middleware/cache/index.ts" }, "to": { "symbol": "createQueryDigest", "path": "src/middleware/cache/index.ts" }, "kinds": ["calls", "references"] },
+        { "from": { "symbol": "cache", "path": "src/middleware/cache/index.ts" }, "to": { "symbol": "createCacheKey", "path": "src/middleware/cache/index.ts" }, "kinds": ["calls", "references"] }
+      ]
+    }
+  ],
+  "gates": {
+    "systems": ["current"],
+    "floors": {
+      "topFiveFileHitRate": 1,
+      "returnedRequiredSourceSpanRecall": 0.8,
+      "meanDirectedFlowCoverage": 1,
+      "graphEvidenceCoverage": 1,
+      "budgetComplianceRate": 1
+    },
+    "integrityFloors": { "schemaVersion": 2 },
+    "integrityCeilings": {
+      "extractedToStoredLoss": 0,
+      "buildToStoredDelta": 0,
+      "duplicateEdges": 0,
+      "danglingEdges": 0,
+      "danglingContainers": 0,
+      "duplicateIdentityKeys": 0,
+      "missingIdentityKeys": 0,
+      "ftsRowDelta": 0,
+      "sourceChunkFtsRowDelta": 0,
+      "danglingImportTargets": 0,
+      "danglingAliases": 0,
+      "invalidConfidenceEdges": 0,
+      "suspiciousProductionToTestEdges": 0
+    },
+    "ceilings": { "invalidRuns": 0 },
+    "criticalMustPass": false
+  }
+}

--- a/evaluate/suites/native/graph/mex-tasks.json
+++ b/evaluate/suites/native/graph/mex-tasks.json
@@ -20,7 +20,7 @@
       "family": "scope-selection",
       "critical": true,
       "operation": "scope",
-      "query": "How does graph retrieval decide which code declarations belong in a task neighborhood?",
+      "query": "Where does Scope fuse symbol, path, node BM25, and source-chunk candidates into cohesive ranked files?",
       "gold": [{ "symbol": "selectScope", "kind": "function", "path": "src/graph/scope.ts" }],
       "mustNotReturn": [{ "symbol": "runImpact", "kind": "function", "path": "src/graph/cli-agent.ts" }]
     },
@@ -37,8 +37,8 @@
       "category": "paraphrase",
       "family": "scope-selection",
       "operation": "scope",
-      "query": "Where should I debug irrelevant declarations being chosen for a natural language code search?",
-      "gold": [{ "symbol": "selectScope", "kind": "function", "path": "src/graph/scope.ts" }]
+      "query": "Where does a natural-language graph request become exact identifiers and normalized path terms?",
+      "gold": [{ "symbol": "planGraphQuery", "kind": "function", "path": "src/graph/retrieval/query.ts" }]
     },
     {
       "id": "budget-enforcement-plain",
@@ -62,19 +62,16 @@
       "category": "paraphrase",
       "family": "budget-enforcement",
       "operation": "scope",
-      "query": "What prevents a retrieval payload from overflowing the agent context allowance?",
-      "gold": [{ "symbol": "BudgetLedger", "kind": "class", "path": "src/graph/agent-protocol.ts" }]
+      "query": "What enforces the hard output token budget when source and flow records compete for response space?",
+      "gold": [{ "symbol": "beginResponse", "kind": "function", "path": "src/graph/cli-agent.ts" }]
     },
     {
       "id": "source-expansion-flow",
       "category": "multi-symbol-flow",
       "critical": true,
       "operation": "scope",
-      "query": "How does an agent expand selected graph node identifiers into bounded source code?",
-      "gold": [
-        { "symbol": "runGraphGet", "kind": "function", "path": "src/graph/cli-agent.ts" },
-        { "symbol": "readNodeSource", "kind": "function", "path": "src/graph/scope.ts" }
-      ]
+      "query": "How does Scope plan bounded source windows for selected symbols and query hits?",
+      "gold": [{ "symbol": "planFileSource", "kind": "function", "path": "src/graph/scope.ts" }]
     },
     {
       "id": "impact-walk",
@@ -87,11 +84,11 @@
       ]
     },
     {
-      "id": "compact-fact-shape",
+      "id": "source-share-admission",
       "category": "natural-language-symbol",
       "operation": "scope",
-      "query": "Where is the compact agent-facing representation of a graph declaration assembled?",
-      "gold": [{ "symbol": "compactFact", "kind": "function", "path": "src/graph/scope.ts" }]
+      "query": "Where are selected source ranges admitted within the response's reserved source share?",
+      "gold": [{ "symbol": "admitSourceWithinShare", "kind": "function", "path": "src/graph/cli-agent.ts" }]
     },
     {
       "id": "where-budget-defined",

--- a/evaluate/suites/native/graph/mex.json
+++ b/evaluate/suites/native/graph/mex.json
@@ -14,11 +14,27 @@
   "tasksFile": "./mex-tasks.json",
   "gates": {
     "systems": ["current"],
-    "floors": { "recallAt5": 0.43, "mrr": 0.34, "completeEvidenceRate": 0.5, "budgetComplianceRate": 1, "negativeAccuracy": 1 },
-    "categoryFloors": {
-      "exact-symbol": { "recallAt5": 1 },
-      "natural-language-symbol": { "recallAt5": 0.33 },
-      "relationship-where-defined": { "recallAt5": 1 }
+    "floors": {
+      "topFiveFileHitRate": 0.9,
+      "returnedRequiredSourceSpanRecall": 0.8,
+      "budgetComplianceRate": 1,
+      "negativeAccuracy": 1
+    },
+    "integrityFloors": { "schemaVersion": 2 },
+    "integrityCeilings": {
+      "extractedToStoredLoss": 0,
+      "buildToStoredDelta": 0,
+      "duplicateEdges": 0,
+      "danglingEdges": 0,
+      "danglingContainers": 0,
+      "duplicateIdentityKeys": 0,
+      "missingIdentityKeys": 0,
+      "ftsRowDelta": 0,
+      "sourceChunkFtsRowDelta": 0,
+      "danglingImportTargets": 0,
+      "danglingAliases": 0,
+      "invalidConfidenceEdges": 0,
+      "suspiciousProductionToTestEdges": 0
     },
     "ceilings": { "invalidRuns": 0, "prohibitedHitRate": 0 }
   }

--- a/evaluate/suites/native/graph/synthetic.json
+++ b/evaluate/suites/native/graph/synthetic.json
@@ -26,7 +26,7 @@
       "category": "paraphrase",
       "family": "budget",
       "operation": "scope",
-      "query": "cap graph payload size",
+      "query": "bound output token spending",
       "gold": [{ "symbol": "OutputBudgetLedger", "kind": "class", "path": "src/retrieval.ts" }]
     },
     {
@@ -82,7 +82,13 @@
       "category": "language-rust",
       "operation": "scope",
       "query": "Which Rust routine resolves a symbol into a call path?",
-      "gold": [{ "symbol": "resolve_call_path", "kind": "function", "path": "pipeline.rs" }]
+      "gold": [{
+        "symbol": "resolve_call_path",
+        "kind": "function",
+        "path": "pipeline.rs",
+        "startLine": 1,
+        "endLine": 3
+      }]
     },
     {
       "id": "negative-symbol",
@@ -96,7 +102,31 @@
   ],
   "gates": {
     "systems": ["current"],
-    "floors": { "recallAt5": 0.75, "mrr": 0.65, "completeEvidenceRate": 0.62, "budgetComplianceRate": 1, "negativeAccuracy": 1 },
+    "floors": {
+      "recallAt5": 0.75,
+      "mrr": 0.65,
+      "completeEvidenceRate": 0.62,
+      "topFiveFileHitRate": 0.9,
+      "returnedRequiredSourceSpanRecall": 0.8,
+      "budgetComplianceRate": 1,
+      "negativeAccuracy": 1
+    },
+    "integrityFloors": { "schemaVersion": 2 },
+    "integrityCeilings": {
+      "extractedToStoredLoss": 0,
+      "buildToStoredDelta": 0,
+      "duplicateEdges": 0,
+      "danglingEdges": 0,
+      "danglingContainers": 0,
+      "duplicateIdentityKeys": 0,
+      "missingIdentityKeys": 0,
+      "ftsRowDelta": 0,
+      "sourceChunkFtsRowDelta": 0,
+      "danglingImportTargets": 0,
+      "danglingAliases": 0,
+      "invalidConfidenceEdges": 0,
+      "suspiciousProductionToTestEdges": 0
+    },
     "ceilings": { "invalidRuns": 0, "prohibitedHitRate": 0 }
   }
 }

--- a/evaluate/suites/native/graph/typescript.json
+++ b/evaluate/suites/native/graph/typescript.json
@@ -1,0 +1,101 @@
+{
+  "schemaVersion": 2,
+  "id": "typescript-native-graph-holdout",
+  "description": "Frozen TypeScript holdout preserving the original six questions while grading first-response files and verified source spans.",
+  "subject": {
+    "name": "microsoft/TypeScript",
+    "repository": "https://github.com/microsoft/TypeScript.git",
+    "revision": "b465fdbfe175304d9b977da137b2c178ae1091d3",
+    "requireClean": false
+  },
+  "determinismRebuilds": 2,
+  "systems": {
+    "current": {
+      "role": "candidate",
+      "label": "active checkout",
+      "command": ["node", "{harnessRoot}/dist/cli.js"]
+    }
+  },
+  "tasks": [
+    {
+      "id": "supported-extensions",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "Which routine decides what source-file suffixes count as supported for the current compiler options?",
+      "gold": [
+        { "symbol": "getSupportedExtensions", "kind": "function", "path": "src/compiler/utilities.ts", "startLine": 9989, "endLine": 10008 }
+      ]
+    },
+    {
+      "id": "common-source-root",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "How is the common source root chosen for emitted files?",
+      "gold": [
+        { "symbol": "getCommonSourceDirectory", "kind": "function", "path": "src/compiler/emitter.ts", "startLine": 636, "endLine": 665 }
+      ]
+    },
+    {
+      "id": "module-resolution",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "How does the compiler locate an imported package or source file?",
+      "gold": [
+        { "symbol": "resolveModuleName", "kind": "function", "path": "src/compiler/moduleNameResolver.ts", "startLine": 1406, "endLine": 1483 }
+      ]
+    },
+    {
+      "id": "config-search",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "Where does command-line compilation search upward for a project configuration?",
+      "gold": [
+        { "symbol": "findConfigFile", "kind": "function", "path": "src/compiler/program.ts", "startLine": 328, "endLine": 333 }
+      ]
+    },
+    {
+      "id": "watch-program",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "What entry point starts and maintains a watch-mode compilation?",
+      "gold": [
+        { "symbol": "createWatchProgram", "kind": "function", "path": "src/compiler/watchPublic.ts", "startLine": 415, "endLine": 420 }
+      ]
+    },
+    {
+      "id": "colored-diagnostics",
+      "category": "natural-language-symbol",
+      "operation": "scope",
+      "query": "How are compiler errors rendered with color and surrounding source lines?",
+      "gold": [
+        { "symbol": "formatDiagnosticsWithColorAndContext", "kind": "function", "path": "src/compiler/program.ts", "startLine": 779, "endLine": 811 }
+      ]
+    }
+  ],
+  "gates": {
+    "systems": ["current"],
+    "floors": {
+      "topFiveFileHitRate": 0.9,
+      "returnedRequiredSourceSpanRecall": 0.8,
+      "graphEvidenceCoverage": 1,
+      "budgetComplianceRate": 1
+    },
+    "integrityFloors": { "schemaVersion": 2 },
+    "integrityCeilings": {
+      "extractedToStoredLoss": 0,
+      "buildToStoredDelta": 0,
+      "duplicateEdges": 0,
+      "danglingEdges": 0,
+      "danglingContainers": 0,
+      "duplicateIdentityKeys": 0,
+      "missingIdentityKeys": 0,
+      "ftsRowDelta": 0,
+      "sourceChunkFtsRowDelta": 0,
+      "danglingImportTargets": 0,
+      "danglingAliases": 0,
+      "invalidConfidenceEdges": 0,
+      "suspiciousProductionToTestEdges": 0
+    },
+    "ceilings": { "invalidRuns": 0 }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
         {
           default = pkgs.buildNpmPackage {
             pname = "mex";
-            version = "0.7.0";
+            version = "0.7.2";
 
             src = ./.;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mex-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mex-agent",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -22,6 +22,7 @@
         "remark-frontmatter": "^5.0.0",
         "remark-parse": "^11.0.0",
         "simple-git": "^3.27.0",
+        "typescript": "5.9.3",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
         "web-tree-sitter": "^0.25.10",
@@ -37,7 +38,6 @@
         "ink-testing-library": "^4.0.0",
         "tree-sitter-wasms": "^0.1.12",
         "tsup": "^8.4.0",
-        "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -4341,7 +4341,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mex-agent",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Persistent project memory and deterministic local code graphs for AI coding agents",
   "type": "module",
   "main": "./dist/index.js",
@@ -76,6 +76,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
     "simple-git": "^3.27.0",
+    "typescript": "5.9.3",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "web-tree-sitter": "^0.25.10",
@@ -88,7 +89,6 @@
     "ink-testing-library": "^4.0.0",
     "tree-sitter-wasms": "^0.1.12",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -224,9 +224,10 @@ graphCommand
 
 graphCommand
   .command("scope <task...>")
-  .description("Retrieve a compact code neighborhood for a task as JSONL")
-  .option("--detail <level>", "minimal | standard | source", "minimal")
+  .description("Retrieve source-backed code context and execution flow for a task as JSONL")
+  .option("--detail <level>", "minimal | standard | source", "source")
   .option("--max-nodes <n>", "maximum nodes to return")
+  .option("--max-files <n>", "maximum source files to return")
   .option("--max-output-tokens <n>", "hard output token ceiling")
   .option("--max-source-lines <n>", "per-node source line cap (with --detail source)")
   .option("--fingerprint", "attach serialized node fingerprints (grounding workflow)")

--- a/src/graph/__tests__/cli-agent.test.ts
+++ b/src/graph/__tests__/cli-agent.test.ts
@@ -1,17 +1,23 @@
 // Integration test for the agent-facing JSONL commands. Builds a real graph over
 // a tiny project and drives runGraphScope / runGraphQuery / runGraphGet / runImpact
 // through injected session + capturing writer, asserting the protocol contract:
-// meta first, compact source-off facts by default, summary last, budget truncation,
-// and source-on-demand via `graph get`.
+// meta first, source-bearing Scope by default, summary last, budget truncation,
+// directed flow records, and narrow source-on-demand via `graph get`.
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createGraphEngine } from "../index.js";
 import type { GraphEngine } from "../engine.js";
+import type { GraphEdge, GraphNode } from "../types.js";
+import type { RankedScopeFile, ScopedCandidate, SourceRange } from "../scope.js";
 import { openSqlite } from "../db/sqlite.js";
-import { runGraphGet, runGraphQuery, runGraphScope, runImpact, type AgentCommandDeps } from "../cli-agent.js";
+import {
+  bestSemanticQuerySourceCandidate,
+  runGraphGet, runGraphQuery, runGraphScope, runImpact, type AgentCommandDeps,
+} from "../cli-agent.js";
 
 let root: string;
 let engine: GraphEngine;
@@ -28,6 +34,48 @@ function idOf(name: string): string {
   const hit = engine.searchNodes(name).find((n) => n.name === name);
   if (!hit) throw new Error(`no node ${name}`);
   return hit.id;
+}
+
+function syntheticScopeGraph(options: {
+  nodes: GraphNode[];
+  edges?: GraphEdge[];
+  sources: Array<{ path: string; content: string }>;
+  searchNodes: (request: string) => GraphNode[];
+  sourceHits?: Array<{
+    filePath: string; startLine: number; endLine: number; contentHash: string;
+    rank: number; matchedTerms: string[]; nodeIds?: string[];
+  }>;
+}): GraphEngine {
+  const edges = options.edges ?? [];
+  const nodeById = new Map(options.nodes.map((node) => [node.id, node]));
+  return {
+    build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+    sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+    close: () => {},
+    searchNodes: options.searchNodes,
+    searchSource: () => options.sourceHits ?? [],
+    getNode: (id) => nodeById.get(id) ?? null,
+    getCallers: (id) => edges.filter((edge) => edge.target === id)
+      .flatMap((edge) => nodeById.get(edge.source) ?? []),
+    getCallees: (id) => edges.filter((edge) => edge.source === id)
+      .flatMap((edge) => nodeById.get(edge.target) ?? []),
+    getIncoming: (id) => edges.filter((edge) => edge.target === id)
+      .flatMap((edge) => {
+        const node = nodeById.get(edge.source);
+        return node ? [{ edge, node }] : [];
+      }),
+    getOutgoing: (id) => edges.filter((edge) => edge.source === id)
+      .flatMap((edge) => {
+        const node = nodeById.get(edge.target);
+        return node ? [{ edge, node }] : [];
+      }),
+    getIndexedFiles: () => options.sources.map(({ path, content }) => ({
+      path, contentHash: createHash("sha256").update(content).digest("hex"),
+      language: "typescript", size: content.length, modifiedAt: 1,
+      nodeCount: options.nodes.filter((node) => node.filePath === path).length,
+      parseStatus: "ok" as const, diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+    })),
+  };
 }
 
 beforeAll(async () => {
@@ -50,25 +98,137 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
+describe("semantic query source reservation", () => {
+  const node = (id: string, name: string, filePath: string, signature?: string): GraphNode => ({
+    id, kind: "function", name, qualifiedName: name, signature,
+    filePath, language: "typescript", startLine: 1, endLine: 20,
+    startColumn: 0, endColumn: 1, updatedAt: 1,
+  });
+  const file = (entry: GraphNode): RankedScopeFile => ({
+    filePath: entry.filePath, score: 1, reasons: [], nodeIds: [entry.id],
+    textHits: [], textOnly: false, parseStatus: "ok",
+  });
+  const candidate = (id: string, score: number, reasons: string[]): ScopedCandidate => ({
+    id, score, reasons, category: "direct",
+  });
+
+  it("groups identifier terms by raw query concept and rejects stronger term-only evidence", () => {
+    const commandLine = node("command-line", "commandLineWorker", "command.ts");
+    const answer = node(
+      "config-answer", "findConfigFile", "config.ts",
+      "(searchPath: string, configName?: string): string | undefined",
+    );
+    const termOnly = node(
+      "term-only", "searchConfigFile", "lexical.ts",
+      "(searchPath: string, configName?: string): string | undefined",
+    );
+    const contextual = node(
+      "contextual", "performIncrementalCompilation", "command.ts",
+      "(config: ParsedCommandLine): void",
+    );
+    const nodes = new Map([commandLine, answer, termOnly, contextual].map((entry) => [entry.id, entry]));
+    const candidates = [
+      candidate(commandLine.id, 100, [
+        "bm25-node", "graph:calls", "source-region:callsite", "term:command", "term:line",
+      ]),
+      candidate(termOnly.id, 200, ["bm25-node", "term:search", "term:confi"]),
+      // Contextual signature coverage (`compilation` + `config`) is useful,
+      // but two independently corroborated answer concepts are stronger.
+      candidate(contextual.id, 300, [
+        "bm25-node", "graph:calls", "source-region:callsite", "term:compilation",
+      ]),
+      candidate(answer.id, 1, ["graph:calls", "source-region:callsite", "term:search", "term:confi"]),
+    ];
+    expect(bestSemanticQuerySourceCandidate(
+      "Where does command-line compilation search upward for a project configuration?",
+      candidates, [file(commandLine), file(termOnly), file(contextual), file(answer)], nodes,
+    )).toBe(answer.id);
+  });
+
+  it("counts direct declaration concepts beyond the first recorded term channel", () => {
+    const target = node(
+      "source-planner", "planFileSource", "scope.ts",
+      "(nodes: GraphNode[], textHits: SourceChunkHit[]): SourceRange[]",
+    );
+    const decoy = node(
+      "query-planner", "planGraphQuery", "query.ts",
+      "(query: string): GraphQueryPlan",
+    );
+    const nodes = new Map([target, decoy].map((entry) => [entry.id, entry]));
+    expect(bestSemanticQuerySourceCandidate(
+      "How does Scope plan bounded source windows for selected symbols and query hits?",
+      [
+        candidate(decoy.id, 200, [
+          "bm25-node", "graph:calls", "source-region:callsite", "term:bounded", "term:plan",
+        ]),
+        // Scope records only the first matching term for a search channel.
+        // `source` and `hits` are still explicit declaration components and
+        // must contribute once `term:plan` independently corroborates it.
+        candidate(target.id, 1, [
+          "bm25-node", "graph:calls", "source-region:callsite",
+          "term:plan", "term:symbols", "term:windows",
+        ]),
+      ],
+      [file(decoy), file(target)], nodes,
+    )).toBe(target.id);
+  });
+
+  it("does not reserve lexical-only or anonymous callback candidates", () => {
+    const termOnly = node(
+      "term-only", "searchConfigFile", "lexical.ts",
+      "(searchPath: string, configName?: string): string | undefined",
+    );
+    const anonymous = node(
+      "anonymous", "<callback:searchConfigFile>", "callback.ts",
+      "(searchPath: string, configName?: string): string | undefined",
+    );
+    const nodes = new Map([termOnly, anonymous].map((entry) => [entry.id, entry]));
+    expect(bestSemanticQuerySourceCandidate(
+      "search project configuration",
+      [
+        candidate(termOnly.id, 100, ["bm25-node", "term:search", "term:project", "term:confi"]),
+        candidate(anonymous.id, 200, [
+          "graph:calls", "source-region:callsite", "term:search", "term:project", "term:confi",
+        ]),
+      ],
+      [file(termOnly), file(anonymous)], nodes,
+    )).toBeUndefined();
+  });
+});
+
 describe("runGraphScope", () => {
-  it("frames output with meta and summary and omits source by default", () => {
+  it("uses protocol v3 and returns source in the first response by default", () => {
     const records = capture(() => runGraphScope("run", root, deps, {}));
-    expect(records[0]).toMatchObject({ type: "meta", schemaVersion: 1, command: "graph scope", detail: "minimal" });
+    expect(records[0]).toMatchObject({
+      type: "meta", protocolVersion: 3, schemaVersion: 3, command: "graph scope", detail: "source",
+      maxFiles: 4, maxFlowSteps: 8, maxOutputTokens: 3500,
+    });
+    expect(records[1]).toMatchObject({ type: "health", indexedFiles: 2, okFiles: 2, failedFiles: 0 });
+    const sources = records.filter((r) => r.type === "source");
+    expect(sources.length).toBeGreaterThan(0);
+    expect(JSON.stringify(sources)).toContain("helper(41)");
+    expect(JSON.stringify(sources)).toMatch(/\d+: .*helper/);
     const facts = records.filter((r) => r.type === "fact");
     expect(facts.length).toBeGreaterThan(0);
     for (const fact of facts) {
       expect(fact).not.toHaveProperty("source");
       expect(fact).not.toHaveProperty("callers");
-      expect(fact.sourceIncluded).toBe(false);
+      expect(fact).not.toHaveProperty("detail");
+      expect(fact).not.toHaveProperty("sourceIncluded");
+      expect(fact).not.toHaveProperty("bodyHash");
       expect(typeof fact.callerCount).toBe("number");
       expect(typeof fact.score).toBe("number");
-      expect(Array.isArray(fact.selectionReasons)).toBe(true);
+      expect(fact).not.toHaveProperty("selectionReasons");
     }
     const summary = records.at(-1)!;
-    expect(summary).toMatchObject({ type: "summary" });
+    expect(summary).toMatchObject({
+      type: "summary", status: "ok", evidenceStrength: "strong",
+      returnedFiles: expect.arrayContaining(["main.ts"]), textFallbackFiles: [], suggestedNextCommands: [],
+    });
+    expect(summary.sourceBackedNodes).toEqual(expect.arrayContaining(facts.map((fact) => fact.id)));
     expect(typeof summary.estimatedOutputTokens).toBe("number");
     expect(typeof summary.truncated).toBe("boolean");
-    expect(records.some((r) => r.type === "source")).toBe(false);
+    expect(records.findIndex((r) => r.type === "source")).toBeLessThan(records.findIndex((r) => r.type === "fact"));
   });
 
   it("emits grouped source records when detail is source", () => {
@@ -79,16 +239,1064 @@ describe("runGraphScope", () => {
     expect(joined).toContain("helper");
   });
 
-  it("truncates under a tight output-token budget", () => {
+  it("rejects an output-token budget too small for honest protocol framing", () => {
     const records = capture(() => runGraphScope("run", root, deps, { maxOutputTokens: 60 }));
-    const summary = records.at(-1)!;
-    expect(summary.type).toBe("summary");
-    expect(summary.truncated).toBe(true);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ type: "error", code: "INVALID_OUTPUT_BUDGET" });
+    expect(records[0]!.message).toContain("use at least");
   });
 
   it("caps the number of returned facts at maxNodes", () => {
     const records = capture(() => runGraphScope("run", root, deps, { maxNodes: 1 }));
     expect(records.filter((r) => r.type === "fact")).toHaveLength(1);
+  });
+
+  it("keeps the full-query declaration source ahead of a whole-file lexical distractor", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-full-query-"));
+    const scopeLines = Array.from({ length: 260 }, (_, index) => `// scope filler ${index + 1}`);
+    scopeLines[0] = "export function selectScope(): void {";
+    scopeLines[79] = "}";
+    scopeLines[119] = "export function planSourceWindows(symbols: unknown[]): unknown[] {";
+    for (let line = 120; line < 149; line++) scopeLines[line] = `  // bounded source window ${line + 1}`;
+    scopeLines[149] = "  return symbols;";
+    scopeLines[150] = "}";
+    const queryLines = Array.from({ length: 183 }, (_, index) => (
+      `// query planning distraction ${index + 1} ${"x".repeat(32)}`
+    ));
+    queryLines[116] = "export function planGraphQuery(query: string): string {";
+    queryLines[168] = "  return query;";
+    queryLines[169] = "}";
+    const scopeSource = scopeLines.join("\n");
+    const querySource = queryLines.join("\n");
+    writeFileSync(join(isolated, "scope.ts"), scopeSource);
+    writeFileSync(join(isolated, "query.ts"), querySource);
+
+    const sourceDecoy: GraphNode = {
+      id: "function:source-decoy", kind: "function", name: "selectScope", qualifiedName: "selectScope",
+      filePath: "scope.ts", language: "typescript", startLine: 1, endLine: 80,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const target: GraphNode = {
+      id: "function:source-planner", kind: "function", name: "planSourceWindows",
+      qualifiedName: "planSourceWindows", signature: "(symbols: unknown[]): unknown[]",
+      filePath: "scope.ts", language: "typescript", startLine: 120, endLine: 151,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const queryPlanner: GraphNode = {
+      id: "function:query-planner", kind: "function", name: "planGraphQuery",
+      qualifiedName: "planGraphQuery", signature: "(query: string): string",
+      filePath: "query.ts", language: "typescript", startLine: 117, endLine: 170,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graphNodes = [target, sourceDecoy, queryPlanner];
+    const query = "plan bounded source windows";
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {},
+      searchNodes: (request) => request === query || ["plan", "source", "windows"].includes(request)
+        ? [target, queryPlanner] : request === "bounded" ? [queryPlanner] : [],
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      searchSource: () => [{
+        filePath: sourceDecoy.filePath, startLine: 1, endLine: 80,
+        contentHash: createHash("sha256").update(scopeSource).digest("hex"), rank: -0.4,
+        matchedTerms: ["plan", "bounded", "source", "windows"], nodeIds: [sourceDecoy.id],
+      }, {
+        filePath: target.filePath, startLine: 101, endLine: 160,
+        contentHash: createHash("sha256").update(scopeSource).digest("hex"), rank: -0.3,
+        matchedTerms: ["plan", "source", "windows"], nodeIds: [target.id],
+      }, {
+        filePath: queryPlanner.filePath, startLine: 101, endLine: 180,
+        contentHash: createHash("sha256").update(querySource).digest("hex"), rank: -0.2,
+        matchedTerms: ["plan", "bounded"], nodeIds: [queryPlanner.id],
+      }],
+      getIndexedFiles: () => [{
+        path: target.filePath, contentHash: createHash("sha256").update(scopeSource).digest("hex"),
+        parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 2,
+      }, {
+        path: queryPlanner.filePath, contentHash: createHash("sha256").update(querySource).digest("hex"),
+        parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      }],
+    };
+    const db = deps.open!(root).db;
+    const directDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(query, isolated, directDeps, {
+        maxNodes: 1, maxFiles: 2, maxSourceLines: 200, maxOutputTokens: 1800,
+      }));
+      const sources = records.filter((record) => record.type === "source");
+      const targetIndex = sources.findIndex((record) => (record.ranges as Array<{ nodeIds: string[] }>)
+        .some((range) => range.nodeIds.includes(target.id)));
+      const queryWholeFileIndex = sources.findIndex((record) => record.filePath === queryPlanner.filePath
+        && (record.ranges as Array<{ startLine: number; endLine: number }>).some((range) => (
+          range.startLine === 1 && range.endLine === 183
+        )));
+      expect(targetIndex, JSON.stringify(records)).toBeGreaterThanOrEqual(0);
+      expect(sources[targetIndex]).toMatchObject({
+        filePath: target.filePath,
+        ranges: [expect.objectContaining({
+          startLine: target.startLine, endLine: target.endLine, nodeIds: [target.id], truncated: false,
+        })],
+      });
+      expect(queryWholeFileIndex === -1 || queryWholeFileIndex > targetIndex).toBe(true);
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(1800);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("includes selection diagnostics only at standard detail", () => {
+    const records = capture(() => runGraphScope("run", root, deps, { detail: "standard" }));
+    const facts = records.filter((r) => r.type === "fact");
+    expect(facts.length).toBeGreaterThan(0);
+    for (const fact of facts) expect(Array.isArray(fact.selectionReasons)).toBe(true);
+  });
+
+  it("emits an exact named symbol before a larger flow-spine file under a tight budget", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-priority-"));
+    const targetLines = Array.from({ length: 220 }, (_, index) => `// target filler ${index + 1}`);
+    targetLines.splice(199, 6,
+      "export function TargetSymbol(): number {", "  return 1;", "}", "", "", "");
+    const flowLines = Array.from({ length: 220 }, (_, index) => `// flow filler ${index + 1}`);
+    flowLines[0] = "export function firstStage(): number {";
+    flowLines[69] = "}";
+    flowLines[89] = "export function secondStage(): number {";
+    flowLines[90] = "  return TargetSymbol();";
+    flowLines[159] = "}";
+    const targetSource = targetLines.join("\n");
+    const flowSource = flowLines.join("\n");
+    writeFileSync(join(isolated, "target.ts"), targetSource);
+    writeFileSync(join(isolated, "flow.ts"), flowSource);
+
+    const target: GraphNode = {
+      id: "function:target", kind: "function", name: "TargetSymbol", qualifiedName: "TargetSymbol",
+      filePath: "target.ts", language: "typescript", startLine: 200, endLine: 202,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const first: GraphNode = {
+      id: "function:first", kind: "function", name: "firstStage", qualifiedName: "firstStage",
+      filePath: "flow.ts", language: "typescript", startLine: 1, endLine: 70,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const second: GraphNode = {
+      id: "function:second", kind: "function", name: "secondStage", qualifiedName: "secondStage",
+      filePath: "flow.ts", language: "typescript", startLine: 90, endLine: 160,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graphNodes = [target, first, second];
+    const graphEdges: GraphEdge[] = [
+      { source: first.id, target: second.id, kind: "calls", line: 40, column: 2, confidence: 1 },
+      { source: second.id, target: target.id, kind: "calls", line: 91, column: 2, confidence: 1 },
+    ];
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, parseErrors: [], durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, parseErrors: [], durationMs: 0 }),
+      close: () => {},
+      searchNodes: () => [target],
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => graphEdges.filter((edge) => edge.target === id).map((edge) => ({
+        edge, node: graphNodes.find((entry) => entry.id === edge.source)!,
+      })),
+      getOutgoing: (id) => graphEdges.filter((edge) => edge.source === id).map((edge) => ({
+        edge, node: graphNodes.find((entry) => entry.id === edge.target)!,
+      })),
+      getIndexedFiles: () => [
+        {
+          path: "target.ts", contentHash: createHash("sha256").update(targetSource).digest("hex"),
+          language: "typescript", size: targetSource.length, modifiedAt: 1, nodeCount: 1,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+        {
+          path: "flow.ts", contentHash: createHash("sha256").update(flowSource).digest("hex"),
+          language: "typescript", size: flowSource.length, modifiedAt: 1, nodeCount: 2,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+      ],
+    };
+    const db = deps.open!(root).db;
+    const priorityDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope("TargetSymbol", isolated, priorityDeps, {
+        maxOutputTokens: 1200, maxSourceLines: 200,
+      }));
+      const sources = records.filter((record) => record.type === "source");
+      expect(sources.length, JSON.stringify(records)).toBeGreaterThan(0);
+      expect(sources[0]).toMatchObject({ type: "source", filePath: "target.ts", evidence: "graph" });
+      expect(JSON.stringify(sources[0])).toContain("TargetSymbol");
+      // Under this deliberately tight budget the two complete flow bodies do
+      // not fit atomically. Preserve the directed flow record instead of
+      // emitting a misleading signature/tail fragment.
+      expect(records.some((record) => record.type === "flow")).toBe(true);
+      const summary = records.at(-1)!;
+      expect(summary).toMatchObject({ status: "ok", truncated: true });
+      expect(summary.estimatedOutputTokens as number).toBeLessThanOrEqual(summary.maxOutputTokens as number);
+
+      const roomy = capture(() => runGraphScope("TargetSymbol", isolated, priorityDeps, {
+        maxOutputTokens: 2400, maxSourceLines: 200,
+      }));
+      const flowRanges = roomy.filter((record) => record.type === "source" && record.filePath === "flow.ts")
+        .flatMap((record) => record.ranges as Array<{
+          startLine: number; endLine: number; truncated: boolean; nodeIds: string[];
+        }>);
+      expect(flowRanges).toEqual(expect.arrayContaining([
+        expect.objectContaining({ startLine: 1, endLine: 70, truncated: false }),
+        expect.objectContaining({ startLine: 90, endLine: 160, truncated: false }),
+      ]));
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an explicit exact lookup ahead of an unrelated displayed-flow target", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-exact-before-flow-"));
+    const exactSource = "export function TargetSymbol(): number {\n  return unrelatedFlowTarget();\n}\n";
+    const flowSource = "export function unrelatedFlowTarget(): number {\n  return 1;\n}\n";
+    writeFileSync(join(isolated, "target.ts"), exactSource);
+    writeFileSync(join(isolated, "flow.ts"), flowSource);
+    const exact: GraphNode = {
+      id: "function:exact-before-flow", kind: "function", name: "TargetSymbol", qualifiedName: "TargetSymbol",
+      filePath: "target.ts", language: "typescript", startLine: 1, endLine: 3,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const flowTarget: GraphNode = {
+      id: "function:unrelated-flow-target", kind: "function", name: "unrelatedFlowTarget",
+      qualifiedName: "unrelatedFlowTarget", filePath: "flow.ts", language: "typescript",
+      startLine: 1, endLine: 3, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const edge: GraphEdge = {
+      source: exact.id, target: flowTarget.id, kind: "calls", line: 2, column: 2, confidence: 1,
+    };
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {}, searchNodes: () => [exact], searchSource: () => [],
+      getNode: (id) => [exact, flowTarget].find((node) => node.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === flowTarget.id ? [{ edge, node: exact }] : [],
+      getOutgoing: (id) => id === exact.id ? [{ edge, node: flowTarget }] : [],
+      getIndexedFiles: () => [
+        {
+          path: exact.filePath, contentHash: createHash("sha256").update(exactSource).digest("hex"),
+          language: "typescript", size: exactSource.length, modifiedAt: 1, nodeCount: 1,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+        {
+          path: flowTarget.filePath, contentHash: createHash("sha256").update(flowSource).digest("hex"),
+          language: "typescript", size: flowSource.length, modifiedAt: 1, nodeCount: 1,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+      ],
+    };
+    const db = deps.open!(root).db;
+    const exactDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(
+        "TargetSymbol", isolated, exactDeps,
+        { maxOutputTokens: 1500, maxSourceLines: 200, maxFiles: 2 },
+      ));
+      const sources = records.filter((record) => record.type === "source");
+      expect(sources[0], JSON.stringify(records)).toMatchObject({
+        filePath: exact.filePath,
+        ranges: [expect.objectContaining({ nodeIds: [exact.id], truncated: false })],
+      });
+      expect(records.some((record) => record.type === "flow")).toBe(true);
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(1500);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat unrelated primary source and flow coverage as completion of a nested query body", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "scope-source-completeness-"));
+    const primaryLines = Array.from({ length: 70 }, (_, index) => `// primary selection ${index + 1}`);
+    primaryLines[0] = "export class PrimarySelector {";
+    primaryLines[68] = "  choose(): void {}";
+    primaryLines[69] = "}";
+    const secondaryLines = Array.from({ length: 150 }, (_, index) => `// secondary flow ${index + 1}`);
+    secondaryLines[0] = "export function collectBackgroundPaths(): void {";
+    secondaryLines[79] = "  function matchBackgroundPaths(): void {";
+    secondaryLines[148] = "  }";
+    secondaryLines[149] = "}";
+    const primarySource = primaryLines.join("\n");
+    const secondarySource = secondaryLines.join("\n");
+    writeFileSync(join(isolated, "primary.ts"), primarySource);
+    writeFileSync(join(isolated, "secondary.ts"), secondarySource);
+
+    const primary: GraphNode = {
+      id: "class:primary-selector", kind: "class", name: "PrimarySelector", qualifiedName: "PrimarySelector",
+      filePath: "primary.ts", language: "typescript", startLine: 1, endLine: 70,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const primaryHelper: GraphNode = {
+      id: "method:primary-choose", kind: "method", name: "choose",
+      qualifiedName: "PrimarySelector::choose", filePath: "primary.ts", language: "typescript",
+      startLine: 69, endLine: 69, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const backgroundStart: GraphNode = {
+      id: "function:background-start", kind: "function", name: "collectBackgroundPaths",
+      qualifiedName: "collectBackgroundPaths", filePath: "secondary.ts", language: "typescript",
+      startLine: 1, endLine: 150, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const backgroundEnd: GraphNode = {
+      id: "function:background-end", kind: "function", name: "matchBackgroundPaths",
+      qualifiedName: "collectBackgroundPaths::matchBackgroundPaths",
+      filePath: "secondary.ts", language: "typescript",
+      startLine: 80, endLine: 149, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const backgroundEdge: GraphEdge = {
+      source: primary.id, target: primaryHelper.id, kind: "calls",
+      line: 69, column: 2, confidence: 1,
+    };
+    const query = "How does nested matchBackgroundPaths advance selected paths?";
+    const graph = syntheticScopeGraph({
+      nodes: [primary, primaryHelper, backgroundStart, backgroundEnd], edges: [backgroundEdge],
+      sources: [
+        { path: primary.filePath, content: primarySource },
+        { path: backgroundStart.filePath, content: secondarySource },
+      ],
+      searchNodes: (request) => request === query || request.includes("PrimarySelector")
+        ? [primary, primaryHelper] : [backgroundStart, backgroundEnd],
+      sourceHits: [{
+        filePath: primary.filePath, startLine: 1, endLine: 70,
+        contentHash: createHash("sha256").update(primarySource).digest("hex"), rank: -1,
+        matchedTerms: ["paths"], nodeIds: [primary.id, primaryHelper.id],
+      }, {
+        filePath: backgroundStart.filePath, startLine: 1, endLine: 150,
+        contentHash: createHash("sha256").update(secondarySource).digest("hex"), rank: -0.05,
+        matchedTerms: ["nested", "match", "background", "paths"],
+        nodeIds: [backgroundEnd.id, backgroundStart.id],
+      }],
+    });
+    const db = deps.open!(root).db;
+    const directDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }), write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(query, isolated, directDeps, {
+        maxFiles: 2, maxSourceLines: 200, maxOutputTokens: 3000,
+      }));
+      const primaryRanges = records.filter((record) => record.type === "source"
+        && record.filePath === primary.filePath)
+        .flatMap((record) => record.ranges as SourceRange[]);
+      const secondaryRanges = records.filter((record) => record.type === "source"
+        && record.filePath === backgroundStart.filePath)
+        .flatMap((record) => record.ranges as SourceRange[]);
+      expect(primaryRanges).toEqual([
+        expect.objectContaining({ startLine: 1, endLine: 70, reason: "whole-file", truncated: false }),
+      ]);
+      const nestedLines = new Set(secondaryRanges.flatMap((range) => (
+        Array.from({ length: range.endLine - range.startLine + 1 }, (_, index) => range.startLine + index)
+      )));
+      expect(nestedLines.has(backgroundEnd.startLine), JSON.stringify(records)).toBe(true);
+      expect(nestedLines.has(backgroundEnd.endLine), JSON.stringify(records)).toBe(true);
+      expect(records.some((record) => record.type === "flow"
+        && (record.steps as GraphEdge[]).some((edge) => edge.source === primary.id
+          && edge.target === primaryHelper.id))).toBe(true);
+      expect(records.at(-1)).toMatchObject({ type: "summary", status: "ok" });
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(3000);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a 185-line primary whole-file answer intact", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "scope-source-long-primary-"));
+    const sourceLines = Array.from({ length: 185 }, (_, index) => `// primary body ${index + 1}`);
+    sourceLines[0] = "export function PrimaryProcedure(): void {";
+    sourceLines[184] = "}";
+    const source = sourceLines.join("\n");
+    writeFileSync(join(isolated, "primary.ts"), source);
+    const primary: GraphNode = {
+      id: "function:primary-procedure", kind: "function", name: "PrimaryProcedure",
+      qualifiedName: "PrimaryProcedure", filePath: "primary.ts", language: "typescript",
+      startLine: 1, endLine: 185, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graph = syntheticScopeGraph({
+      nodes: [primary], sources: [{ path: primary.filePath, content: source }],
+      searchNodes: () => [primary],
+      sourceHits: [{
+        filePath: primary.filePath, startLine: 1, endLine: 185,
+        contentHash: createHash("sha256").update(source).digest("hex"), rank: -1,
+        matchedTerms: ["primary", "procedure"], nodeIds: [primary.id],
+      }],
+    });
+    const db = deps.open!(root).db;
+    const directDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }), write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope("PrimaryProcedure", isolated, directDeps, {
+        maxFiles: 1, maxSourceLines: 200, maxOutputTokens: 3000,
+      }));
+      const ranges = records.filter((record) => record.type === "source")
+        .flatMap((record) => record.ranges as SourceRange[]);
+      expect(ranges).toEqual([
+        expect.objectContaining({
+          startLine: 1, endLine: 185, nodeIds: expect.arrayContaining([primary.id]),
+          reason: "whole-file", truncated: false,
+        }),
+      ]);
+      expect(records.at(-1)).toMatchObject({ type: "summary", status: "ok" });
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(3000);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("coalesces overlapping complete declarations before source serialization", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "scope-source-overlap-"));
+    const sourceLines = Array.from({ length: 220 }, (_, index) => `// assembly body ${index + 1}`);
+    sourceLines[19] = "export function EnvelopeAssembler(): void {";
+    sourceLines[29] = "  const representation = 'stable';";
+    sourceLines[79] = "  function boundedDigest(): string {";
+    sourceLines[109] = "  }";
+    sourceLines[159] = "}";
+    const source = sourceLines.join("\n");
+    writeFileSync(join(isolated, "assembly.ts"), source);
+    const parent: GraphNode = {
+      id: "function:envelope-assembler", kind: "function", name: "EnvelopeAssembler",
+      qualifiedName: "EnvelopeAssembler", filePath: "assembly.ts", language: "typescript",
+      startLine: 20, endLine: 160, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const property: GraphNode = {
+      id: "property:representation", kind: "property", name: "representation",
+      qualifiedName: "EnvelopeAssembler::representation", filePath: "assembly.ts", language: "typescript",
+      startLine: 30, endLine: 30, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const helper: GraphNode = {
+      id: "function:bounded-digest", kind: "function", name: "boundedDigest",
+      qualifiedName: "EnvelopeAssembler::boundedDigest", filePath: "assembly.ts", language: "typescript",
+      startLine: 80, endLine: 110, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const edge: GraphEdge = {
+      source: parent.id, target: helper.id, kind: "calls", line: 120, column: 2, confidence: 1,
+    };
+    const graph = syntheticScopeGraph({
+      nodes: [parent, property, helper], edges: [edge],
+      sources: [{ path: parent.filePath, content: source }],
+      searchNodes: () => [parent, property, helper],
+      sourceHits: [{
+        filePath: parent.filePath, startLine: 20, endLine: 160,
+        contentHash: createHash("sha256").update(source).digest("hex"), rank: -1,
+        matchedTerms: ["envelope", "assembler"], nodeIds: [parent.id, property.id, helper.id],
+      }],
+    });
+    const db = deps.open!(root).db;
+    const directDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }), write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope("EnvelopeAssembler", isolated, directDeps, {
+        maxFiles: 1, maxSourceLines: 200, maxOutputTokens: 3000,
+      }));
+      const ranges = records.filter((record) => record.type === "source")
+        .flatMap((record) => record.ranges as SourceRange[])
+        .sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine);
+      for (let index = 1; index < ranges.length; index++) {
+        expect(ranges[index]!.startLine).toBeGreaterThan(ranges[index - 1]!.endLine);
+      }
+      expect(ranges).toEqual([
+        expect.objectContaining({
+          startLine: 20, endLine: 160, truncated: false,
+          nodeIds: expect.arrayContaining([parent.id, helper.id]),
+        }),
+      ]);
+      expect(records.some((record) => record.type === "flow"
+        && (record.steps as GraphEdge[]).some((step) => step.source === parent.id
+          && step.target === helper.id))).toBe(true);
+      expect(records.at(-1)).toMatchObject({ type: "summary", status: "ok" });
+      expect(records.at(-1)!.sourceBackedNodes).toEqual(expect.arrayContaining([
+        parent.id, helper.id,
+      ]));
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(3000);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("emits the most cohesive file before an incidental exact project symbol and ignores optional trimming for status", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-cohesion-"));
+    mkdirSync(join(isolated, "runtime"));
+    const frameworkSource = "export class Framework {}\n";
+    const targetSource = Array.from({ length: 70 }, (_, index) => (
+      index === 0 ? "export function assemblePipeline(stages: unknown[], handlers: unknown[]) {"
+        : index === 68 ? "  return handlers.map((handler) => handler(stages))"
+          : index === 69 ? "}" : `  // cohesive pipeline stage ${index}`
+    )).join("\n");
+    const optionalSource = Array.from({ length: 200 }, (_, index) => `// optional handler note ${index + 1}`).join("\n");
+    writeFileSync(join(isolated, "framework.ts"), frameworkSource);
+    writeFileSync(join(isolated, "runtime", "assemble-pipeline.ts"), targetSource);
+    writeFileSync(join(isolated, "optional.ts"), optionalSource);
+
+    const framework: GraphNode = {
+      id: "class:framework", kind: "class", name: "Framework", qualifiedName: "Framework",
+      filePath: "framework.ts", language: "typescript", startLine: 1, endLine: 1,
+      startColumn: 0, endColumn: 25, updatedAt: 1,
+    };
+    const target: GraphNode = {
+      id: "function:assemble", kind: "function", name: "assemblePipeline", qualifiedName: "assemblePipeline",
+      signature: "function assemblePipeline(stages: unknown[], handlers: unknown[]): unknown[]",
+      filePath: "runtime/assemble-pipeline.ts", language: "typescript", startLine: 1, endLine: 70,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const optional: GraphNode = {
+      id: "function:optional", kind: "function", name: "optionalHandler", qualifiedName: "optionalHandler",
+      signature: "function optionalHandler(handler: unknown): void",
+      filePath: "optional.ts", language: "typescript", startLine: 1, endLine: 200,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graphNodes = [framework, target, optional];
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {}, searchNodes: () => graphNodes,
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      searchSource: () => [
+        {
+          filePath: target.filePath, startLine: 1, endLine: 70,
+          contentHash: createHash("sha256").update(targetSource).digest("hex"), rank: -0.08,
+          matchedTerms: ["assemble", "pipeline", "stages", "handlers"],
+        },
+        {
+          filePath: optional.filePath, startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(optionalSource).digest("hex"), rank: -0.02,
+          matchedTerms: ["handler"],
+        },
+      ],
+      getIndexedFiles: () => [
+        {
+          path: framework.filePath, contentHash: createHash("sha256").update(frameworkSource).digest("hex"),
+          parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        },
+        {
+          path: target.filePath, contentHash: createHash("sha256").update(targetSource).digest("hex"),
+          parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        },
+        {
+          path: optional.filePath, contentHash: createHash("sha256").update(optionalSource).digest("hex"),
+          parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        },
+      ],
+    };
+    const db = deps.open!(root).db;
+    const cohesiveDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(
+        "How does Framework assemble pipeline stages with handlers?",
+        isolated,
+        cohesiveDeps,
+        { maxOutputTokens: 1800, maxSourceLines: 200, maxFiles: 3 },
+      ));
+      const sources = records.filter((record) => record.type === "source");
+      expect(sources[0]).toMatchObject({ filePath: target.filePath });
+      const targetRanges = sources.filter((record) => record.filePath === target.filePath)
+        .flatMap((record) => record.ranges as Array<{ startLine: number; endLine: number }>);
+      expect(sources.filter((record) => record.filePath === target.filePath)).toHaveLength(1);
+      expect(targetRanges).toEqual([
+        expect.objectContaining({ startLine: 1, endLine: 70, reason: "whole-file", truncated: false }),
+      ]);
+      expect(records.at(-1)).toMatchObject({ type: "summary", status: "ok", truncated: true });
+
+      const constrained = capture(() => runGraphScope(
+        "How does Framework assemble pipeline stages with handlers?",
+        isolated,
+        cohesiveDeps,
+        { maxOutputTokens: 1200, maxSourceLines: 200, maxFiles: 3 },
+      ));
+      expect(constrained.at(-1)).toMatchObject({
+        type: "summary", status: "partial", truncated: true,
+        warnings: expect.arrayContaining([expect.stringContaining("High-priority evidence omitted")]),
+      });
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("admits a rank-three file's compact primary before an earlier file's optional bodies", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-fairness-"));
+    const dense = "x".repeat(120);
+    const firstLines = Array.from({ length: 240 }, (_, index) => `// first filler ${index + 1}`);
+    firstLines.splice(0, 6,
+      "export function pipelineStart(): void {", "  // primary pipeline anchor", "}", "", "", "");
+    for (let line = 19; line < 99; line++) firstLines[line] = `// optional alpha ${dense}`;
+    for (let line = 109; line < 189; line++) firstLines[line] = `// optional beta ${dense}`;
+    const secondLines = Array.from({ length: 220 }, (_, index) => `// second filler ${index + 1}`);
+    secondLines.splice(0, 4, "export function pipelineSecondary(): void {", "  return;", "}", "");
+    const thirdLines = Array.from({ length: 240 }, (_, index) => `// third filler ${index + 1}`);
+    thirdLines[0] = "export function pipelineDeclarationOne(): number {";
+    for (let line = 1; line < 79; line++) thirdLines[line] = `// third decoy one ${dense}`;
+    thirdLines[79] = "}";
+    thirdLines[89] = "export function pipelineDeclarationTwo(): number {";
+    for (let line = 90; line < 159; line++) thirdLines[line] = `// third decoy two ${dense}`;
+    thirdLines[159] = "}";
+    thirdLines.splice(169, 6,
+      "export function pipelineDeclarationAnswer(): number {", "  // compact requested declaration", "  return 3;", "}", "", "");
+    const firstSource = firstLines.join("\n");
+    const secondSource = secondLines.join("\n");
+    const thirdSource = thirdLines.join("\n");
+    writeFileSync(join(isolated, "first.ts"), firstSource);
+    writeFileSync(join(isolated, "second.ts"), secondSource);
+    writeFileSync(join(isolated, "third.ts"), thirdSource);
+
+    const primary: GraphNode = {
+      id: "function:pipeline-start", kind: "function", name: "pipelineStart", qualifiedName: "pipelineStart",
+      filePath: "first.ts", language: "typescript", startLine: 1, endLine: 6,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const optionalAlpha: GraphNode = {
+      id: "function:optional-alpha", kind: "function", name: "pipelineOptionalAlpha",
+      qualifiedName: "pipelineOptionalAlpha", filePath: "first.ts", language: "typescript",
+      startLine: 20, endLine: 99, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const optionalBeta: GraphNode = {
+      id: "function:optional-beta", kind: "function", name: "pipelineOptionalBeta",
+      qualifiedName: "pipelineOptionalBeta", filePath: "first.ts", language: "typescript",
+      startLine: 110, endLine: 189, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const secondary: GraphNode = {
+      id: "function:pipeline-secondary", kind: "function", name: "pipelineSecondary",
+      qualifiedName: "pipelineSecondary", filePath: "second.ts", language: "typescript",
+      startLine: 1, endLine: 4, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const thirdDecoyOne: GraphNode = {
+      id: "function:third-decoy-one", kind: "function", name: "pipelineDeclarationOne",
+      qualifiedName: "pipelineDeclarationOne", filePath: "third.ts", language: "typescript",
+      startLine: 1, endLine: 80, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const thirdDecoyTwo: GraphNode = {
+      id: "function:third-decoy-two", kind: "function", name: "pipelineDeclarationTwo",
+      qualifiedName: "pipelineDeclarationTwo", filePath: "third.ts", language: "typescript",
+      startLine: 90, endLine: 160, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const target: GraphNode = {
+      id: "function:third-answer", kind: "function", name: "pipelineDeclarationAnswer",
+      qualifiedName: "pipelineDeclarationAnswer", filePath: "third.ts", language: "typescript",
+      startLine: 170, endLine: 175, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graphNodes = [primary, optionalAlpha, optionalBeta, secondary, thirdDecoyOne, thirdDecoyTwo, target];
+    const sources = new Map([
+      ["first.ts", firstSource], ["second.ts", secondSource], ["third.ts", thirdSource],
+    ]);
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {}, searchNodes: () => graphNodes,
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      searchSource: () => [
+        {
+          filePath: "first.ts", startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(firstSource).digest("hex"), rank: -3,
+          matchedTerms: ["pipeline"], nodeIds: [primary.id, optionalAlpha.id],
+        },
+        {
+          filePath: "second.ts", startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(secondSource).digest("hex"), rank: -2,
+          matchedTerms: ["pipeline"], nodeIds: [secondary.id],
+        },
+        {
+          filePath: "third.ts", startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(thirdSource).digest("hex"), rank: -0.3,
+          matchedTerms: ["pipeline", "declaration"], nodeIds: [thirdDecoyOne.id],
+        },
+        {
+          filePath: "third.ts", startLine: 90, endLine: 160,
+          contentHash: createHash("sha256").update(thirdSource).digest("hex"), rank: -0.2,
+          matchedTerms: ["pipeline", "declaration"], nodeIds: [thirdDecoyTwo.id],
+        },
+        {
+          filePath: "third.ts", startLine: 170, endLine: 220,
+          contentHash: createHash("sha256").update(thirdSource).digest("hex"), rank: -0.1,
+          matchedTerms: ["pipeline", "declaration"], nodeIds: [target.id],
+        },
+      ],
+      getIndexedFiles: () => [...sources].map(([path, source]) => ({
+        path, contentHash: createHash("sha256").update(source).digest("hex"),
+        language: "typescript" as const, size: source.length, modifiedAt: 1,
+        nodeCount: graphNodes.filter((node) => node.filePath === path).length,
+        parseStatus: "ok" as const, diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+      })),
+    };
+    const db = deps.open!(root).db;
+    const fairnessDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(
+        "locate the pipeline declaration answer",
+        isolated,
+        fairnessDeps,
+        { maxOutputTokens: 3500, maxSourceLines: 200, maxFiles: 3 },
+      ));
+      const sourceRecords = records.filter((record) => record.type === "source");
+      const targetIndex = sourceRecords.findIndex((record) => (record.ranges as Array<{ nodeIds: string[] }>)
+        .some((range) => range.nodeIds.includes(target.id)));
+      const optionalIndex = sourceRecords.findIndex((record) => record.filePath === "first.ts"
+        && (record.ranges as Array<{ startLine: number }>).some((range) => range.startLine > 25));
+      expect(targetIndex, JSON.stringify(records)).toBeGreaterThanOrEqual(0);
+      expect(optionalIndex === -1 || optionalIndex > targetIndex).toBe(true);
+      expect(sourceRecords[targetIndex]).toMatchObject({
+        filePath: "third.ts",
+        ranges: [expect.objectContaining({ startLine: 170, endLine: 175, truncated: false })],
+      });
+      expect(records.at(-1)).toMatchObject({
+        type: "summary",
+        returnedFiles: expect.arrayContaining(["first.ts", "second.ts", "third.ts"]),
+        maxOutputTokens: 3500,
+      });
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(3500);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("completes a later file's first bounded direct answer after an oversized decoy", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-direct-answer-"));
+    const leadLines = Array.from({ length: 90 }, (_, index) => (
+      index === 0 ? "export function primaryPipelineAnswer(): number {"
+        : index === 89 ? "}" : `// primary answer context ${index + 1} ${"lead".repeat(12)}`
+    ));
+    const answerLines = Array.from({ length: 240 }, (_, index) => `// secondary filler ${index + 1}`);
+    answerLines[0] = "export function pipelineCoordinator(): number {";
+    for (let line = 1; line < 179; line++) {
+      answerLines[line] = `// pipeline answer decoy ${line + 1} ${"dense".repeat(10)}`;
+    }
+    answerLines[179] = "}";
+    answerLines[189] = "export function sourceAnswer(): number {";
+    for (let line = 190; line < 218; line++) answerLines[line] = `// requested source answer ${line + 1}`;
+    answerLines[218] = "}";
+    const leadSource = leadLines.join("\n");
+    const answerSource = answerLines.join("\n");
+    writeFileSync(join(isolated, "lead.ts"), leadSource);
+    writeFileSync(join(isolated, "answer.ts"), answerSource);
+
+    const lead: GraphNode = {
+      id: "function:lead-answer", kind: "function", name: "primaryPipelineAnswer",
+      qualifiedName: "primaryPipelineAnswer", filePath: "lead.ts", language: "typescript",
+      startLine: 1, endLine: 90, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const decoy: GraphNode = {
+      id: "function:answer-decoy", kind: "function", name: "pipelineCoordinator",
+      qualifiedName: "pipelineCoordinator", filePath: "answer.ts", language: "typescript",
+      startLine: 1, endLine: 180, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const target: GraphNode = {
+      id: "function:source-answer", kind: "function", name: "sourceAnswer",
+      qualifiedName: "sourceAnswer", filePath: "answer.ts", language: "typescript",
+      startLine: 190, endLine: 219, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graphNodes = [lead, decoy, target];
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {}, searchNodes: () => graphNodes,
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      searchSource: () => [
+        {
+          filePath: "lead.ts", startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(leadSource).digest("hex"), rank: -8,
+          matchedTerms: ["pipeline", "answer", "source"], nodeIds: [lead.id],
+        },
+        {
+          filePath: "answer.ts", startLine: 1, endLine: 80,
+          contentHash: createHash("sha256").update(answerSource).digest("hex"), rank: -5,
+          matchedTerms: ["pipeline", "answer"], nodeIds: [decoy.id],
+        },
+        {
+          filePath: "answer.ts", startLine: 181, endLine: 240,
+          contentHash: createHash("sha256").update(answerSource).digest("hex"), rank: -4,
+          matchedTerms: ["source", "answer"], nodeIds: [target.id],
+        },
+      ],
+      getIndexedFiles: () => [
+        {
+          path: "lead.ts", contentHash: createHash("sha256").update(leadSource).digest("hex"),
+          language: "typescript", size: leadSource.length, modifiedAt: 1, nodeCount: 1,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+        {
+          path: "answer.ts", contentHash: createHash("sha256").update(answerSource).digest("hex"),
+          language: "typescript", size: answerSource.length, modifiedAt: 1, nodeCount: 2,
+          parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+      ],
+    };
+    const db = deps.open!(root).db;
+    const directDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(
+        "find the pipeline source answer", isolated, directDeps,
+        { maxOutputTokens: 3500, maxSourceLines: 200, maxFiles: 2 },
+      ));
+      const targetRanges = records.filter((record) => record.type === "source" && record.filePath === "answer.ts")
+        .flatMap((record) => record.ranges as Array<{ startLine: number; endLine: number; nodeIds: string[] }>)
+        .filter((range) => range.nodeIds.includes(target.id));
+      const coveredLines = targetRanges.flatMap((range) => (
+        Array.from({ length: range.endLine - range.startLine + 1 }, (_, index) => range.startLine + index)
+      ));
+      expect(Math.min(...coveredLines), JSON.stringify(records)).toBe(target.startLine);
+      expect(Math.max(...coveredLines), JSON.stringify(records)).toBe(target.endLine);
+      expect(new Set(coveredLines).size).toBe(target.endLine - target.startLine + 1);
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(3500);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("admits bounded callsite answers before fairness when a direct hit also appears in a flow", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-source-callsite-anchor-"));
+    const dense = "z".repeat(24);
+    const competitorDense = "z".repeat(24);
+    const sourceLines = Array.from({ length: 340 }, (_, index) => `// filler ${index + 1}`);
+    const declarations = [
+      { id: "function:direct-one", name: "pipelineDeclarationOne", start: 1, end: 80 },
+      { id: "function:direct-two", name: "pipelineDeclarationTwo", start: 90, end: 160 },
+      { id: "function:direct-three", name: "pipelineDeclarationThree", start: 170, end: 230 },
+    ];
+    for (const declaration of declarations) {
+      sourceLines[declaration.start - 1] = `export function ${declaration.name}(): number {`;
+      for (let line = declaration.start; line < declaration.end - 1; line++) {
+        sourceLines[line] = `// dense direct body ${dense}`;
+      }
+      sourceLines[declaration.end - 1] = "}";
+    }
+    sourceLines.splice(239, 6,
+      "export function semanticContinuation(): number {", "  // semantic callsite target", "  return 4;", "}", "", "");
+    sourceLines[249] = "export function pipelineDeclarationFallback(): number {";
+    for (let line = 250; line < 326; line++) {
+      sourceLines[line] = `// semantic target body ${line + 1} ${"answer".repeat(4)}`;
+    }
+    sourceLines[326] = "}";
+    sourceLines.splice(329, 6,
+      "export function finalSemanticTarget(): number {", "  // final semantic target", "  return 5;", "}", "", "");
+    const source = sourceLines.join("\n");
+    writeFileSync(join(isolated, "pipeline.ts"), source);
+
+    const competitorSources = new Map([
+      ["competitor-one.ts", "pipelineDeclarationCompetitorOne"],
+      ["competitor-two.ts", "pipelineDeclarationCompetitorTwo"],
+      ["competitor-three.ts", "pipelineDeclarationCompetitorThree"],
+    ].map(([filePath, name]) => {
+      const fileLines = Array.from({ length: 40 }, (_, index) => (
+        index === 0 ? `export function ${name}(): number {`
+          : index === 39 ? "}"
+            : `// competing declaration body ${index + 1} ${competitorDense}`
+      ));
+      const fileSource = fileLines.join("\n");
+      writeFileSync(join(isolated, filePath), fileSource);
+      return [filePath, fileSource] as const;
+    }));
+
+    const directNodes: GraphNode[] = declarations.map((declaration) => ({
+      id: declaration.id, kind: "function", name: declaration.name, qualifiedName: declaration.name,
+      filePath: "pipeline.ts", language: "typescript", startLine: declaration.start, endLine: declaration.end,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    }));
+    const semanticTarget: GraphNode = {
+      id: "function:semantic-target", kind: "function", name: "semanticContinuation",
+      qualifiedName: "semanticContinuation", filePath: "pipeline.ts", language: "typescript",
+      startLine: 240, endLine: 245, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const secondSemanticTarget: GraphNode = {
+      id: "function:second-semantic-target", kind: "function", name: "pipelineDeclarationFallback",
+      qualifiedName: "pipelineDeclarationFallback", filePath: "pipeline.ts", language: "typescript",
+      startLine: 250, endLine: 327, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const finalSemanticTarget: GraphNode = {
+      id: "function:final-semantic-target", kind: "function", name: "finalSemanticTarget",
+      qualifiedName: "finalSemanticTarget", filePath: "pipeline.ts", language: "typescript",
+      startLine: 330, endLine: 335, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const competitorNodes: GraphNode[] = [...competitorSources.keys()].map((filePath, index) => ({
+      id: `function:competitor-${index + 1}`, kind: "function",
+      name: `pipelineDeclarationCompetitor${index + 1}`,
+      qualifiedName: `pipelineDeclarationCompetitor${index + 1}`,
+      filePath, language: "typescript", startLine: 1, endLine: 40,
+      startColumn: 0, endColumn: 1, updatedAt: 1,
+    }));
+    const graphNodes = [
+      ...directNodes, semanticTarget, secondSemanticTarget, finalSemanticTarget, ...competitorNodes,
+    ];
+    const graphEdges: GraphEdge[] = [
+      { source: directNodes[0]!.id, target: semanticTarget.id, kind: "calls", line: 10, column: 2, confidence: 1 },
+      { source: directNodes[1]!.id, target: secondSemanticTarget.id, kind: "calls", line: 100, column: 2, confidence: 1 },
+      // This non-reserved authoritative source hit is also a later-flow
+      // endpoint. It must count against the direct quota, leaving both bounded
+      // flow slots available for the two semantic targets.
+      { source: directNodes[2]!.id, target: finalSemanticTarget.id, kind: "calls", line: 180, column: 2, confidence: 1 },
+    ];
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: 0 }),
+      close: () => {}, searchNodes: () => graphNodes,
+      getNode: (id) => graphNodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => graphEdges.filter((edge) => edge.target === id).map((edge) => ({
+        edge, node: graphNodes.find((entry) => entry.id === edge.source)!,
+      })),
+      getOutgoing: (id) => graphEdges.filter((edge) => edge.source === id).map((edge) => ({
+        edge, node: graphNodes.find((entry) => entry.id === edge.target)!,
+      })),
+      searchSource: () => [
+        ...directNodes.map((node, index) => ({
+          filePath: node.filePath, startLine: node.startLine, endLine: node.endLine,
+          contentHash: createHash("sha256").update(source).digest("hex"), rank: -6 + index,
+          matchedTerms: ["pipeline", "declaration"], nodeIds: [node.id],
+        })),
+        ...competitorNodes.map((node, index) => ({
+          filePath: node.filePath, startLine: node.startLine, endLine: node.endLine,
+          contentHash: createHash("sha256").update(competitorSources.get(node.filePath)!).digest("hex"),
+          rank: -2.9 + index * 0.1, matchedTerms: ["pipeline", "declaration"], nodeIds: [node.id],
+        })),
+      ],
+      getIndexedFiles: () => [
+        {
+          path: "pipeline.ts", contentHash: createHash("sha256").update(source).digest("hex"),
+          language: "typescript", size: source.length, modifiedAt: 1,
+          nodeCount: directNodes.length + 2, parseStatus: "ok",
+          diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+        },
+        ...competitorNodes.map((node) => {
+          const fileSource = competitorSources.get(node.filePath)!;
+          return {
+            path: node.filePath, contentHash: createHash("sha256").update(fileSource).digest("hex"),
+            language: "typescript" as const, size: fileSource.length, modifiedAt: 1, nodeCount: 1,
+            parseStatus: "ok" as const, diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+          };
+        }),
+      ],
+    };
+    const db = deps.open!(root).db;
+    const callsiteDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(
+        "locate the pipeline declaration", isolated, callsiteDeps,
+        { maxOutputTokens: 6000, maxSourceLines: 200, maxFiles: 4 },
+      ));
+      const sourceRecords = records.filter((record) => record.type === "source");
+      const semanticIndex = sourceRecords.findIndex((record) => (
+        record.ranges as Array<{ nodeIds: string[] }>
+      ).some((range) => range.nodeIds.includes(semanticTarget.id)));
+      const secondSemanticIndex = sourceRecords.findIndex((record) => (
+        record.ranges as Array<{ nodeIds: string[] }>
+      ).some((range) => range.nodeIds.includes(secondSemanticTarget.id)));
+      const finalSemanticIndex = sourceRecords.findIndex((record) => (
+        record.ranges as Array<{ nodeIds: string[] }>
+      ).some((range) => range.nodeIds.includes(finalSemanticTarget.id)));
+      const firstBodyIndex = sourceRecords.findIndex((record) => (
+        record.ranges as Array<{ startLine: number; nodeIds: string[] }>
+      ).some((range) => range.nodeIds.includes(directNodes[0]!.id) && range.startLine > 6));
+      const firstCompetitorIndex = sourceRecords.findIndex((record) => (
+        typeof record.filePath === "string" && record.filePath.startsWith("competitor-")
+      ));
+      // The terminal target of the first displayed path is the first atomic
+      // source answer, even though three earlier source-region declarations
+      // in the same file would otherwise consume the answer waves first.
+      expect(semanticIndex, JSON.stringify(records)).toBe(0);
+      // The globally best NL-correlated candidate is next: it has two direct
+      // identifier concepts plus callsite/graph proof. The competitor nodes
+      // have the same lexical concepts but no semantic callsite and therefore
+      // must not receive this global reservation.
+      expect(secondSemanticIndex, JSON.stringify(records)).toBe(1);
+      expect(finalSemanticIndex, JSON.stringify(records)).toBeGreaterThanOrEqual(0);
+      expect(firstCompetitorIndex, JSON.stringify(records)).toBeGreaterThan(Math.max(
+        semanticIndex, secondSemanticIndex, finalSemanticIndex,
+      ));
+      expect(firstBodyIndex === -1 || firstBodyIndex > Math.max(
+        semanticIndex, secondSemanticIndex, finalSemanticIndex,
+      )).toBe(true);
+      expect(sourceRecords[semanticIndex]).toMatchObject({
+        filePath: "pipeline.ts",
+        ranges: [expect.objectContaining({ startLine: 240, endLine: 245, truncated: false })],
+      });
+      expect(sourceRecords[secondSemanticIndex]).toMatchObject({
+        filePath: "pipeline.ts",
+        ranges: [expect.objectContaining({ startLine: 250, endLine: 327, truncated: false })],
+      });
+      expect(sourceRecords[finalSemanticIndex]).toMatchObject({
+        filePath: "pipeline.ts",
+        ranges: [expect.objectContaining({ startLine: 330, endLine: 335, truncated: false })],
+      });
+      const competitorRecords = sourceRecords.filter((record) => (
+        typeof record.filePath === "string" && record.filePath.startsWith("competitor-")
+      ));
+      expect(competitorRecords.length).toBeGreaterThan(0);
+      for (const record of competitorRecords) {
+        expect(record.ranges).toEqual([
+          expect.objectContaining({ startLine: 1, endLine: 40, reason: "whole-file", truncated: false }),
+        ]);
+      }
+      expect(records.at(-1)).toMatchObject({
+        type: "summary", returnedFiles: expect.arrayContaining(["pipeline.ts"]),
+      });
+      expect(records.at(-1)!.estimatedOutputTokens as number).toBeLessThanOrEqual(6000);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("caps deterministic summary lists and reports how many entries were omitted", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "mex-summary-cap-"));
+    const source = "export function alphaBeta(): void {}\n";
+    writeFileSync(join(isolated, "terms.ts"), source);
+    const terms = [
+      "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "theta", "lambda", "kappa", "sigma",
+      "omega", "quartz", "falcon", "harbor", "island", "jungle", "kernel", "matrix", "nebula", "orbit",
+    ];
+    const termNode: GraphNode = {
+      id: "function:terms", kind: "function", name: "alphaBeta", qualifiedName: "alphaBeta",
+      signature: `function alphaBeta(${terms.join(" ")}): void`, filePath: "terms.ts", language: "typescript",
+      startLine: 1, endLine: 1, startColumn: 0, endColumn: 1, updatedAt: 1,
+    };
+    const graph: GraphEngine = {
+      build: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, parseErrors: [], durationMs: 0 }),
+      sync: async () => ({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, parseErrors: [], durationMs: 0 }),
+      close: () => {}, searchNodes: () => [termNode],
+      getNode: (id) => id === termNode.id ? termNode : null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: "terms.ts", contentHash: createHash("sha256").update(source).digest("hex"),
+        language: "typescript", size: source.length, modifiedAt: 1, nodeCount: 1,
+        parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+      }],
+    };
+    const db = deps.open!(root).db;
+    const summaryDeps: AgentCommandDeps = {
+      open: () => ({ graph, db, close: () => {} }),
+      write: (line) => lines.push(line),
+    };
+    try {
+      const records = capture(() => runGraphScope(terms.join(" "), isolated, summaryDeps, { detail: "minimal" }));
+      const summary = records.at(-1)!;
+      expect(summary.coveredTerms).toHaveLength(12);
+      expect(summary.omittedCounts).toMatchObject({ coveredTerms: 8 });
+      expect(summary).toMatchObject({ type: "summary", truncated: true, status: "ok" });
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
   });
 });
 
@@ -99,14 +1307,10 @@ describe("runGraphGet", () => {
     expect(records.some((r) => r.type === "error" && r.code === "NODE_NOT_FOUND")).toBe(true);
   });
 
-  it("keeps a hard ceiling: an undersized budget is clamped to the framing floor and flagged", () => {
+  it("does not rewrite an undersized budget to make compliance appear successful", () => {
     const records = capture(() => runGraphGet(["missing:a", "missing:b", "missing:c"], root, deps, { maxOutputTokens: 20 }));
-    const summary = records.at(-1)!;
-    expect(summary.type).toBe("summary");
-    expect(summary.truncated).toBe(true);
-    // Clamped up from the impossible 20 to a framing floor, and honored as a real ceiling.
-    expect(summary.maxOutputTokens as number).toBeGreaterThan(20);
-    expect(summary.estimatedOutputTokens as number).toBeLessThanOrEqual(summary.maxOutputTokens as number);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ type: "error", code: "INVALID_OUTPUT_BUDGET" });
   });
 });
 
@@ -144,24 +1348,37 @@ describe("runImpact", () => {
 });
 
 describe("budget accounting honesty", () => {
-  it("flags truncation when edges are budget-dropped in standard detail", () => {
+  it("emits confidence-gated directed flow records and accounts every returned step", () => {
     const full = capture(() => runGraphScope("run", root, deps, { detail: "standard" }));
-    const fullEdges = full.filter((r) => r.type === "edge").length;
-    expect(fullEdges).toBeGreaterThan(0);
-    // A budget that fits the facts but not the edges must report truncated, not silently drop them.
-    const tight = capture(() => runGraphScope("run", root, deps, { detail: "standard", maxOutputTokens: 260 }));
-    const summary = tight.at(-1)!;
-    if ((summary.returnedEdges as number) < fullEdges) expect(summary.truncated).toBe(true);
+    const flows = full.filter((r) => r.type === "flow");
+    expect(flows.length).toBeGreaterThan(0);
+    expect(full.some((r) => r.type === "edge")).toBe(false);
+    const steps = flows.flatMap((flow) => flow.steps as Array<Record<string, unknown>>);
+    expect(steps.length).toBeGreaterThan(0);
+    for (const flow of flows) {
+      const endpointIds = new Set((flow.nodes as Array<{ id: string }>).map((node) => node.id));
+      expect(endpointIds.size).toBeGreaterThan(0);
+      for (const step of flow.steps as Array<{ source: string; target: string }>) {
+        expect(endpointIds.has(step.source)).toBe(true);
+        expect(endpointIds.has(step.target)).toBe(true);
+      }
+    }
+    for (const step of steps) {
+      expect(step.kind).toBe("calls");
+      expect(step.confidence as number).toBeGreaterThanOrEqual(0.8);
+    }
+    expect(full.at(-1)).toMatchObject({ type: "summary", returnedEdges: steps.length });
   });
 
-  it("only claims sourceIncluded on facts whose source was actually emitted", () => {
+  it("links emitted source to facts by node id without a redundant per-fact flag", () => {
     const records = capture(() => runGraphScope("run", root, deps, { detail: "source" }));
     const facts = records.filter((r) => r.type === "fact");
     const sourcedNodeIds = new Set(
       records.filter((r) => r.type === "source").flatMap((r) => (r.ranges as Array<{ nodeIds: string[] }>).flatMap((x) => x.nodeIds)),
     );
     for (const fact of facts) {
-      expect(fact.sourceIncluded).toBe(sourcedNodeIds.has(fact.id as string));
+      expect(fact).not.toHaveProperty("sourceIncluded");
+      expect(sourcedNodeIds.has(fact.id as string)).toBe(true);
     }
   });
 
@@ -173,12 +1390,73 @@ describe("budget accounting honesty", () => {
   });
 
   it("does not under-report tokens: estimate covers the actually emitted bytes and stays under the ceiling", () => {
-    for (const maxOutputTokens of [200, 1500]) {
+    for (const maxOutputTokens of [1500, 3500]) {
       const records = capture(() => runGraphScope("run", root, deps, { detail: "source", maxOutputTokens }));
       const summary = records.at(-1)!;
       const actual = records.reduce((sum, r) => sum + Math.ceil(JSON.stringify(r).length / 4), 0);
       expect(summary.estimatedOutputTokens as number).toBeGreaterThanOrEqual(actual);
       expect(summary.estimatedOutputTokens as number).toBeLessThanOrEqual(summary.maxOutputTokens as number);
     }
+  });
+
+  it("returns a newly added matching file as text-only evidence without graph claims", () => {
+    writeFileSync(join(root, "new-live.ts"), "export const freshNeedle = 'only in live source';\n");
+    const records = capture(() => runGraphScope("freshNeedle", root, deps, {}));
+    expect(records).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "source", filePath: "new-live.ts", evidence: "text-only", unindexed: true,
+      }),
+    ]));
+    expect(records.some((record) => record.type === "fact" && record.filePath === "new-live.ts")).toBe(false);
+    expect(records.at(-1)).toMatchObject({
+      type: "summary", status: "degraded", truncated: true,
+      textFallbackFiles: expect.arrayContaining(["new-live.ts"]),
+    });
+  });
+
+  it("keeps a complete graph answer ok when optional live text also matches", () => {
+    const optionalPath = join(root, "optional-live-note.ts");
+    writeFileSync(optionalPath, "// incidental run note for operators\n");
+    try {
+      const records = capture(() => runGraphScope("run incidental", root, deps, {}));
+      expect(records).toEqual(expect.arrayContaining([
+        expect.objectContaining({ type: "source", filePath: "main.ts", evidence: "graph" }),
+        expect.objectContaining({
+          type: "source", filePath: "optional-live-note.ts", evidence: "text-only", unindexed: true,
+        }),
+      ]));
+      expect(records.some((record) => record.type === "flow")).toBe(true);
+      expect(records.at(-1)).toMatchObject({
+        type: "summary", status: "ok", truncated: true,
+        textFallbackFiles: expect.arrayContaining(["optional-live-note.ts"]),
+        suggestedNextCommands: [],
+      });
+    } finally {
+      rmSync(optionalPath, { force: true });
+    }
+  });
+
+  it("never emits stale graph flows or stale facts after a live file changes", () => {
+    writeFileSync(
+      join(root, "main.ts"),
+      `import { helper } from "./util";\nexport function run(): number {\n  return helper(42);\n}\n`,
+    );
+    const records = capture(() => runGraphScope("run helper", root, deps, {}));
+    expect(records.some((record) => record.type === "flow")).toBe(false);
+    expect(records.some((record) => record.type === "fact" && record.filePath === "main.ts")).toBe(false);
+    expect(records).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "source", filePath: "main.ts", evidence: "text-only", stale: true }),
+    ]));
+    expect(JSON.stringify(records.filter((record) => record.type === "source"))).toContain("helper(42)");
+  });
+
+  it("drops stale indexed hits when the live file no longer matches the query", () => {
+    writeFileSync(join(root, "main.ts"), "export const unrelatedLiveValue = 42;\n");
+    const records = capture(() => runGraphScope("run", root, deps, {}));
+    expect(records.some((record) => record.type === "source" && record.filePath === "main.ts")).toBe(false);
+    expect(records.some((record) => record.type === "fact" && record.filePath === "main.ts")).toBe(false);
+    expect(records.some((record) => record.type === "flow")).toBe(false);
+    expect(records.at(-1)?.returnedFiles).not.toContain("main.ts");
+    expect(records.at(-1)?.textFallbackFiles).not.toContain("main.ts");
   });
 });

--- a/src/graph/__tests__/compiler-extraction.test.ts
+++ b/src/graph/__tests__/compiler-extraction.test.ts
@@ -1,0 +1,319 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildTypeScriptExtraction,
+  canonicalCompilerIdentity,
+  discoverTypeScriptProjects,
+  normalizedCompilerTokens,
+} from "../extraction/compiler.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function project(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-compiler-extraction-"));
+  temporaryRoots.push(root);
+  for (const [path, source] of Object.entries(files)) {
+    const absolute = join(root, path);
+    mkdirSync(join(absolute, ".."), { recursive: true });
+    writeFileSync(absolute, source, "utf8");
+  }
+  return root;
+}
+
+function mainFixture(): { root: string; candidates: string[] } {
+  const root = project({
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        target: "ES2022",
+        module: "ESNext",
+        moduleResolution: "Bundler",
+        baseUrl: ".",
+        paths: { "@lib/*": ["src/lib/*"] },
+        strict: true,
+        skipLibCheck: true,
+      },
+      include: ["src/**/*.ts"],
+      references: [{ path: "packages/child" }],
+    }),
+    "packages/child/tsconfig.json": JSON.stringify({
+      compilerOptions: { composite: true, target: "ES2022", module: "ESNext" },
+      include: ["src/**/*.ts"],
+    }),
+    "packages/child/src/child.ts": "export const child = 1;\n",
+    "src/lib/base.ts": [
+      "export class Base {",
+      "  protected baseRun(): string { return 'base'; }",
+      "}",
+      "",
+    ].join("\n"),
+    "src/helper.ts": "export function duplicate(): void {}\n",
+    "src/use.ts": "import { duplicate } from './helper'; export function use(): void { duplicate(); }\n",
+    "test/helper.test.ts": "export function duplicate(): void {}\n",
+    "src/service.ts": [
+      "import { Base as Parent } from '@lib/base';",
+      "export class Alpha extends Parent {",
+      "  private same(value: string): string;",
+      "  private same(value: number): number;",
+      "  private same(value: string | number): string | number { return value; }",
+      "  execute(): string { return this.same('ok'); }",
+      "}",
+      "export class Beta { same(): string { return 'beta'; } }",
+      "export function invoke(callback: () => void): void { callback(); }",
+      "export function helper(): void {}",
+      "export function boot(): void { invoke(() => helper()); }",
+      "interface First { act(): void }",
+      "interface Second { act(): void }",
+      "export function dispatch(value: First | Second): void { value.act(); }",
+      "",
+    ].join("\n"),
+    // Outside the configured include: this must be owned by one inferred program.
+    "loose.js": "export function loose() { return 1 }\n",
+  });
+  return {
+    root,
+    candidates: [
+      "src/lib/base.ts",
+      "src/service.ts",
+      "src/helper.ts",
+      "src/use.ts",
+      "test/helper.test.ts",
+      "packages/child/src/child.ts",
+      "loose.js",
+    ],
+  };
+}
+
+describe("TypeScript compiler extraction", () => {
+  it("discovers configs, project references, and one inferred program for uncovered files", () => {
+    const { root, candidates } = mainFixture();
+    const discovered = discoverTypeScriptProjects(root, candidates);
+    expect(discovered.map((entry) => entry.configPath)).toEqual([
+      "packages/child/tsconfig.json",
+      "tsconfig.json",
+    ]);
+    expect(discovered.find((entry) => entry.configPath === "tsconfig.json")?.projectReferences)
+      .toEqual(["packages/child/tsconfig.json"]);
+
+    const result = buildTypeScriptExtraction(root, candidates);
+    expect(result.compilerVersion).toBe("5.9.3");
+    expect(result.projects.filter((entry) => entry.id === "inferred")).toHaveLength(1);
+    expect(result.files.find((entry) => entry.filePath === "loose.js")?.projectId).toBe("inferred");
+  });
+
+  it("uses container-qualified canonical ids and coalesces overload declarations", () => {
+    const { root, candidates } = mainFixture();
+    const result = buildTypeScriptExtraction(root, candidates);
+    const file = result.files.find((entry) => entry.filePath === "src/service.ts")!;
+    const alphaSame = file.nodes.find((node) => node.qualifiedName === "Alpha::same")!;
+    const betaSame = file.nodes.find((node) => node.qualifiedName === "Beta::same")!;
+
+    expect(alphaSame.id).not.toBe(betaSame.id);
+    expect(alphaSame.containerId).toBe(file.nodes.find((node) => node.name === "Alpha")?.id);
+    expect(alphaSame.visibility).toBe("private");
+    expect(alphaSame.declarationSpans).toHaveLength(3);
+    expect(file.nodes.filter((node) => node.qualifiedName === "Alpha::same")).toHaveLength(1);
+  });
+
+  it("resolves aliases, paths, inheritance, signatures, and proven callback wiring", () => {
+    const { root, candidates } = mainFixture();
+    const result = buildTypeScriptExtraction(root, candidates);
+    const service = result.files.find((entry) => entry.filePath === "src/service.ts")!;
+    const base = result.files.find((entry) => entry.filePath === "src/lib/base.ts")!
+      .nodes.find((node) => node.name === "Base")!;
+    const alpha = service.nodes.find((node) => node.name === "Alpha")!;
+    const alphaSame = service.nodes.find((node) => node.qualifiedName === "Alpha::same")!;
+    const invoke = service.nodes.find((node) => node.name === "invoke")!;
+    const callback = service.nodes.find((node) => node.declarationRole === "callback-argument:invoke:0")!;
+
+    expect(service.importBindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        localName: "Parent",
+        importedName: "Base",
+        resolvedFilePath: "src/lib/base.ts",
+        targetId: base.id,
+        confidence: 1,
+      }),
+    ]));
+    expect(service.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sourceId: alpha.id, targetId: base.id, kind: "extends", confidence: 1 }),
+      expect.objectContaining({ targetId: alphaSame.id, kind: "calls", confidence: 1 }),
+      expect.objectContaining({
+        sourceId: invoke.id,
+        targetId: callback.id,
+        kind: "calls",
+        confidence: 0.85,
+        resolutionMethod: "typescript-callback-parameter",
+      }),
+    ]));
+    const ambiguous = service.references.find((reference) => reference.targetName === "act" && reference.kind === "calls")!;
+    expect(ambiguous).toMatchObject({
+      status: "ambiguous",
+      targetId: undefined,
+      confidence: 0.75,
+    });
+    expect(ambiguous.candidates).toHaveLength(2);
+  });
+
+  it("keeps identities stable across line shifts and candidate ordering", () => {
+    const { root, candidates } = mainFixture();
+    const before = buildTypeScriptExtraction(root, candidates);
+    const servicePath = join(root, "src/service.ts");
+    const original = before.files.find((entry) => entry.filePath === "src/service.ts")!;
+    writeFileSync(servicePath, `// shifted\n// twice\n${readFileSync(servicePath, "utf8")}`, "utf8");
+    const after = buildTypeScriptExtraction(root, [...candidates].reverse());
+
+    const ids = (file: typeof original) => Object.fromEntries(
+      file.nodes
+        .map((node) => [node.qualifiedName, node.id]),
+    );
+    expect(ids(after.files.find((entry) => entry.filePath === "src/service.ts")!)).toEqual(ids(original));
+    expect(after.files.map((file) => file.filePath)).toEqual([...before.files.map((file) => file.filePath)].sort());
+  });
+
+  it("does not bind a production call to a same-named test symbol or duplicate a callsite", () => {
+    const { root, candidates } = mainFixture();
+    const result = buildTypeScriptExtraction(root, candidates);
+    const productionTarget = result.files.find((file) => file.filePath === "src/helper.ts")!
+      .nodes.find((node) => node.name === "duplicate")!;
+    const testTarget = result.files.find((file) => file.filePath === "test/helper.test.ts")!
+      .nodes.find((node) => node.name === "duplicate")!;
+    const useFile = result.files.find((file) => file.filePath === "src/use.ts")!;
+    const call = useFile.references.find((reference) => reference.kind === "calls" && reference.targetName === "duplicate")!;
+
+    expect(call.targetId).toBe(productionTarget.id);
+    expect(call.targetId).not.toBe(testTarget.id);
+
+    const semanticKeys = result.files.flatMap((file) => file.references)
+      .filter((reference) => reference.targetId)
+      .map((reference) => [reference.sourceId, reference.targetId, reference.kind, reference.line, reference.column].join(":"));
+    expect(new Set(semanticKeys).size).toBe(semanticKeys.length);
+  });
+
+  it("does not map excess callback arguments onto an ordinary final parameter", () => {
+    const root = project({
+      "callbacks.ts": [
+        "export function invoke(callback: () => void): void { callback(); }",
+        "export function invokeFirst(...callbacks: Array<() => void>): void { callbacks[0](); }",
+        "export function real(): void {}",
+        "export function decoy(): void {}",
+        "export function boot(): void {",
+        "  invoke(real, decoy);",
+        "  invokeFirst(real, decoy);",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    const file = buildTypeScriptExtraction(root, ["callbacks.ts"]).files[0]!;
+    const invoke = file.nodes.find((node) => node.name === "invoke")!;
+    const invokeFirst = file.nodes.find((node) => node.name === "invokeFirst")!;
+    const real = file.nodes.find((node) => node.name === "real")!;
+    const decoy = file.nodes.find((node) => node.name === "decoy")!;
+    const synthesizedTargets = (sourceId: string): string[] => file.references
+      .filter((reference) => reference.sourceId === sourceId && reference.provenance === "callback-synthesis")
+      .map((reference) => reference.targetId!);
+
+    expect(synthesizedTargets(invoke.id)).toEqual([real.id]);
+    // A real rest parameter is handled per element: only callbacks[0]() is
+    // proven, so the second actual argument cannot acquire a traversable edge.
+    expect(synthesizedTargets(invokeFirst.id)).toEqual([real.id]);
+    expect(synthesizedTargets(invoke.id)).not.toContain(decoy.id);
+    expect(synthesizedTargets(invokeFirst.id)).not.toContain(decoy.id);
+  });
+
+  it("reports partial syntax health and excludes only intersecting declarations", () => {
+    const root = project({
+      "broken.ts": [
+        "export function sound(): number { return 1; }",
+        "export function broken(): number { return @@@; }",
+        "export function alsoSound(): number { return 2; }",
+      ].join("\n"),
+    });
+    const result = buildTypeScriptExtraction(root, ["broken.ts"]);
+    const file = result.files[0];
+    expect(file.health.status).toBe("partial");
+    expect(file.health.syntacticDiagnosticCount).toBeGreaterThan(0);
+    expect(file.health.diagnosticByteCoverage).toBeLessThanOrEqual(0.25);
+    expect(file.nodes.some((node) => node.name === "sound")).toBe(true);
+    expect(file.nodes.some((node) => node.name === "alsoSound")).toBe(true);
+    expect(file.nodes.some((node) => node.name === "broken")).toBe(false);
+    expect(file.health.excludedDeclarationCount).toBeGreaterThan(0);
+  });
+
+  it("indexes the Hono Context response-construction regression symbols and call edge", () => {
+    const root = project({
+      "src/context.ts": [
+        "type Data = BodyInit | string;",
+        "type StatusCode = number;",
+        "type HeaderRecord = Record<string, string>;",
+        "type ResponseOrInit = { headers?: HeadersInit; status?: StatusCode } | Response;",
+        "const createResponseInstance = (body?: BodyInit | null, init?: ResponseInit): Response => new Response(body, init);",
+        "export class Context<E = unknown> {",
+        "  #preparedHeaders: Headers | undefined;",
+        "  #status: StatusCode = 200;",
+        "  #newResponse(data: Data | null, arg?: StatusCode | ResponseOrInit, headers?: HeaderRecord): Response {",
+        "    const status = typeof arg === 'number' ? arg : (arg?.status ?? this.#status);",
+        "    return createResponseInstance(data, { status, headers: this.#preparedHeaders ?? headers });",
+        "  }",
+        "  newResponse = (...args: Parameters<Context['newResponse']>): Response => this.#newResponse(...args);",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    const result = buildTypeScriptExtraction(root, ["src/context.ts"]);
+    const file = result.files[0]!;
+    const context = file.nodes.find((node) => node.name === "Context")!;
+    const privateResponse = file.nodes.find((node) => node.name === "#newResponse")!;
+    const responseFactory = file.nodes.find((node) => node.name === "createResponseInstance")!;
+
+    expect(file.health.status).toBe("ok");
+    expect(context.kind).toBe("class");
+    expect(privateResponse).toMatchObject({ kind: "method", qualifiedName: "Context::#newResponse" });
+    // Arrow-function bindings are callable symbols in the compiler graph.
+    expect(responseFactory.kind).toBe("function");
+    expect(file.references).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        sourceId: privateResponse.id,
+        targetId: responseFactory.id,
+        kind: "calls",
+        provenance: "typescript-compiler",
+      }),
+    ]));
+  });
+
+  it("makes the canonical identity independent of source positions", () => {
+    const input = {
+      filePath: "src/service.ts",
+      kind: "method" as const,
+      qualifiedName: "Alpha::same",
+      declarationRole: "method",
+      signature: "(value: string): string",
+    };
+    expect(canonicalCompilerIdentity(input)).toBe(canonicalCompilerIdentity(input));
+    expect(canonicalCompilerIdentity(input)).not.toContain("line");
+  });
+
+  it("normalizes compiler fingerprint tokens without identifier or literal spellings", () => {
+    const source = [
+      "export function alpha(value: string): string { return value + 'one'; }",
+      "export function beta(input: string): string { return input + 'two'; }",
+    ].join("\n");
+    const root = project({ "tokens.ts": source });
+    const file = buildTypeScriptExtraction(root, ["tokens.ts"]).files[0];
+    const alpha = file.nodes.find((node) => node.name === "alpha")!;
+    const beta = file.nodes.find((node) => node.name === "beta")!;
+    const tokens = normalizedCompilerTokens(source, [alpha, beta]);
+
+    expect(tokens.get(alpha.id)).toEqual(tokens.get(beta.id));
+    expect(tokens.get(alpha.id)).toContain("FunctionKeyword");
+    expect(tokens.get(alpha.id)).toContain("Identifier");
+    expect(tokens.get(alpha.id)).toContain("StringLiteral");
+    expect(tokens.get(alpha.id)).not.toContain("alpha");
+    expect(tokens.get(alpha.id)).not.toContain("one");
+  });
+});

--- a/src/graph/__tests__/engine-python.test.ts
+++ b/src/graph/__tests__/engine-python.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +19,10 @@ let engine: GraphEngine;
 beforeAll(async () => {
   root = mkdtempSync(join(tmpdir(), "mex-python-graph-"));
   cpSync(FIXTURE, join(root, "pkg"), { recursive: true });
+  writeFileSync(
+    join(root, "pkg/alias_service.py"),
+    "from . import exported as named_export\n\ndef alias_call():\n    return named_export()\n",
+  );
   engine = createGraphEngine({ rootDir: root });
   await engine.build(root);
 });
@@ -39,12 +43,17 @@ describe("Python graph resolution", () => {
 
     const db = openSqlite(join(root, ".mex", "graph.db"));
     try {
+      const serviceFile = db.prepare(
+        "SELECT id FROM nodes WHERE kind = 'file' AND file_path = 'pkg/service.py'",
+      ).get() as { id: string };
       const importTargets = db.prepare(
-        "SELECT target FROM edges WHERE source = ? AND kind = 'imports' ORDER BY target",
-      ).all("file:pkg/service.py") as Array<{ target: string }>;
-      expect(importTargets.map((row) => row.target)).toEqual([
-        "file:pkg/__init__.py",
-        "file:pkg/models.py",
+        `SELECT target.file_path FROM edges
+         JOIN nodes target ON target.id = edges.target
+         WHERE edges.source = ? AND edges.kind = 'imports' ORDER BY target.file_path`,
+      ).all(serviceFile.id) as Array<{ file_path: string }>;
+      expect(importTargets.map((row) => row.file_path)).toEqual([
+        "pkg/__init__.py",
+        "pkg/models.py",
       ]);
       expect(db.prepare(
         "SELECT COUNT(*) AS count FROM edges WHERE source = ? AND target = ? AND kind = 'calls'",
@@ -52,6 +61,19 @@ describe("Python graph resolution", () => {
       expect(db.prepare(
         "SELECT COUNT(*) AS count FROM edges WHERE source = ? AND target = ? AND kind = 'instantiates'",
       ).get(build.id, widget.id)).toMatchObject({ count: 1 });
+      const aliasCall = engine.searchNodes("alias_call").find((node) => node.name === "alias_call")!;
+      expect(db.prepare(
+        "SELECT COUNT(*) AS count FROM edges WHERE source = ? AND target = ? AND kind = 'calls'",
+      ).get(aliasCall.id, exported.id)).toMatchObject({ count: 1 });
+      expect(db.prepare(
+        `SELECT local_name, imported_name, resolved_file_path, target_id FROM import_bindings
+         WHERE file_path = 'pkg/alias_service.py' AND local_name = 'named_export'`,
+      ).all()).toEqual(expect.arrayContaining([{
+        local_name: "named_export",
+        imported_name: "exported",
+        resolved_file_path: "pkg/__init__.py",
+        target_id: exported.id,
+      }]));
     } finally {
       db.close();
     }

--- a/src/graph/__tests__/engine-rust.test.ts
+++ b/src/graph/__tests__/engine-rust.test.ts
@@ -1,4 +1,4 @@
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -20,6 +20,16 @@ let engine: GraphEngine;
 beforeAll(async () => {
   root = mkdtempSync(join(tmpdir(), "mex-rust-graph-"));
   cpSync(FIXTURE, join(root, "sample.rs"));
+  mkdirSync(join(root, "src"));
+  writeFileSync(join(root, "src/lib.rs"), "pub mod util;\npub mod caller;\n");
+  writeFileSync(join(root, "src/util.rs"), "pub fn imported_helper() -> u8 { 1 }\n");
+  writeFileSync(
+    join(root, "src/caller.rs"),
+    "use crate::util::imported_helper;\n"
+      + "use crate::util::imported_helper as aliased_helper;\n"
+      + "pub fn invoke_imported() -> u8 { imported_helper() }\n"
+      + "pub fn invoke_alias() -> u8 { aliased_helper() }\n",
+  );
   engine = createGraphEngine({ rootDir: root });
   await engine.build(root);
 });
@@ -44,6 +54,36 @@ describe("Rust graph discovery", () => {
     const db = openSqlite(join(root, ".mex", "graph.db"));
     try {
       expect(findChangedSourceFiles(root, db)).toContain("added.rs");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("resolves calls only through an explicit local Rust use binding", () => {
+    const caller = engine.searchNodes("invoke_imported").find((node) => node.name === "invoke_imported");
+    const target = engine.searchNodes("imported_helper").find((node) => node.name === "imported_helper");
+    expect(caller).toBeDefined();
+    expect(target).toBeDefined();
+    expect(engine.getCallees(caller!.id).map((node) => node.id)).toContain(target!.id);
+    expect(engine.getOutgoing(caller!.id, ["calls"])).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        node: expect.objectContaining({ id: target!.id }),
+        edge: expect.objectContaining({ resolutionMethod: "explicit-import", confidence: 1 }),
+      }),
+    ]));
+    const aliasCaller = engine.searchNodes("invoke_alias").find((node) => node.name === "invoke_alias")!;
+    expect(engine.getCallees(aliasCaller.id).map((node) => node.id)).toContain(target!.id);
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      expect(db.prepare(
+        `SELECT local_name, imported_name, resolved_file_path, target_id FROM import_bindings
+         WHERE file_path = 'src/caller.rs' AND local_name = 'aliased_helper'`,
+      ).get()).toMatchObject({
+        local_name: "aliased_helper",
+        imported_name: "imported_helper",
+        resolved_file_path: "src/util.rs",
+        target_id: target!.id,
+      });
     } finally {
       db.close();
     }

--- a/src/graph/__tests__/engine.test.ts
+++ b/src/graph/__tests__/engine.test.ts
@@ -15,7 +15,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createGraphEngine } from "../index.js";
 import type { GraphEngine } from "../engine.js";
 import { openSqlite } from "../db/sqlite.js";
-import { readSchemaVersion } from "../db/database.js";
+import { DB_SCHEMA_VERSION, readSchemaVersion } from "../db/database.js";
 
 let root: string;
 let engine: GraphEngine;
@@ -32,18 +32,28 @@ beforeAll(async () => {
       `export function run(): number {\n  return helper(41);\n}\n` +
       `export class App {\n  start(): number { return run(); }\n}\n`,
   );
-  // Both methods intentionally map to the same line-independent node id. This
-  // exercises the duplicate-id write path that formerly orphaned FTS rowids.
+  // Same-named methods in distinct containers must retain distinct identities.
   writeFileSync(
     join(root, "duplicate-methods.ts"),
     `export class First {\n  execute(): number { return 1; }\n}\n` +
       `export class Second {\n  execute(): number { return 2; }\n}\n`,
   );
+  writeFileSync(
+    join(root, "semantic-error.ts"),
+    `export const semanticallyInvalid: number = "not a number";\n`,
+  );
   writeFileSync(join(root, "package.json"), JSON.stringify({ dependencies: { express: "^5.0.0" } }));
+  writeFileSync(join(root, "handlers.ts"), "export function importedHandler(): void {}\n");
+  const bridgeLines = Array.from({ length: 110 }, (_, index) => `  // source bridge filler ${index + 1}`);
+  bridgeLines[0] = "export function sourceChunkOwner(): string {";
+  bridgeLines[89] = "  return 'deterministicEngineBridgeNeedle';";
+  bridgeLines[109] = "}";
+  writeFileSync(join(root, "source-bridge.ts"), bridgeLines.join("\n"));
   writeFileSync(
     join(root, "routes.ts"),
-    `import express from "express";\nconst app = express();\n` +
-      `export function healthHandler(): void {}\napp.get("/health", healthHandler);\n`,
+    `import express from "express";\nimport { importedHandler } from "./handlers";\nconst app = express();\n` +
+      `export function healthHandler(): void {}\napp.get("/health", healthHandler);\n` +
+      `app.post("/imported", importedHandler);\n`,
   );
   engine = createGraphEngine({ rootDir: root });
   await engine.build(root);
@@ -68,6 +78,15 @@ describe("GraphEngine build + reads", () => {
     expect(engine.searchNodes("execute").some((n) => n.name === "execute")).toBe(true);
   });
 
+  it("returns the named declaration enclosing an FTS source window", () => {
+    const ownerId = findId("sourceChunkOwner");
+    const readIds = (): string[] | undefined => engine.searchSource?.("deterministicEngineBridgeNeedle")
+      .find((hit) => hit.filePath === "source-bridge.ts" && hit.startLine === 61)?.nodeIds;
+    const firstRead = readIds();
+    expect(firstRead).toEqual([ownerId]);
+    expect(readIds()).toEqual(firstRead);
+  });
+
   it("keeps the external-content FTS index consistent after duplicate node ids", () => {
     const db = openSqlite(join(root, ".mex", "graph.db"));
     try {
@@ -81,6 +100,11 @@ describe("GraphEngine build + reads", () => {
       ).get() as { count: number };
       expect(indexed.count).toBe(nodes.count);
       expect(orphans.count).toBe(0);
+      const methods = db.prepare(
+        "SELECT id, qualified_name FROM nodes WHERE name = 'execute' ORDER BY qualified_name",
+      ).all() as Array<{ id: string; qualified_name: string }>;
+      expect(methods.map((method) => method.qualified_name)).toEqual(["First::execute", "Second::execute"]);
+      expect(new Set(methods.map((method) => method.id)).size).toBe(2);
     } finally {
       db.close();
     }
@@ -114,10 +138,16 @@ describe("GraphEngine build + reads", () => {
   it("writes a schema_versions row (migration safety)", () => {
     const db = openSqlite(join(root, ".mex", "graph.db"));
     try {
-      expect(readSchemaVersion(db)).toBe(1);
+      expect(readSchemaVersion(db)).toBe(DB_SCHEMA_VERSION);
     } finally {
       db.close();
     }
+  });
+
+  it("does not report ordinary type-checking errors as structural parser loss", () => {
+    const file = engine.getIndexedFiles?.().find((entry) => entry.path === "semantic-error.ts");
+    expect(file).toMatchObject({ parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0 });
+    expect(engine.searchNodes("semanticallyInvalid").some((node) => node.filePath === "semantic-error.ts")).toBe(true);
   });
 
   it("activates the Express resolver and links a route to its handler", () => {
@@ -127,7 +157,24 @@ describe("GraphEngine build + reads", () => {
     const db = openSqlite(join(root, ".mex", "graph.db"));
     try {
       expect(db.prepare("SELECT kind, provenance FROM edges WHERE source = ? AND target = ?")
-        .get(route!.id, handlerId)).toMatchObject({ kind: "references", provenance: "heuristic" });
+        .get(route!.id, handlerId)).toMatchObject({ kind: "references", provenance: "framework" });
+    } finally { db.close(); }
+  });
+
+  it("uses an explicit compiler import binding for an Express route handler", () => {
+    const route = engine.searchNodes("POST /imported").find((node) => node.kind === "route");
+    const handlerId = findId("importedHandler");
+    expect(route).toBeDefined();
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      expect(db.prepare(
+        "SELECT kind, provenance, confidence, resolution_method FROM edges WHERE source = ? AND target = ?",
+      ).get(route!.id, handlerId)).toMatchObject({
+        kind: "references",
+        provenance: "framework",
+        confidence: 0.8,
+        resolution_method: "express-route-handler",
+      });
     } finally { db.close(); }
   });
 });

--- a/src/graph/__tests__/extraction-regression.test.ts
+++ b/src/graph/__tests__/extraction-regression.test.ts
@@ -9,7 +9,7 @@ const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 
 describe("Graph Extraction Regression", () => {
   beforeAll(async () => {
-    await loadGrammars(["typescript", "javascript", "tsx", "jsx"]);
+    await loadGrammars(["typescript", "javascript", "tsx", "jsx", "python", "rust"]);
   });
 
   const extractFixture = (filename: string): FileExtraction => {
@@ -94,8 +94,11 @@ describe("Graph Extraction Regression", () => {
     });
 
     it("degrades gracefully on ambiguous syntax", () => {
-      // The file should parse and extract the valid symbols despite any syntax errors
-      expect(node(result, "function", "withWeirdSyntax")).toBeDefined();
+      expect(result.health.status).toBe("partial");
+      // A declaration intersecting a parser diagnostic is not a trustworthy
+      // graph fact; valid declarations elsewhere in the file remain indexed.
+      expect(node(result, "function", "withWeirdSyntax")).toBeUndefined();
+      expect(node(result, "class", "Manager")).toBeDefined();
     });
   });
 
@@ -111,11 +114,12 @@ describe("Graph Extraction Regression", () => {
 
     it("extracts components, arrow functions, and calls", () => {
       expect(node(result, "interface", "Props")).toBeDefined();
-      expect(node(result, "function", "Widget")).toBeDefined();
+      expect(result.health.status).toBe("partial");
+      expect(node(result, "function", "Widget")).toBeUndefined();
       
-      // Arrow functions inside functions are local variables and are not extracted as nodes
-      // But the calls they make should attribute to the enclosing function
-      expect(hasEdge(result, "calls", "setCount")).toBe(true);
+      // Widget intersects the invalid JSX line, so calls inside it are withheld
+      // with the declaration instead of being presented as trusted structure.
+      expect(hasEdge(result, "calls", "setCount")).toBe(false);
     });
 
     it("captures JSX component usage via imports", () => {
@@ -144,6 +148,28 @@ describe("Graph Extraction Regression", () => {
 
     it("captures promise instantiations", () => {
       expect(hasEdge(result, "instantiates", "Promise")).toBe(true);
+    });
+  });
+
+  describe("fallback parser recovery", () => {
+    it("keeps healthy Python declarations and withholds declarations intersecting errors", () => {
+      const result = extractFile(
+        "src/recovery.py",
+        "def healthy_python():\n    return 1\n\ndef broken_python(:\n    return 2\n",
+      )!;
+      expect(result.health.status).toBe("partial");
+      expect(node(result, "function", "healthy_python")).toBeDefined();
+      expect(node(result, "function", "broken_python")).toBeUndefined();
+    });
+
+    it("keeps healthy Rust declarations and withholds declarations intersecting errors", () => {
+      const result = extractFile(
+        "src/recovery.rs",
+        "pub fn healthy_rust() -> u8 { 1 }\nfn broken_rust( { 2 }\n",
+      )!;
+      expect(result.health.status).toBe("partial");
+      expect(node(result, "function", "healthy_rust")).toBeDefined();
+      expect(node(result, "function", "broken_rust")).toBeUndefined();
     });
   });
 });

--- a/src/graph/__tests__/extractor-python.test.ts
+++ b/src/graph/__tests__/extractor-python.test.ts
@@ -206,6 +206,18 @@ describe("Python extractor", () => {
     ))).toHaveLength(1);
   });
 
+  it("assigns deterministic occurrence identities to same-scope duplicate declarations", () => {
+    const extracted = extractFile(
+      "duplicates.py",
+      "def repeated():\n    return 1\n\ndef repeated():\n    return 2\n",
+      "python",
+    )!;
+    const repeated = extracted.nodes.filter((node) => node.name === "repeated");
+    expect(repeated).toHaveLength(2);
+    expect(new Set(repeated.map((node) => node.id)).size).toBe(2);
+    expect(new Set(repeated.map((node) => node.identityKey)).size).toBe(2);
+  });
+
   it("captures prefixed docstrings and degrades safely on malformed syntax", () => {
     const prefixed = extractFile(
       "docs.py",

--- a/src/graph/__tests__/extractor-rust.test.ts
+++ b/src/graph/__tests__/extractor-rust.test.ts
@@ -151,6 +151,25 @@ describe("Rust extractor", () => {
     expect(callsMake.length).toBe(1);
   });
 
+  it("assigns deterministic occurrence identities to same-scope duplicate declarations", () => {
+    const duplicate = extractFile(
+      "duplicates.rs",
+      "fn repeated() -> u8 { 1 }\nfn repeated() -> u8 { 2 }\n",
+      "rust",
+    )!;
+    const repeated = duplicate.nodes.filter((entry) => entry.kind === "function" && entry.name === "repeated");
+    expect(repeated).toHaveLength(2);
+    expect(new Set(repeated.map((entry) => entry.id)).size).toBe(2);
+    expect(new Set(repeated.map((entry) => entry.identityKey)).size).toBe(2);
+    expect(repeated.map((entry) => entry.id)).toEqual(
+      extractFile(
+        "duplicates.rs",
+        "fn repeated() -> u8 { 1 }\nfn repeated() -> u8 { 2 }\n",
+        "rust",
+      )!.nodes.filter((entry) => entry.kind === "function" && entry.name === "repeated").map((entry) => entry.id),
+    );
+  });
+
   it("normalizes nested generic struct instantiation to its base name (6)", () => {
     // `Boxed::<Vec<u8>> { ... }` must resolve to `Boxed`.
     const instantiatesBoxed = result.edges.filter(

--- a/src/graph/__tests__/fingerprint-builder.test.ts
+++ b/src/graph/__tests__/fingerprint-builder.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { createFingerprint, createFingerprintBuilder } from "../fingerprint.js";
+import { FingerprintStore } from "../fingerprint-store.js";
+import type { Fingerprint } from "../reconcile.js";
+
+describe("corpus fingerprint builder", () => {
+  it("is bit-for-bit equivalent to independent fingerprint construction", () => {
+    const builder = createFingerprintBuilder();
+    const cases = [
+      { tokens: [] as string[], callers: [] as string[], callees: [] as string[] },
+      { tokens: ["Identifier", "OpenParenToken"], callers: ["b"], callees: ["a"] },
+      {
+        tokens: [
+          "FunctionKeyword", "Identifier", "OpenParenToken", "CloseParenToken",
+          "OpenBraceToken", "ReturnKeyword", "Identifier", "SemicolonToken", "CloseBraceToken",
+        ],
+        callers: ["caller-b", "caller-a"],
+        callees: ["callee", "caller-a"],
+      },
+      {
+        tokens: [
+          "FunctionKeyword", "Identifier", "OpenParenToken", "CloseParenToken",
+          "OpenBraceToken", "ReturnKeyword", "StringLiteral", "SemicolonToken", "CloseBraceToken",
+        ],
+        callers: ["other"],
+        callees: [],
+      },
+    ];
+
+    for (const entry of cases) {
+      expect(builder.create(entry.tokens, entry.callers, entry.callees)).toEqual(
+        createFingerprint(entry.tokens, entry.callers, entry.callees),
+      );
+    }
+  });
+
+  it("batch-upserts deterministic final fingerprints and replaces old LSH rows", () => {
+    const db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec(readFileSync(new URL("../schema.sql", import.meta.url), "utf8"));
+    for (const id of ["a", "b"]) {
+      db.prepare(
+        `INSERT INTO nodes (
+           id, kind, name, qualified_name, identity_key, file_path, language,
+           start_line, end_line, start_column, end_column, updated_at
+         ) VALUES (?, 'function', ?, ?, ?, 'src/a.ts', 'typescript', 1, 1, 0, 1, 1)`,
+      ).run(id, id, id, id);
+    }
+    const value = (offset: number): Fingerprint => ({
+      minhash: Array.from({ length: 64 }, (_, index) => offset + index),
+      neighbors: [],
+      tokenCount: 40,
+    });
+    const oldA = value(1);
+    const newA = value(10_000);
+    const b = value(20_000);
+    const store = new FingerprintStore(db);
+
+    store.upsertMany([
+      { nodeId: "a", fingerprint: oldA },
+      { nodeId: "b", fingerprint: b },
+      { nodeId: "a", fingerprint: newA },
+    ]);
+    expect(store.get("a")).toEqual(newA);
+    expect(store.get("b")).toEqual(b);
+    expect(store.lookup(newA).map((entry) => entry.nodeId)).toContain("a");
+    expect(store.lookup(oldA).map((entry) => entry.nodeId)).not.toContain("a");
+
+    store.upsert("a", oldA);
+    expect(store.get("a")).toEqual(oldA);
+    expect(store.lookup(newA).map((entry) => entry.nodeId)).not.toContain("a");
+    db.close();
+  });
+});

--- a/src/graph/__tests__/graph-v2-integrity.test.ts
+++ b/src/graph/__tests__/graph-v2-integrity.test.ts
@@ -1,0 +1,554 @@
+import {
+  chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createGraphEngine, GraphSourceStagingError } from "../engine-impl.js";
+import {
+  DB_SCHEMA_VERSION,
+  graphRequiresRebuild,
+  openGraphDatabase,
+  readSchemaVersion,
+} from "../db/database.js";
+import { openSqlite, type SqliteDatabase } from "../db/sqlite.js";
+import { GraphStore } from "../db/store.js";
+import { GraphRebuildRequiredError } from "../errors.js";
+import { runGraphScope } from "../cli-agent.js";
+import type { GraphEdge, GraphNode } from "../types.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function temporaryRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function node(id: string, name: string, filePath = "src/sample.ts"): GraphNode {
+  return {
+    id,
+    kind: "function",
+    name,
+    qualifiedName: name,
+    identityKey: `${filePath}\0function\0${name}`,
+    filePath,
+    language: "typescript",
+    startLine: 1,
+    endLine: 2,
+    startColumn: 0,
+    endColumn: 1,
+    updatedAt: 1,
+  };
+}
+
+/** A minimal pre-v2 database. The migration must add everything else itself. */
+function createV1Database(path: string): void {
+  const db = openSqlite(path);
+  try {
+    db.exec(`
+      CREATE TABLE schema_versions (
+        version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL, description TEXT
+      );
+      INSERT INTO schema_versions VALUES (1, 1, 'legacy graph');
+      CREATE TABLE nodes (
+        id TEXT PRIMARY KEY, kind TEXT NOT NULL, name TEXT NOT NULL,
+        qualified_name TEXT NOT NULL, file_path TEXT NOT NULL, language TEXT NOT NULL,
+        start_line INTEGER NOT NULL, end_line INTEGER NOT NULL,
+        start_column INTEGER NOT NULL, end_column INTEGER NOT NULL,
+        docstring TEXT, signature TEXT, visibility TEXT,
+        is_exported INTEGER DEFAULT 0, is_async INTEGER DEFAULT 0,
+        is_static INTEGER DEFAULT 0, is_abstract INTEGER DEFAULT 0,
+        decorators TEXT, type_parameters TEXT, return_type TEXT, body_hash TEXT,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE edges (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, source TEXT NOT NULL, target TEXT NOT NULL,
+        kind TEXT NOT NULL, metadata TEXT, line INTEGER, col INTEGER, provenance TEXT
+      );
+      CREATE TABLE files (
+        path TEXT PRIMARY KEY, content_hash TEXT NOT NULL, language TEXT NOT NULL,
+        size INTEGER NOT NULL, modified_at INTEGER NOT NULL, indexed_at INTEGER NOT NULL,
+        node_count INTEGER DEFAULT 0, errors TEXT
+      );
+      CREATE TABLE unresolved_refs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, from_node_id TEXT NOT NULL,
+        reference_name TEXT NOT NULL, reference_kind TEXT NOT NULL,
+        line INTEGER NOT NULL, col INTEGER NOT NULL, candidates TEXT,
+        file_path TEXT NOT NULL DEFAULT '', language TEXT NOT NULL DEFAULT 'unknown'
+      );
+      CREATE TABLE _mex_grounded_source (
+        scaffold_file TEXT NOT NULL, node_id TEXT NOT NULL, body_hash TEXT NOT NULL,
+        captured_at INTEGER NOT NULL, PRIMARY KEY (scaffold_file, node_id)
+      );
+      INSERT INTO _mex_grounded_source VALUES ('docs/unit.md', 'function:old', 'abc', 1);
+    `);
+  } finally {
+    db.close();
+  }
+}
+
+function rows(db: SqliteDatabase, sql: string): unknown[] {
+  return db.prepare(sql).all() as unknown[];
+}
+
+function semanticSnapshot(path: string): Record<string, unknown[]> {
+  const db = openSqlite(path);
+  try {
+    return {
+      files: rows(db, `SELECT path, content_hash, language, size, node_count,
+        parse_status, diagnostic_count, missing_count, error_coverage, extractor_version
+        FROM files ORDER BY path`),
+      nodes: rows(db, `SELECT id, kind, name, qualified_name, container_id, identity_key,
+        file_path, language, start_line, end_line, start_column, end_column, signature,
+        visibility, is_exported, is_async, is_static, is_abstract, return_type, body_hash
+        FROM nodes ORDER BY id`),
+      edges: rows(db, `SELECT source, target, kind, metadata, line, col, provenance,
+        confidence, resolution_method, evidence FROM edges
+        ORDER BY source, target, kind, IFNULL(line, -1), IFNULL(col, -1)`),
+      references: rows(db, `SELECT ref_key, from_node_id, reference_name, reference_kind,
+        line, col, candidates, file_path, language, receiver, qualifier, import_source,
+        metadata, status, target_id, confidence, resolver FROM unresolved_refs ORDER BY ref_key`),
+      imports: rows(db, `SELECT binding_key, file_path, local_name, imported_name,
+        module_specifier, resolved_file_path, target_id, is_type_only, metadata
+        FROM import_bindings ORDER BY binding_key`),
+      chunks: rows(db, `SELECT file_path, start_line, end_line, content_hash,
+        path_terms, identifier_terms, comment_terms FROM source_chunks
+        ORDER BY file_path, start_line`),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+describe("graph schema v2 migration and storage", () => {
+  it("migrates v1 additively, preserves grounding, and requires a full rebuild", () => {
+    const root = temporaryRoot("mex-schema-v2-");
+    const dbPath = join(root, "graph.db");
+    createV1Database(dbPath);
+
+    expect(() => openGraphDatabase(dbPath)).toThrow(GraphRebuildRequiredError);
+
+    const db = openGraphDatabase(dbPath, { allowRebuild: true });
+    try {
+      expect(readSchemaVersion(db)).toBe(DB_SCHEMA_VERSION);
+      expect(graphRequiresRebuild(db)).toBe(true);
+      expect(rows(db, "SELECT scaffold_file, node_id, body_hash FROM _mex_grounded_source"))
+        .toEqual([{ scaffold_file: "docs/unit.md", node_id: "function:old", body_hash: "abc" }]);
+      const nodeColumns = rows(db, "PRAGMA table_info(nodes)") as Array<{ name: string }>;
+      expect(nodeColumns.map((column) => column.name)).toEqual(expect.arrayContaining([
+        "container_id", "identity_key",
+      ]));
+      expect(rows(db, "SELECT name FROM sqlite_master WHERE type = 'table'")).toEqual(
+        expect.arrayContaining([
+          { name: "node_aliases" },
+          { name: "source_chunks" },
+          { name: "import_bindings" },
+        ]),
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it("resolves legacy ids through aliases without changing the canonical result", () => {
+    const root = temporaryRoot("mex-alias-v2-");
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    try {
+      const canonical = node("function:new", "renamed");
+      store.insertNode(canonical);
+      expect(store.insertAlias("function:old", canonical.id, "body-hash", 0.95)).toBe(true);
+      expect(store.getNodeById("function:old")).toMatchObject({ id: canonical.id, name: "renamed" });
+      expect(store.getNodeById(canonical.id)).toMatchObject({ id: canonical.id });
+      expect(store.getNodeById("function:missing")).toBeNull();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("serves Scope through genuinely read-only graph connections", async () => {
+    const root = temporaryRoot("mex-readonly-v2-");
+    writeFileSync(join(root, "sample.ts"), "export function healthyNeedle(): number { return 1; }\n");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build(root);
+    engine.close();
+
+    const graphDir = join(root, ".mex");
+    const dbPath = join(graphDir, "graph.db");
+    for (const suffix of ["-wal", "-shm"]) {
+      const sidecar = `${dbPath}${suffix}`;
+      if (existsSync(sidecar)) unlinkSync(sidecar);
+    }
+    chmodSync(dbPath, 0o444);
+    chmodSync(graphDir, 0o555);
+
+    try {
+      const readOnly = openGraphDatabase(dbPath, { readOnly: true });
+      expect(() => readOnly.prepare(
+        "INSERT INTO project_metadata (key, value) VALUES ('forbidden', 'write')",
+      ).run()).toThrow(/read.?only/i);
+      readOnly.close();
+
+      const output: string[] = [];
+      runGraphScope("healthyNeedle", root, { write: (line) => output.push(line) });
+      const records = output.map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(records[0]).toMatchObject({ type: "meta", command: "graph scope" });
+      expect(records.some((record) => record.type === "source")).toBe(true);
+      expect(records.some((record) => record.type === "error")).toBe(false);
+    } finally {
+      chmodSync(graphDir, 0o755);
+      chmodSync(dbPath, 0o644);
+    }
+  });
+
+  it("deduplicates semantic callsites and retains the strongest resolution", () => {
+    const root = temporaryRoot("mex-edges-v2-");
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    try {
+      store.insertNode(node("function:source", "source"));
+      store.insertNode(node("function:target", "target"));
+      const weak: GraphEdge = {
+        source: "function:source", target: "function:target", kind: "calls",
+        line: 4, column: 8, confidence: 0.6, provenance: "heuristic",
+        resolutionMethod: "name-match", evidence: [{ kind: "name" }],
+      };
+      store.insertEdge(weak);
+      store.insertEdge({
+        ...weak, confidence: 1, provenance: "typescript-compiler",
+        resolutionMethod: "typescript-symbol", evidence: [{ kind: "compiler" }],
+      });
+      store.insertEdge({ ...weak, line: 5, confidence: 0.9 });
+
+      expect(rows(db, "SELECT COUNT(*) AS count FROM edges")).toEqual([{ count: 2 }]);
+      expect(store.getOutgoingEdges("function:source", ["calls"])).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          line: 4,
+          confidence: 1,
+          provenance: "typescript-compiler",
+          resolutionMethod: "typescript-symbol",
+          evidence: expect.arrayContaining([
+            { kind: "compiler" },
+            { kind: "name" },
+            expect.objectContaining({
+              type: "resolution-support", confidence: 1,
+              provenance: "typescript-compiler", resolutionMethod: "typescript-symbol",
+            }),
+            expect.objectContaining({
+              type: "resolution-support", confidence: 0.6,
+              provenance: "heuristic", resolutionMethod: "name-match",
+            }),
+          ]),
+        }),
+      ]));
+      expect(store.validateInvariants()).toMatchObject({ duplicateEdges: 0, danglingEdges: 0 });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("replaces overlapping source chunks and removes their FTS rows", () => {
+    const root = temporaryRoot("mex-chunks-v2-");
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    try {
+      const lines = Array.from({ length: 150 }, (_, index) => `const line${index + 1} = ${index + 1};`);
+      lines[69] = "export const astonishingGraphNeedle = true;";
+      expect(store.replaceSourceChunks("src/large.ts", lines.join("\n"), "hash-one")).toBe(3);
+      expect(store.searchSourceChunks("astonishingGraphNeedle")).toEqual(expect.arrayContaining([
+        expect.objectContaining({ filePath: "src/large.ts", startLine: 1, endLine: 80 }),
+        expect.objectContaining({ filePath: "src/large.ts", startLine: 61, endLine: 140 }),
+      ]));
+
+      expect(store.replaceSourceChunks("src/large.ts", "export const replacementToken = 1;\n", "hash-two"))
+        .toBe(1);
+      expect(store.searchSourceChunks("astonishingGraphNeedle")).toEqual([]);
+      expect(store.searchSourceChunks("replacementToken")).toEqual([
+        expect.objectContaining({ filePath: "src/large.ts", contentHash: "hash-two" }),
+      ]);
+      store.deleteSourceChunks("src/large.ts");
+      expect(store.searchSourceChunks("replacementToken")).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("round-trips parser health and summarizes every health state", () => {
+    const root = temporaryRoot("mex-health-v2-");
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    try {
+      store.upsertFile({
+        path: "src/partial.ts", contentHash: "partial", language: "typescript", size: 10,
+        modifiedAt: 1, indexedAt: 2, nodeCount: 1, parseStatus: "partial",
+        diagnosticCount: 2, missingCount: 1, errorCoverage: 0.125,
+        extractorVersion: "typescript-compiler:5.9.3",
+        errors: [{ code: 1109, message: "Expression expected" }],
+      });
+      for (const [path, parseStatus] of [["src/ok.ts", "ok"], ["src/failed.ts", "failed"]] as const) {
+        store.upsertFile({
+          path, contentHash: path, language: "typescript", size: 1,
+          modifiedAt: 1, indexedAt: 2, nodeCount: 0, parseStatus,
+        });
+      }
+      expect(store.getFileRecord("src/partial.ts")).toMatchObject({
+        parseStatus: "partial", diagnosticCount: 2, missingCount: 1,
+        errorCoverage: 0.125, extractorVersion: "typescript-compiler:5.9.3",
+        errors: [{ code: 1109, message: "Expression expected" }],
+      });
+      expect(store.getHealthSummary()).toEqual({
+        indexedFiles: 3, okFiles: 1, partialFiles: 1, failedFiles: 1,
+      });
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("graph construction integration", () => {
+  it("creates compatibility aliases by signature, then by an unambiguous high-confidence fingerprint", async () => {
+    const signatureRoot = temporaryRoot("mex-signature-alias-");
+    mkdirSync(join(signatureRoot, "src"), { recursive: true });
+    const originalPath = join(signatureRoot, "src", "original.ts");
+    writeFileSync(originalPath, "export function stableMove(value: number): number { return value + 1; }\n");
+    const signatureEngine = createGraphEngine({ rootDir: signatureRoot, dbPath: join(signatureRoot, "graph.db") });
+    await signatureEngine.build();
+    const oldSignatureId = signatureEngine.searchNodes("stableMove").find((entry) => entry.name === "stableMove")!.id;
+    unlinkSync(originalPath);
+    writeFileSync(
+      join(signatureRoot, "src", "moved.ts"),
+      "export function stableMove(value: number): number { return Math.max(0, value + 2); }\n",
+    );
+    await signatureEngine.sync(["src/original.ts", "src/moved.ts"]);
+    expect(signatureEngine.getNode(oldSignatureId)).toMatchObject({ filePath: "src/moved.ts" });
+    signatureEngine.close();
+    const signatureDb = openGraphDatabase(join(signatureRoot, "graph.db"));
+    expect(rows(signatureDb, "SELECT alias_id, match_method FROM node_aliases")).toContainEqual({
+      alias_id: oldSignatureId, match_method: "signature",
+    });
+    signatureDb.close();
+
+    const fingerprintRoot = temporaryRoot("mex-fingerprint-alias-");
+    mkdirSync(join(fingerprintRoot, "src"), { recursive: true });
+    const source = join(fingerprintRoot, "src", "handler.ts");
+    writeFileSync(source, `export function legacyHandler(value: number): number {
+  const first = value + 1;
+  const second = first * 2;
+  const third = second - 3;
+  const fourth = Math.max(third, 4);
+  const fifth = Math.min(fourth, 5);
+  return first + second + third + fourth + fifth;
+}\n`);
+    const fingerprintEngine = createGraphEngine({ rootDir: fingerprintRoot, dbPath: join(fingerprintRoot, "graph.db") });
+    await fingerprintEngine.build();
+    const oldFingerprintId = fingerprintEngine.searchNodes("legacyHandler")
+      .find((entry) => entry.name === "legacyHandler")!.id;
+    writeFileSync(source, `export function modernHandler(input: number): number {
+  const alpha = input + 10;
+  const beta = alpha * 20;
+  const gamma = beta - 30;
+  const delta = Math.max(gamma, 40);
+  const epsilon = Math.min(delta, 50);
+  return alpha + beta + gamma + delta + epsilon;
+}\n`);
+    await fingerprintEngine.sync(["src/handler.ts"]);
+    expect(fingerprintEngine.getNode(oldFingerprintId)).toMatchObject({ name: "modernHandler" });
+    fingerprintEngine.close();
+    const fingerprintDb = openGraphDatabase(join(fingerprintRoot, "graph.db"));
+    expect(rows(fingerprintDb, "SELECT alias_id, match_method FROM node_aliases")).toContainEqual({
+      alias_id: oldFingerprintId, match_method: "fingerprint",
+    });
+    fingerprintDb.close();
+  });
+
+  it("never guesses a fingerprint alias when equally strong candidates exist", async () => {
+    const root = temporaryRoot("mex-ambiguous-alias-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    const source = join(root, "src", "handler.ts");
+    const body = (name: string, value: number) => `export function ${name}(input: number): number {
+  const alpha = input + ${value};
+  const beta = alpha * ${value + 1};
+  const gamma = beta - ${value + 2};
+  const delta = Math.max(gamma, ${value + 3});
+  const epsilon = Math.min(delta, ${value + 4});
+  return alpha + beta + gamma + delta + epsilon;
+}\n`;
+    writeFileSync(source, body("legacyHandler", 1));
+    const dbPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const oldId = engine.searchNodes("legacyHandler").find((entry) => entry.name === "legacyHandler")!.id;
+    writeFileSync(source, body("firstCandidate", 10) + body("secondCandidate", 20));
+    await engine.sync(["src/handler.ts"]);
+    expect(engine.getNode(oldId)).toBeNull();
+    engine.close();
+    const db = openGraphDatabase(dbPath);
+    expect(rows(db, "SELECT alias_id FROM node_aliases")).not.toContainEqual({ alias_id: oldId });
+    db.close();
+  });
+
+  it("forces a deterministic rebuild when compiler configuration changes without a source edit", async () => {
+    const root = temporaryRoot("mex-graph-manifest-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "manifest-fixture", type: "module" }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      compilerOptions: { target: "ES2022", module: "ESNext" },
+      include: ["src/**/*.ts"],
+    }));
+    writeFileSync(join(root, "src", "entry.ts"), "export const manifestNeedle = 1;\n");
+
+    const dbPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const beforeDb = openGraphDatabase(dbPath);
+    const before = new GraphStore(beforeDb);
+    const manifestBefore = before.getMetadata("manifest_hash");
+    const configBefore = before.getMetadata("config_hash");
+    expect(before.getMetadata("grammar_hash")).toMatch(/^[a-f0-9]{64}$/);
+    expect(before.getMetadata("compiler_version")).toBe("5.9.3");
+    expect(before.getMetadata("extractor_version")).toContain("typescript-5.9");
+    beforeDb.close();
+
+    expect(await engine.sync([])).toMatchObject({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0 });
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      compilerOptions: { target: "ES2022", module: "NodeNext", moduleResolution: "NodeNext" },
+      include: ["src/**/*.ts"],
+    }));
+    const staleOutput: string[] = [];
+    runGraphScope("manifestNeedle", root, { write: (line) => staleOutput.push(line) });
+    expect(staleOutput.map((line) => JSON.parse(line))).toEqual([
+      expect.objectContaining({ code: "GRAPH_REBUILD_REQUIRED", recoveryCommand: "mex graph" }),
+    ]);
+    expect(await engine.sync(["tsconfig.json"])).toMatchObject({ filesIndexed: 1 });
+    engine.close();
+
+    const afterDb = openGraphDatabase(dbPath);
+    const after = new GraphStore(afterDb);
+    expect(after.getMetadata("manifest_hash")).not.toBe(manifestBefore);
+    expect(after.getMetadata("config_hash")).not.toBe(configBefore);
+    afterDb.close();
+  });
+
+  it("aborts a failed incremental parse and preserves the last trustworthy snapshot", async () => {
+    const root = temporaryRoot("mex-failed-sync-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    const source = join(root, "src", "stable.ts");
+    writeFileSync(source, "export function stableNeedle(): number { return 7; }\n");
+    const engine = createGraphEngine({ rootDir: root, dbPath: join(root, "graph.db") });
+    await engine.build();
+    const prior = engine.searchNodes("stableNeedle").find((entry) => entry.name === "stableNeedle")!;
+    writeFileSync(source, "}\n");
+
+    const result = await engine.sync(["src/stable.ts"]);
+    expect(result).toMatchObject({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0 });
+    expect(result.health?.failed).toBe(1);
+    expect(engine.getNode(prior.id)).toMatchObject({ id: prior.id, bodyHash: prior.bodyHash });
+    engine.close();
+  });
+
+  it("aborts an unreadable changed source without confusing it for a deletion", async () => {
+    const root = temporaryRoot("mex-unreadable-sync-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    const source = join(root, "src", "stable.ts");
+    writeFileSync(source, "export function stableIoNeedle(): number { return 7; }\n");
+    let failRead = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath: join(root, "graph.db"),
+      sourceFileAccess: {
+        read: (absolutePath) => {
+          if (failRead && absolutePath === source) {
+            throw Object.assign(new Error("injected unreadable source"), { code: "EACCES" });
+          }
+          return readFileSync(absolutePath, "utf-8");
+        },
+      },
+    });
+    await engine.build();
+    const prior = engine.searchNodes("stableIoNeedle")
+      .find((entry) => entry.name === "stableIoNeedle")!;
+    writeFileSync(source, "export function stableIoNeedle(): number { return 9; }\n");
+    failRead = true;
+
+    const rejected = engine.sync(["src/stable.ts"]);
+    await expect(rejected).rejects.toBeInstanceOf(GraphSourceStagingError);
+    await expect(rejected).rejects.toMatchObject({
+      code: "GRAPH_SOURCE_STAGING_FAILED",
+      failures: [{ filePath: "src/stable.ts", operation: "read", code: "EACCES" }],
+    });
+    expect(engine.getNode(prior.id)).toMatchObject({ id: prior.id, bodyHash: prior.bodyHash });
+    expect(engine.getIndexedFiles?.().map((file) => file.path)).toContain("src/stable.ts");
+
+    failRead = false;
+    const updated = await engine.sync(["src/stable.ts"]);
+    expect(updated.filesIndexed).toBe(1);
+    expect(engine.getNode(prior.id)?.bodyHash).not.toBe(prior.bodyHash);
+
+    unlinkSync(source);
+    const deleted = await engine.sync(["src/stable.ts"]);
+    expect(deleted.filesIndexed).toBe(0);
+    expect(engine.getNode(prior.id)).toBeNull();
+    expect(engine.getIndexedFiles?.().map((file) => file.path)).not.toContain("src/stable.ts");
+    engine.close();
+  });
+
+  it("sync deletion converges to a clean build and never binds production calls to tests", async () => {
+    const root = temporaryRoot("mex-graph-convergence-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    mkdirSync(join(root, "test"), { recursive: true });
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      compilerOptions: { target: "ES2022", module: "ESNext", moduleResolution: "Bundler" },
+      include: ["src/**/*.ts", "test/**/*.ts"],
+    }));
+    writeFileSync(join(root, "src", "helper.ts"), "export function duplicate(): number { return 1; }\n");
+    writeFileSync(join(root, "test", "helper.test.ts"), "export function duplicate(): number { return -1; }\n");
+    writeFileSync(
+      join(root, "src", "use.ts"),
+      "import { duplicate } from './helper';\nexport function use(): number { return duplicate(); }\n",
+    );
+    writeFileSync(
+      join(root, "src", "containers.ts"),
+      "export class First { execute(): number { return 1; } }\n" +
+        "export class Second { execute(): number { return 2; } }\n",
+    );
+    writeFileSync(join(root, "src", "obsolete.ts"), "export function obsolete(): void {}\n");
+
+    const incrementalPath = join(root, "incremental.db");
+    const incremental = createGraphEngine({ rootDir: root, dbPath: incrementalPath });
+    await incremental.build();
+    const executeNodes = incremental.searchNodes("execute").filter((candidate) => candidate.name === "execute");
+    expect(executeNodes.map((candidate) => candidate.qualifiedName).sort()).toEqual([
+      "First::execute", "Second::execute",
+    ]);
+    expect(new Set(executeNodes.map((candidate) => candidate.id)).size).toBe(2);
+
+    const production = incremental.searchNodes("duplicate")
+      .find((candidate) => candidate.filePath === "src/helper.ts")!;
+    const testOnly = incremental.searchNodes("duplicate")
+      .find((candidate) => candidate.filePath === "test/helper.test.ts")!;
+    const use = incremental.searchNodes("use").find((candidate) => candidate.name === "use")!;
+    expect(incremental.getCallees(use.id).map((candidate) => candidate.id)).toContain(production.id);
+    expect(incremental.getCallees(use.id).map((candidate) => candidate.id)).not.toContain(testOnly.id);
+
+    writeFileSync(join(root, "src", "helper.ts"), "export function duplicate(): number { return 2; }\n");
+    writeFileSync(join(root, "src", "added.ts"), "export function added(): string { return 'new'; }\n");
+    unlinkSync(join(root, "src", "obsolete.ts"));
+    await incremental.sync(["src/helper.ts", "src/added.ts", "src/obsolete.ts"]);
+    expect(incremental.searchNodes("obsolete")).toEqual([]);
+    expect(incremental.getIndexedFiles?.().map((file) => file.path)).not.toContain("src/obsolete.ts");
+    const incrementalSnapshot = semanticSnapshot(incrementalPath);
+    incremental.close();
+
+    const cleanPath = join(root, "clean.db");
+    const clean = createGraphEngine({ rootDir: root, dbPath: cleanPath });
+    await clean.build();
+    const cleanSnapshot = semanticSnapshot(cleanPath);
+    clean.close();
+    expect(incrementalSnapshot).toEqual(cleanSnapshot);
+  });
+});

--- a/src/graph/__tests__/graph-v2-integrity.test.ts
+++ b/src/graph/__tests__/graph-v2-integrity.test.ts
@@ -366,6 +366,53 @@ describe("graph construction integration", () => {
     fingerprintDb.close();
   });
 
+  it("does not alias a deleted symbol to a newly added differently named signature match", async () => {
+    const root = temporaryRoot("mex-signature-name-guard-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    const removedPath = join(root, "src", "removed.ts");
+    const replacementPath = join(root, "src", "replacement.ts");
+    writeFileSync(removedPath, "export function removed(value: number): number { return value + 1; }\n");
+    const dbPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const oldId = engine.searchNodes("removed").find((entry) => entry.name === "removed")!.id;
+
+    unlinkSync(removedPath);
+    writeFileSync(replacementPath, "export function replacement(value: number): number { return value * 2; }\n");
+    await engine.sync(["src/removed.ts", "src/replacement.ts"]);
+    expect(engine.getNode(oldId)).toBeNull();
+    engine.close();
+
+    const db = openGraphDatabase(dbPath);
+    expect(rows(db, "SELECT alias_id FROM node_aliases")).not.toContainEqual({ alias_id: oldId });
+    db.close();
+  });
+
+  it("does not alias one of two old same-name signatures to the sole survivor", async () => {
+    const root = temporaryRoot("mex-signature-old-ambiguity-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    const removedPath = join(root, "src", "first.ts");
+    writeFileSync(removedPath, "export function shared(value: number): number { return value + 1; }\n");
+    writeFileSync(
+      join(root, "src", "second.ts"),
+      "export function shared(value: number): number { return value * 2; }\n",
+    );
+    const dbPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const oldId = engine.searchNodes("shared", { limit: 10 })
+      .find((entry) => entry.filePath === "src/first.ts")!.id;
+
+    unlinkSync(removedPath);
+    await engine.sync(["src/first.ts"]);
+    expect(engine.getNode(oldId)).toBeNull();
+    engine.close();
+
+    const db = openGraphDatabase(dbPath);
+    expect(rows(db, "SELECT alias_id FROM node_aliases")).not.toContainEqual({ alias_id: oldId });
+    db.close();
+  });
+
   it("never guesses a fingerprint alias when equally strong candidates exist", async () => {
     const root = temporaryRoot("mex-ambiguous-alias-");
     mkdirSync(join(root, "src"), { recursive: true });

--- a/src/graph/__tests__/resolver-express.test.ts
+++ b/src/graph/__tests__/resolver-express.test.ts
@@ -24,9 +24,16 @@ describe("Express reference resolver", () => {
     const ref = expressResolver.extract!("src/express-app.ts", source).references[0]!;
     expect(expressResolver.resolve(ref, context)).toMatchObject({
       targetNodeId: handler.id,
-      confidence: 1,
-      resolvedBy: "framework",
+      confidence: 0.8,
+      resolvedBy: "express-route-handler",
     });
+  });
+
+  it("never uses a repository-global sole-name fallback for a handler", () => {
+    const elsewhere = { ...node("function:handler", "healthHandler"), filePath: "src/other.ts" };
+    const context = fakeContext([elsewhere]);
+    const ref = expressResolver.extract!("src/express-app.ts", source).references[0]!;
+    expect(expressResolver.resolve(ref, context)).toBeNull();
   });
 });
 

--- a/src/graph/__tests__/retrieval-query.test.ts
+++ b/src/graph/__tests__/retrieval-query.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  identifierComponents, isDistinctiveIdentifier, planGraphQuery, stemVariants,
+} from "../retrieval/query.js";
+
+describe("graph query planning", () => {
+  it("splits compound identifiers without losing the full symbol", () => {
+    expect(identifierComponents("BudgetLedger")).toEqual(["budgetledger", "budget", "ledger"]);
+  });
+
+  it("drops question boilerplate while retaining literal repository terms", () => {
+    const plan = planGraphQuery("How are ranked nodes selected?");
+    const terms = new Set(plan.terms.map((entry) => entry.term));
+    expect(terms).not.toContain("how");
+    expect(terms.has("ranked")).toBe(true);
+    expect(terms.has("selected")).toBe(true);
+  });
+
+  it("does not invent budget/limit synonyms for an allowance query", () => {
+    const terms = new Set(planGraphQuery("prevent context allowance overflow").terms.map((entry) => entry.term));
+    expect([...terms]).toEqual(expect.arrayContaining(["prevent", "context", "allowance", "overflow"]));
+    expect(terms.has("budget")).toBe(false);
+    expect(terms.has("limit")).toBe(false);
+  });
+
+  it("keeps terse payload vocabulary literal instead of using a synonym table", () => {
+    const terms = new Set(planGraphQuery("cap graph payload size").terms.map((entry) => entry.term));
+    expect([...terms]).toEqual(expect.arrayContaining(["cap", "payload", "size"]));
+    expect(terms.has("budget")).toBe(false);
+    expect(terms.has("limit")).toBe(false);
+  });
+
+  it("pins distinctive named symbols but never promotes stopwords as identifiers", () => {
+    const plan = planGraphQuery("How does BudgetLedger enforce max_output_tokens?");
+    expect(plan.explicitIdentifiers).toEqual(["BudgetLedger", "max_output_tokens"]);
+    expect(plan.explicitIdentifiers).not.toContain("How");
+  });
+
+  it("preserves a private symbol for exact lookup while splitting its identifier", () => {
+    const plan = planGraphQuery("How does #newResponse call createResponseInstance?");
+    expect(plan.explicitIdentifiers).toEqual(expect.arrayContaining(["#newResponse", "createResponseInstance"]));
+    expect(plan.terms.map((entry) => entry.term)).toEqual(expect.arrayContaining(["newresponse", "new", "response"]));
+  });
+
+  it("keeps path segments separate instead of concatenating punctuation", () => {
+    expect(identifierComponents("src/http/context-cache.ts")).toEqual([
+      "src", "http", "context", "cache", "ts",
+    ]);
+    const terms = planGraphQuery("look in src/http/context-cache.ts").terms.map((entry) => entry.term);
+    expect(terms).toEqual(expect.arrayContaining(["src", "http", "context", "cache"]));
+    expect(terms).not.toContain("srchttpcontextcachets");
+  });
+
+  it("keeps ordinary hyphenated prose out of the exact-symbol channel", () => {
+    const plan = planGraphQuery("command-line watch-mode source-file behavior");
+    expect(plan.explicitIdentifiers).toEqual([]);
+    expect(plan.terms.find((entry) => entry.term === "command")).toMatchObject({
+      identifierLike: false,
+      weight: 1,
+    });
+    expect(plan.terms.find((entry) => entry.term === "watch")).toMatchObject({
+      identifierLike: false,
+      weight: 1,
+    });
+    expect(plan.terms.find((entry) => entry.term === "source")).toMatchObject({
+      identifierLike: false,
+      weight: 0.35,
+    });
+  });
+
+  it("still pins paths, extensions, private and qualified names, and code-shaped ids", () => {
+    const plan = planGraphQuery(
+      "src/http/context-cache.ts config.json #newResponse Router.create snake_case camelCase Handler2",
+    );
+    expect(plan.explicitIdentifiers).toEqual(expect.arrayContaining([
+      "src/http/context-cache.ts",
+      "config.json",
+      "#newResponse",
+      "Router.create",
+      "snake_case",
+      "camelCase",
+      "Handler2",
+    ]));
+    expect(isDistinctiveIdentifier("watch-mode")).toBe(false);
+    expect(isDistinctiveIdentifier("context-cache.ts")).toBe(true);
+  });
+
+  it("adds low-weight derivational prefixes for long tion and sion nouns", () => {
+    const plan = planGraphQuery("configuration compilation resolution");
+    const terms = new Map(plan.terms.map((entry) => [entry.term, entry]));
+    expect(terms.get("confi")).toMatchObject({ stem: true, weight: 0.2 });
+    expect(terms.get("compi")).toMatchObject({ stem: true, weight: 0.2 });
+    expect(terms.get("resol")).toMatchObject({ stem: true, weight: 0.2 });
+    expect(stemVariants("configuration")).toContain("confi");
+    expect(stemVariants("compilation")).toContain("compi");
+    expect(stemVariants("resolution")).toContain("resol");
+    expect(stemVariants("configuration")).not.toContain("configurat");
+  });
+
+  it("does not create truncated three-letter stems for ordinary s-plurals", () => {
+    expect(stemVariants("files")).toContain("file");
+    expect(stemVariants("files")).not.toContain("fil");
+    expect(stemVariants("lines")).toContain("line");
+    expect(stemVariants("lines")).not.toContain("lin");
+    expect(stemVariants("suffixes")).toContain("suffix");
+  });
+});

--- a/src/graph/__tests__/scope.test.ts
+++ b/src/graph/__tests__/scope.test.ts
@@ -615,6 +615,40 @@ describe("scored scope selection", () => {
     expect(selection.flows[0]?.steps).toEqual([edge]);
   });
 
+  it("keeps filtered phrase concepts attached to their compiler-proven bridge", () => {
+    const source = node("function:file-resolution-dispatcher", "fileResolutionDispatcher", 10, {
+      filePath: "src/dispatcher.ts",
+    });
+    const target = node("function:file-resolution-handler", "fileResolutionHandler", 20, {
+      filePath: "src/handler.ts",
+    });
+    const edge: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", line: 12, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [source, target];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "file resolution" ? [source] : []),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [],
+    };
+
+    // The first three pairs are filtered as low-signal. The surviving pair's
+    // original index is 3, even though it occupies index 0 in the filtered list.
+    const selection = selectScope(graph, "graph node source file resolution", 12, 2);
+    expect(selection.candidates.find((candidate) => candidate.id === target.id)?.reasons)
+      .toContain("query-phrase-flow");
+    expect(selection.coveredTerms).toEqual(["file", "resolution"]);
+    expect(selection.flows[0]?.steps).toEqual([edge]);
+  });
+
   it.each([
     {
       phrase: "graph retrieval",

--- a/src/graph/__tests__/scope.test.ts
+++ b/src/graph/__tests__/scope.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphEngine } from "../engine.js";
-import { compactFact, groupByFile, readNodeSource, scopeSelect, selectScope } from "../scope.js";
-import type { GraphNode } from "../types.js";
+import { compactFact, groupByFile, planFileSource, readNodeSource, scopeSelect, selectScope } from "../scope.js";
+import type { GraphEdge, GraphNode } from "../types.js";
 
 function node(id: string, name: string, line: number, extra: Partial<GraphNode> = {}): GraphNode {
   return {
@@ -18,22 +18,138 @@ function fixture(): { graph: GraphEngine; seed: GraphNode; caller: GraphNode; ca
   const seed = node("function:seed", "seed", 2, { signature: "function seed(): string", docstring: "Seed docs", returnType: "string" });
   const caller = node("function:caller", "caller", 1);
   const callee = node("function:callee", "callee", 3);
-  const nodes = [seed, caller, callee];
+  const ambiguous = node("function:ambiguous", "ambiguous", 4);
+  const incoming: GraphEdge = {
+    source: caller.id, target: seed.id, kind: "calls", line: 8, column: 2,
+    confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+  };
+  const outgoing: GraphEdge = {
+    source: seed.id, target: callee.id, kind: "calls", line: 3, column: 2,
+    confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+  };
+  const lowConfidence: GraphEdge = {
+    source: seed.id, target: ambiguous.id, kind: "calls", line: 4, column: 2,
+    confidence: 0.75, resolutionMethod: "partial-candidate", provenance: "heuristic",
+  };
+  const nodes = [seed, caller, callee, ambiguous];
   const graph: GraphEngine = {
     build: vi.fn(), sync: vi.fn(), close: vi.fn(),
     searchNodes: vi.fn(() => [seed]),
     getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
     getCallers: (id) => id === seed.id ? [caller] : [],
     getCallees: (id) => id === seed.id ? [callee] : [],
+    getIncoming: (id) => id === seed.id ? [{ node: caller, edge: incoming }] : [],
+    getOutgoing: (id) => id === seed.id
+      ? [{ node: callee, edge: outgoing }, { node: ambiguous, edge: lowConfidence }]
+      : [],
   };
   return { graph, seed, caller, callee };
 }
 
+function callPairCallbackCompletionFixture(options: {
+  terminalName?: string;
+  containmentConfidence?: number;
+  callbackContainerId?: string;
+  proveCallPair?: boolean;
+} = {}): {
+  graph: GraphEngine;
+  task: string;
+  spine: GraphEdge[];
+  entry: GraphNode;
+  planner: GraphNode;
+} {
+  const task = "How does an agent expand a selected graph node into bounded source code?";
+  const entry = node("function:callback-entry", "runGraphGet", 1, {
+    filePath: "src/agent.ts", startLine: 1, endLine: 20, isExported: true,
+    signature: options.proveCallPair === false
+      ? "(ids: string[]): void"
+      : "(ids: string[], deps?: AgentCommandDeps, rawOptions?: RawOptions): void",
+    docstring: options.proveCallPair === false ? undefined
+      : "Targeted source expansion by graph node id. Output is source records.",
+  });
+  const planner = node("function:callback-planner", "planSource", 30, {
+    filePath: entry.filePath, startLine: 30, endLine: 70,
+    signature: "(ledger: BudgetLedger, nodes: GraphNode[], opts: AgentOptions): SourceRange[]",
+  });
+  const callback = node("function:callback-planner-map", "<callback:fileNodes.map[0]>", 40, {
+    filePath: planner.filePath, qualifiedName: "planSource::<callback:fileNodes.map[0]>",
+    startLine: 40, endLine: 50, containerId: options.callbackContainerId ?? planner.id,
+  });
+  const terminal = node("function:callback-terminal", options.terminalName ?? "readNodeSource", 1, {
+    filePath: "src/source.ts", startLine: 1, endLine: 15, isExported: true,
+  });
+  const distractors = Array.from({ length: 8 }, (_, index) => node(
+    `function:callback-noise-${index}`,
+    `opaqueBranch${index}`,
+    1,
+    { filePath: entry.filePath, isExported: true },
+  ));
+  const corpusFillers = Array.from({ length: 8 }, (_, index) => node(
+    `function:callback-corpus-${index}`,
+    `unrelatedCorpusSymbol${index}`,
+    1,
+    { filePath: `src/corpus-${index}.ts` },
+  ));
+  const entryPlanner: GraphEdge = {
+    source: entry.id, target: planner.id, kind: "calls", line: 10, column: 2,
+    confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+  };
+  const plannerCallback: GraphEdge = {
+    source: planner.id, target: callback.id, kind: "contains", line: 40, column: 2,
+    confidence: options.containmentConfidence ?? 1,
+    resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+  };
+  const callbackTerminal: GraphEdge = {
+    source: callback.id, target: terminal.id, kind: "calls", line: 45, column: 4,
+    confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+  };
+  const noiseEdges = distractors.map((target, index): GraphEdge => ({
+    source: entry.id, target: target.id, kind: "calls", line: 2 + index, column: 2,
+    confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+  }));
+  const nodes = [entry, planner, callback, terminal, ...distractors, ...corpusFillers];
+  const byId = new Map(nodes.map((entry) => [entry.id, entry]));
+  const edges = [entryPlanner, plannerCallback, callbackTerminal, ...noiseEdges];
+  const outgoing = new Map<string, Array<{ node: GraphNode; edge: GraphEdge }>>();
+  const incoming = new Map<string, Array<{ node: GraphNode; edge: GraphEdge }>>();
+  for (const edge of edges) {
+    const source = byId.get(edge.source)!;
+    const target = byId.get(edge.target)!;
+    outgoing.set(source.id, [...(outgoing.get(source.id) ?? []), { node: target, edge }]);
+    incoming.set(target.id, [...(incoming.get(target.id) ?? []), { node: source, edge }]);
+  }
+  const searchResults = [...corpusFillers, ...distractors, entry, planner];
+  const graph: GraphEngine = {
+    build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => searchResults),
+    getNode: (id) => byId.get(id) ?? null,
+    getCallers: () => [], getCallees: () => [],
+    getIncoming: (id, kinds) => (incoming.get(id) ?? [])
+      .filter(({ edge }) => !kinds || kinds.includes(edge.kind)),
+    getOutgoing: (id, kinds) => (outgoing.get(id) ?? [])
+      .filter(({ edge }) => !kinds || kinds.includes(edge.kind)),
+    getIndexedFiles: () => [...new Set(nodes.map((entry) => entry.filePath))].map((path) => ({
+      path, contentHash: path, parseStatus: "ok" as const, diagnosticCount: 0,
+      errorCoverage: 0, nodeCount: nodes.filter((entry) => entry.filePath === path).length,
+    })),
+    searchSource: () => [{
+      filePath: entry.filePath, startLine: 1, endLine: 20, contentHash: "agent-entry",
+      rank: -0.3, matchedTerms: ["expand", "selected", "graph", "node"], nodeIds: [entry.id],
+    }, {
+      filePath: planner.filePath, startLine: 30, endLine: 35, contentHash: "agent-planner",
+      rank: -0.29, matchedTerms: ["bounded", "source", "node"], nodeIds: [planner.id],
+    }],
+  };
+  return { graph, task, spine: [entryPlanner, plannerCallback, callbackTerminal], entry, planner };
+}
+
 describe("query-time graph scope", () => {
-  it("selects top-ten FTS seeds plus one-hop callers and callees, deduped", () => {
+  it("pins an explicit seed and expands two hops only through reliable typed edges", () => {
     const { graph } = fixture();
-    expect(scopeSelect(graph, "seed task")).toEqual(["function:seed", "function:caller", "function:callee"]);
-    expect(graph.searchNodes).toHaveBeenCalledWith("seed task", { limit: 10 });
+    const selected = scopeSelect(graph, "Seed task");
+    expect(selected[0]).toBe("function:seed");
+    expect(new Set(selected.slice(1))).toEqual(new Set(["function:caller", "function:callee"]));
+    expect(selected).not.toContain("function:ambiguous");
+    expect(graph.searchNodes).toHaveBeenCalledWith("Seed task", { limit: 80 });
   });
 
   it("builds a compact fact with relationship counts and no source", () => {
@@ -63,10 +179,12 @@ describe("query-time graph scope", () => {
     try {
       const wide = node("function:wide", "wide", 1, { endLine: 4 });
       expect(readNodeSource(wide, root, 0)).toEqual({
-        startLine: 1, endLine: 4, nodeIds: ["function:wide"], content: "line-a\nline-b\nline-c\nline-d", truncated: false,
+        startLine: 1, endLine: 4, nodeIds: ["function:wide"],
+        content: "1: line-a\n2: line-b\n3: line-c\n4: line-d", truncated: false, reason: "complete-symbol",
       });
       expect(readNodeSource(wide, root, 2)).toEqual({
-        startLine: 1, endLine: 2, nodeIds: ["function:wide"], content: "line-a\nline-b", truncated: true,
+        startLine: 1, endLine: 2, nodeIds: ["function:wide"],
+        content: "1: line-a\n2: line-b", truncated: true, reason: "signature",
       });
     } finally {
       rmSync(root, { recursive: true, force: true });
@@ -87,23 +205,1648 @@ describe("query-time graph scope", () => {
   });
 });
 
+describe("source range planning", () => {
+  it("preserves caller-provided node priority instead of reverting to source-line order", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-source-order-"));
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "src/sample.ts"), Array.from({ length: 260 }, (_, index) => `line ${index + 1}`).join("\n"));
+    try {
+      const named = node("function:named", "NamedTarget", 200, { startLine: 200, endLine: 205 });
+      const neighbor = node("function:neighbor", "neighbor", 10, { startLine: 10, endLine: 15 });
+      const ranges = planFileSource("src/sample.ts", [named, neighbor], [], root, "NamedTarget", 200);
+      expect(ranges.map((range) => range.nodeIds)).toEqual([[named.id], [neighbor.id]]);
+      expect(ranges.map((range) => range.startLine)).toEqual([200, 10]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates a complete parent/child pair while retaining both source-backed ids", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-source-parent-"));
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "src/sample.ts"), Array.from({ length: 260 }, (_, index) => `line ${index + 1}`).join("\n"));
+    try {
+      const child = node("method:child", "child", 40, { startLine: 40, endLine: 60 });
+      const parent = node("class:parent", "Parent", 10, { kind: "class", startLine: 10, endLine: 100 });
+      const ranges = planFileSource("src/sample.ts", [child, parent], [], root, "Parent.child", 200);
+      expect(ranges).toHaveLength(1);
+      expect(ranges[0]).toMatchObject({
+        startLine: 10, endLine: 100, reason: "complete-symbol", truncated: false,
+      });
+      expect(new Set(ranges[0]!.nodeIds)).toEqual(new Set([child.id, parent.id]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses a signature plus at most two 25-line callsite/query windows for a long symbol", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-source-long-"));
+    mkdirSync(join(root, "src"));
+    const lines = Array.from({ length: 260 }, (_, index) => `line ${index + 1}`);
+    lines[89] = "const queryAlpha = first();";
+    lines[119] = "return queryAlpha;";
+    lines[179] = "invokeFlowSpine();";
+    writeFileSync(join(root, "src/sample.ts"), lines.join("\n"));
+    try {
+      const long = node("method:long", "longMethod", 1, { kind: "method", startLine: 1, endLine: 240 });
+      const ranges = planFileSource("src/sample.ts", [long], [], root, "queryAlpha", 200, [180]);
+      expect(ranges).toHaveLength(3);
+      expect(ranges[0]).toMatchObject({
+        startLine: 1, endLine: 6, reason: "signature", truncated: true, nodeIds: [long.id],
+      });
+      expect(ranges[1]).toMatchObject({ startLine: 168, endLine: 192, reason: "callsite", nodeIds: [long.id] });
+      expect(ranges[2]).toMatchObject({ startLine: 78, endLine: 102, reason: "query-hit", nodeIds: [long.id] });
+      for (const range of ranges.slice(1)) expect(range.endLine - range.startLine + 1).toBeLessThanOrEqual(25);
+      expect(ranges.some((range) => range.content.includes("return queryAlpha"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("merges two source windows separated by ten lines or fewer without merging the signature", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-source-merge-"));
+    mkdirSync(join(root, "src"));
+    const lines = Array.from({ length: 260 }, (_, index) => `line ${index + 1}`);
+    lines[49] = "queryNeedle();";
+    lines[79] = "queryNeedle();";
+    writeFileSync(join(root, "src/sample.ts"), lines.join("\n"));
+    try {
+      const long = node("method:long", "longMethod", 1, { kind: "method", startLine: 1, endLine: 240 });
+      const ranges = planFileSource("src/sample.ts", [long], [], root, "queryNeedle", 200);
+      expect(ranges).toHaveLength(2);
+      expect(ranges[0]).toMatchObject({ startLine: 1, endLine: 6, reason: "signature" });
+      expect(ranges[1]).toMatchObject({ startLine: 38, endLine: 92, reason: "query-hit" });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("scored scope selection", () => {
+  it("prefers query concepts co-located in one source region over terms scattered across a central file", () => {
+    const focused = node("function:focused", "focused", 1, {
+      filePath: "src/focused.ts", signature: "function focused(alpha: Alpha, beta: Beta, gamma: Gamma): void",
+    });
+    const central = node("function:central", "central", 1, {
+      filePath: "src/central.ts", signature: "function central(alpha: Alpha, beta: Beta, gamma: Gamma): void",
+    });
+    const nodes = [central, focused];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => nodes),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [
+        { path: "src/central.ts", contentHash: "central", parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1 },
+        { path: "src/focused.ts", contentHash: "focused", parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1 },
+      ],
+      searchSource: () => [
+        { filePath: "src/central.ts", startLine: 1, endLine: 20, contentHash: "central", rank: -0.05, matchedTerms: ["alpha"] },
+        { filePath: "src/central.ts", startLine: 61, endLine: 80, contentHash: "central", rank: -0.05, matchedTerms: ["beta"] },
+        { filePath: "src/central.ts", startLine: 121, endLine: 140, contentHash: "central", rank: -0.05, matchedTerms: ["gamma"] },
+        {
+          filePath: "src/focused.ts", startLine: 1, endLine: 20, contentHash: "focused", rank: -0.05,
+          matchedTerms: ["alpha", "beta", "gamma"],
+        },
+      ],
+    };
+
+    const selection = selectScope(graph, "alpha beta gamma", 10, 2);
+    expect(selection.files[0]).toMatchObject({ filePath: "src/focused.ts" });
+    expect(selection.files[0]!.score).toBeGreaterThan(selection.files[1]!.score);
+  });
+
+  it("reserves the best source-chunk declaration before aggregate representatives", () => {
+    const aligned = node("function:aligned", "recoverCandidate", 10, {
+      filePath: "src/extensions.ts", startLine: 10, endLine: 30,
+    });
+    const aggregate = node("function:aggregate", "supportedExtensionLookup", 12, {
+      filePath: "src/extensions.ts", startLine: 12, endLine: 20,
+    });
+    const nodes = [aligned, aggregate];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [aggregate]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: aligned.filePath, contentHash: "extensions", parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: aligned.filePath, startLine: 10, endLine: 30, contentHash: "extensions",
+        rank: -0.2, matchedTerms: ["supported", "extension", "lookup"],
+        nodeIds: [aligned.id],
+      }, {
+        filePath: aggregate.filePath, startLine: 12, endLine: 20, contentHash: "extensions",
+        rank: -0.19, matchedTerms: ["supported", "extension", "lookup"],
+        nodeIds: [aggregate.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "supported extension lookup", 2, 1);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([aggregate.id, aligned.id]);
+    expect(selection.files[0]?.nodeIds).toEqual([aggregate.id, aligned.id]);
+  });
+
+  it("preserves a plan+source full-query declaration when a same-file source region ranks first", () => {
+    const target = node("function:target", "planFileSource", 120, {
+      filePath: "src/planner.ts", startLine: 120, endLine: 150,
+      signature: "function planFileSource(symbols: Symbol[]): SourceWindow[]",
+    });
+    const sourceDecoy = node("function:source-decoy", "selectScope", 1, {
+      filePath: target.filePath, startLine: 1, endLine: 80,
+    });
+    const nodes = [target, sourceDecoy];
+    const query = "plan source";
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((request) => request === query || ["plan", "source"].includes(request)
+        ? [target] : []),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: target.filePath, contentHash: "planner", parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: target.filePath, startLine: 1, endLine: 80, contentHash: "planner",
+        rank: -0.3, matchedTerms: ["plan", "source"],
+        nodeIds: [sourceDecoy.id],
+      }, {
+        filePath: target.filePath, startLine: 101, endLine: 160, contentHash: "planner",
+        rank: -0.2, matchedTerms: ["plan", "source"], nodeIds: [target.id],
+      }],
+    };
+
+    const selection = selectScope(graph, query, 1, 1);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([target.id]);
+    expect(selection.files[0]?.nodeIds).toEqual([target.id]);
+    expect(selection.candidates[0]?.reasons).toContain("bm25-node");
+    expect(selection.candidates[0]?.reasons).not.toContain("query-phrase-flow");
+  });
+
+  it("does not count stems of one raw concept as independent full-query proof", () => {
+    const wrapper = node("function:wrapper", "getSupportedExtensionsWithJsonIfResolveJsonModule", 40, {
+      filePath: "src/extensions.ts", startLine: 40, endLine: 50,
+      signature: "function getSupportedExtensionsWithJsonIfResolveJsonModule(options: CompilerOptions): string[]",
+    });
+    const aligned = node("function:aligned", "getSupportedExtensions", 10, {
+      filePath: wrapper.filePath, startLine: 10, endLine: 30,
+      signature: "function getSupportedExtensions(options: CompilerOptions): string[]",
+    });
+    const nodes = [wrapper, aligned];
+    const query = "which routine decides supported compiler options";
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [wrapper, aligned]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: wrapper.filePath, contentHash: "extensions", parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: aligned.filePath, startLine: 10, endLine: 30, contentHash: "extensions",
+        rank: -0.3, matchedTerms: ["supported", "compiler", "options"], nodeIds: [aligned.id],
+      }],
+    };
+
+    const selection = selectScope(graph, query, 1, 1);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([aligned.id]);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(wrapper.id);
+  });
+
+  it("does not reserve a full-query BM25 hit corroborated only by prose", () => {
+    const proseOnly = node("function:prose-only", "utility", 1, {
+      filePath: "src/utility.ts", docstring: "Plan bounded source windows for a request.",
+    });
+    const aligned = node("function:aligned-answer", "sourceWindows", 20, {
+      filePath: "src/planner.ts", startLine: 20, endLine: 40,
+      signature: "function sourceWindows(plan: Plan): SourceWindow[]",
+    });
+    const nodes = [proseOnly, aligned];
+    const query = "plan bounded source windows";
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((request) => request === query ? [proseOnly] : [proseOnly, aligned]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: aligned.filePath, startLine: 20, endLine: 40, contentHash: "planner",
+        rank: -0.3, matchedTerms: ["plan", "bounded", "source", "windows"], nodeIds: [aligned.id],
+      }],
+    };
+
+    const selection = selectScope(graph, query, 1, 2);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([aligned.id]);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(proseOnly.id);
+  });
+
+  it("reserves one production full-query declaration deterministically without widening maxNodes", () => {
+    const testHit = node("function:test-hit", "alphaBetaTest", 1, {
+      filePath: "src/__tests__/pipeline.test.ts", signature: "function alphaBetaTest(pipeline: Pipeline): void",
+    });
+    const firstProduction = node("function:production-first", "alphaBetaPrimary", 100, {
+      filePath: "src/pipeline.ts", signature: "function alphaBetaPrimary(pipeline: Pipeline): void",
+    });
+    const secondProduction = node("function:production-second", "alphaBetaSecondary", 140, {
+      filePath: firstProduction.filePath, signature: "function alphaBetaSecondary(pipeline: Pipeline): void",
+    });
+    const sourceDecoy = node("function:source-decoy", "regionOwner", 1, {
+      filePath: firstProduction.filePath, startLine: 1, endLine: 80,
+    });
+    const nodes = [testHit, firstProduction, secondProduction, sourceDecoy];
+    const query = "alpha beta pipeline";
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [testHit, firstProduction, secondProduction]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [testHit.filePath, firstProduction.filePath].map((path) => ({
+        path, contentHash: path, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.filter((entry) => entry.filePath === path).length,
+      })),
+      searchSource: () => [{
+        filePath: sourceDecoy.filePath, startLine: 1, endLine: 80, contentHash: "pipeline",
+        rank: -0.3, matchedTerms: ["alpha", "beta", "pipeline"], nodeIds: [sourceDecoy.id],
+      }],
+    };
+
+    const first = selectScope(graph, query, 2, 2);
+    const second = selectScope(graph, query, 2, 2);
+    expect(first.candidates).toHaveLength(2);
+    expect(first.candidates.map((candidate) => candidate.id)).toEqual([
+      firstProduction.id, sourceDecoy.id,
+    ]);
+    expect(first.candidates.map((candidate) => candidate.id)).not.toContain(testHit.id);
+    expect(first.candidates.map((candidate) => candidate.id)).not.toContain(secondProduction.id);
+    expect(second.candidates.map((candidate) => candidate.id))
+      .toEqual(first.candidates.map((candidate) => candidate.id));
+  });
+
+  it("does not turn sibling declarations in a broad source chunk into graph candidates", () => {
+    const file = node("file:context", "retrievedContext.ts", 1, {
+      kind: "file", filePath: "src/retrieved-context.ts", startLine: 1, endLine: 80,
+    });
+    const anchor = node("function:anchor", "quotaGate", 10, {
+      filePath: file.filePath, startLine: 10, endLine: 30,
+    });
+    const sibling = node("function:sibling", "legacyNeighborhood", 50, {
+      filePath: anchor.filePath, startLine: 50, endLine: 55,
+    });
+    const callback = node("function:file-callback", "<callback:file[0]>", 60, {
+      filePath: anchor.filePath, startLine: 60, endLine: 60,
+    });
+    const callbackTarget = node("function:callback-target", "unrelatedCallbackTarget", 70, {
+      filePath: anchor.filePath, startLine: 70, endLine: 75,
+    });
+    const nodes = [file, anchor, sibling, callback, callbackTarget];
+    const contains = (target: GraphNode): GraphEdge => ({
+      source: file.id, target: target.id, kind: "contains", line: target.startLine,
+      confidence: 1, resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+    });
+    const anchorContainment = contains(anchor);
+    const siblingContainment = contains(sibling);
+    const callbackContainment = contains(callback);
+    const callbackCall: GraphEdge = {
+      source: callback.id, target: callbackTarget.id, kind: "calls", line: 60,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const indexedFile = {
+      path: anchor.filePath, contentHash: "context", parseStatus: "ok" as const,
+      diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.length,
+    };
+    const base: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => [file]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === anchor.id ? [{ node: file, edge: anchorContainment }]
+        : id === sibling.id ? [{ node: file, edge: siblingContainment }] : [],
+      getOutgoing: (id) => id === file.id ? [
+        { node: anchor, edge: anchorContainment }, { node: sibling, edge: siblingContainment },
+        { node: callback, edge: callbackContainment },
+      ] : id === callback.id ? [{ node: callbackTarget, edge: callbackCall }] : [],
+      getIndexedFiles: () => [indexedFile],
+      searchSource: () => [{
+        filePath: anchor.filePath, startLine: 1, endLine: 80, contentHash: "context",
+        rank: -0.2, matchedTerms: ["retrieved", "context", "token"],
+        nodeIds: [anchor.id, sibling.id],
+      }],
+    };
+
+    const selection = selectScope(
+      base,
+      "prevent retrieved context from exceeding its token allowance",
+      10,
+      1,
+    );
+    expect(selection.candidates.map((candidate) => candidate.id)).toContain(anchor.id);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(sibling.id);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(callback.id);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(callbackTarget.id);
+    expect(selection.files[0]).toMatchObject({ filePath: anchor.filePath, textOnly: false });
+    expect(selection.files[0]?.nodeIds).not.toContain(sibling.id);
+
+    const weak = selectScope({
+      ...base,
+      searchNodes: vi.fn(() => []),
+      getNode: (id) => id === sibling.id ? sibling : null,
+      getIncoming: () => [], getOutgoing: () => [],
+      searchSource: () => [{
+        filePath: sibling.filePath, startLine: 1, endLine: 80, contentHash: "context",
+        rank: -0.2, matchedTerms: ["retrieved", "context"], nodeIds: [sibling.id],
+      }],
+    }, "retrieved context allowance", 10, 1);
+    expect(weak.candidates).toEqual([]);
+    expect(weak.files[0]).toMatchObject({
+      filePath: sibling.filePath, nodeIds: [], textOnly: true,
+    });
+    expect(weak.files[0]?.textHits).toHaveLength(1);
+  });
+
+  it("reserves a compiler-proven cross-file destination when both endpoints match an adjacent phrase", () => {
+    const schedule = node("function:schedule", "scheduleCacheInvalidation", 10, {
+      filePath: "src/coordinator.ts",
+    });
+    const invalidate = node("function:invalidate", "cacheInvalidationHandler", 20, {
+      filePath: "src/cache.ts",
+    });
+    const distractors = Array.from({ length: 3 }, (_, index) => node(
+      `function:distractor-${index}`,
+      `cacheInvalidationGuide${index}`,
+      1,
+      { filePath: `src/guide-${index}.ts` },
+    ));
+    const edge: GraphEdge = {
+      source: schedule.id, target: invalidate.id, kind: "calls", line: 12, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const laterCallsite: GraphEdge = { ...edge, line: 29, column: 4 };
+    const nodes = [schedule, invalidate, ...distractors];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "cache invalidation" ? [schedule] : distractors),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      // Deliberately reverse callsite order: storage order must not choose the
+      // representative edge for a repeated source/target relationship.
+      getOutgoing: (id) => id === schedule.id
+        ? [{ node: invalidate, edge: laterCallsite }, { node: invalidate, edge }]
+        : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => distractors.map((entry, index) => ({
+        filePath: entry.filePath, startLine: 1, endLine: 20, contentHash: entry.id,
+        rank: -0.2 + index * 0.001, matchedTerms: ["cache", "invalidation"], nodeIds: [entry.id],
+      })),
+    };
+
+    const selection = selectScope(graph, "How does cache invalidation cross the service boundary?", 12, 2);
+    expect(selection.files.map((file) => file.filePath)).toContain(invalidate.filePath);
+    expect(selection.candidates.find((candidate) => candidate.id === invalidate.id)?.reasons)
+      .toContain("query-phrase-flow");
+    expect(selection.flows[0]?.steps).toEqual([edge]);
+  });
+
+  it.each([
+    {
+      phrase: "graph retrieval",
+      sourceName: "runGraphScope",
+      targetName: "selectScope",
+      signature: "(graph: GraphEngine): GraphScopeSelection",
+      docstring: "Broad graph retrieval for a natural-language request.",
+    },
+    {
+      phrase: "build graph",
+      sourceName: "graphCommandCallback",
+      targetName: "runGraph",
+      signature: "(graph: GraphEngine): void",
+      docstring: "Build the graph for the current repository.",
+    },
+  ])("retains the required $phrase semantic bridge when its other concept is low-signal", ({
+    phrase, sourceName, targetName, signature, docstring,
+  }) => {
+    const source = node(`function:${sourceName}`, sourceName, 10, {
+      filePath: "src/command.ts", signature, docstring,
+    });
+    const target = node(`function:${targetName}`, targetName, 20, {
+      filePath: "src/implementation.ts", signature, docstring,
+    });
+    const edge: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", line: 12, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [source, target];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [source]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [],
+    };
+
+    const selection = selectScope(graph, phrase, 12, 2);
+    expect(selection.files.map((file) => file.filePath)).toContain(target.filePath);
+    expect(selection.candidates.find((candidate) => candidate.id === target.id)?.reasons)
+      .toContain("query-phrase-flow");
+    expect(selection.flows[0]?.steps).toEqual([edge]);
+  });
+
+  it("does not promote a compiler-proven source-file bridge over focused retrieval evidence", () => {
+    const source = node("function:source-map", "getSourceMapDirectory", 10, {
+      filePath: "src/emitter.ts",
+    });
+    const target = node("function:new-dir", "getSourceFilePathInNewDir", 20, {
+      filePath: "src/utilities.ts",
+    });
+    const focused = node("function:resolver", "resolveModuleName", 30, {
+      filePath: "src/module-name-resolver.ts",
+    });
+    const edge: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", line: 12, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [source, target, focused];
+    const query = "locate an imported package or source file";
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((request) => request.toLowerCase() === "source file" ? [source] : [focused]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: focused.filePath, startLine: 30, endLine: 40, contentHash: "resolver",
+        rank: -0.3, matchedTerms: ["locate", "imported", "package"], nodeIds: [focused.id],
+      }],
+    };
+
+    const selection = selectScope(graph, query, 12, 1);
+    expect(selection.files.map((file) => file.filePath)).toEqual([focused.filePath]);
+    expect(selection.files.flatMap((file) => file.reasons)).not.toContain("query-phrase-flow");
+    expect(selection.candidates.flatMap((candidate) => candidate.reasons)).not.toContain("query-phrase-flow");
+    expect(selection.flows.flatMap((flow) => flow.steps)).not.toContainEqual(edge);
+  });
+
+  it("bounds phrase-flow endpoint inspection after stable callsite ordering", () => {
+    const source = node("function:source", "scheduleCacheInvalidation", 10, { filePath: "src/source.ts" });
+    const rejected = Array.from({ length: 16 }, (_, index) => node(
+      `function:rejected-${index}`,
+      `ordinaryHandler${index}`,
+      index + 1,
+      { filePath: `src/rejected-${index}.ts` },
+    ));
+    const beyondLimit = node("function:beyond-limit", "cacheInvalidationHandler", 30, {
+      filePath: "src/beyond-limit.ts",
+    });
+    const edges = [...rejected.map((target, index) => ({
+      node: target,
+      edge: {
+        source: source.id, target: target.id, kind: "calls" as const, line: index + 1, column: 1,
+        confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler" as const,
+      },
+    })), {
+      node: beyondLimit,
+      edge: {
+        source: source.id, target: beyondLimit.id, kind: "calls" as const, line: 17, column: 1,
+        confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler" as const,
+      },
+    }].reverse();
+    const nodes = [source, ...rejected, beyondLimit];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "cache invalidation" ? [source] : []),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? edges : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [],
+    };
+
+    const selection = selectScope(graph, "cache invalidation across a boundary", 12, 2);
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(beyondLimit.id);
+    expect(selection.files.map((file) => file.filePath)).not.toContain(beyondLimit.filePath);
+    expect(selection.flows).toEqual([]);
+  });
+
+  it("does not activate phrase-flow admission for same-file or low-confidence edges", () => {
+    const run = (sameFile: boolean, confidence: number) => {
+      const source = node("function:source", "scheduleCacheInvalidation", 10, {
+        filePath: "src/source.ts",
+      });
+      const target = node("function:target", "cacheInvalidationHandler", 20, {
+        filePath: sameFile ? source.filePath : "src/hidden.ts",
+      });
+      const distractor = node("function:distractor", "cacheInvalidationGuide", 1, {
+        filePath: "src/guide.ts",
+      });
+      const edge: GraphEdge = {
+        source: source.id, target: target.id, kind: "calls", line: 12, column: 2,
+        confidence, resolutionMethod: confidence >= 0.8 ? "typescript-signature" : "partial-candidate",
+        provenance: confidence >= 0.8 ? "typescript-compiler" : "heuristic",
+      };
+      const nodes = [source, target, distractor];
+      const graph: GraphEngine = {
+        build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+        searchNodes: vi.fn((query) => query.toLowerCase() === "cache invalidation" ? [source] : [distractor]),
+        getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+        getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+        getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+        getIndexedFiles: () => nodes.map((entry) => ({
+          path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+          diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        })),
+        searchSource: () => [{
+          filePath: distractor.filePath, startLine: 1, endLine: 20, contentHash: distractor.id,
+          rank: -0.2, matchedTerms: ["cache", "invalidation"], nodeIds: [distractor.id],
+        }],
+      };
+      return selectScope(graph, "cache invalidation across a boundary", 12, 2);
+    };
+
+    for (const selection of [run(true, 1), run(false, 0.75)]) {
+      expect(selection.files.flatMap((file) => file.reasons)).not.toContain("query-phrase-flow");
+      expect(selection.candidates.flatMap((candidate) => candidate.reasons)).not.toContain("query-phrase-flow");
+    }
+  });
+
+  it("requires phrase evidence in each endpoint identity instead of comments alone", () => {
+    const source = node("function:source", "scheduleCacheInvalidation", 10, { filePath: "src/source.ts" });
+    const target = node("function:target", "clearEntries", 20, {
+      filePath: "src/hidden.ts", docstring: "Performs cache invalidation after a write.",
+    });
+    const distractor = node("function:distractor", "cacheInvalidationGuide", 1, { filePath: "src/guide.ts" });
+    const edge: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", confidence: 1,
+      resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [source, target, distractor];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "cache invalidation" ? [source] : [distractor]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: distractor.filePath, startLine: 1, endLine: 20, contentHash: distractor.id,
+        rank: -0.2, matchedTerms: ["cache", "invalidation"], nodeIds: [distractor.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "cache invalidation across a boundary", 12, 2);
+    expect(selection.files.flatMap((file) => file.reasons)).not.toContain("query-phrase-flow");
+    expect(selection.candidates.flatMap((candidate) => candidate.reasons)).not.toContain("query-phrase-flow");
+  });
+
+  it("does not let a two-word low-signal phrase displace stronger source evidence", () => {
+    const source = node("function:source", "graphDeclarationScanner", 10, { filePath: "src/scanner.ts" });
+    const target = node("function:target", "graphDeclarationRegistry", 20, { filePath: "src/registry.ts" });
+    const focused = node("function:focused", "explainArchitecture", 4, {
+      filePath: "src/architecture.ts", docstring: "Explains graph declarations and their ownership.",
+    });
+    const edge: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", line: 12, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [source, target, focused];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "graph declarations" ? [source] : [focused]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: focused.filePath, startLine: 1, endLine: 20, contentHash: focused.id,
+        rank: -0.3, matchedTerms: ["graph", "declarations"], nodeIds: [focused.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "How do graph declarations work?", 12, 1);
+    expect(selection.files.map((file) => file.filePath)).toEqual([focused.filePath]);
+    expect(selection.files.flatMap((file) => file.reasons)).not.toContain("query-phrase-flow");
+    expect(selection.candidates.flatMap((candidate) => candidate.reasons)).not.toContain("query-phrase-flow");
+  });
+
+  it("prefers a query-correlated declaration over an earlier broad overlap in the same chunk", () => {
+    const broad = node("function:broad-overlap", "formatCodeSpan", 10, {
+      filePath: "src/diagnostics.ts", startLine: 10, endLine: 50,
+    });
+    const correlated = node("function:correlated", "formatDiagnosticsWithRelatedInformation", 20, {
+      filePath: "src/diagnostics.ts", startLine: 20, endLine: 30,
+    });
+    const nodes = [broad, correlated];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [broad]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: broad.filePath, contentHash: "diagnostics", parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: broad.filePath, startLine: 10, endLine: 50, contentHash: "diagnostics",
+        rank: -0.2, matchedTerms: ["format", "diagnostics", "information"],
+        nodeIds: [broad.id, correlated.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "format diagnostics information", 1, 1);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([correlated.id]);
+    expect(selection.files[0]?.nodeIds).toEqual([correlated.id]);
+  });
+
+  it("keeps the fourth global hit in the direct source floor ahead of propagated callsite files", () => {
+    const origin = node("function:origin", "originHandler", 1, {
+      filePath: "src/origin.ts", startLine: 1, endLine: 20,
+    });
+    const direct = node("function:direct", "directWinner", 1, {
+      filePath: "src/direct.ts",
+    });
+    const propagatedA = node("function:propagated-a", "propagatedOne", 1, {
+      filePath: "src/propagated-a.ts",
+    });
+    const propagatedB = node("function:propagated-b", "propagatedTwo", 1, {
+      filePath: "src/propagated-b.ts",
+    });
+    const propagatedC = node("function:propagated-c", "propagatedThree", 1, {
+      filePath: "src/propagated-c.ts",
+    });
+    const nodes = [origin, direct, propagatedA, propagatedB, propagatedC];
+    const edge = (target: GraphNode, line: number): GraphEdge => ({
+      source: origin.id, target: target.id, kind: "calls", line, column: 2,
+      confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+    });
+    const originToA = edge(propagatedA, 5);
+    const originToB = edge(propagatedB, 6);
+    const originToC = edge(propagatedC, 7);
+    const hit = (entry: GraphNode, rank: number) => ({
+      filePath: entry.filePath, startLine: 1, endLine: 20, contentHash: entry.id,
+      rank: -0.2 + rank * 0.001,
+      matchedTerms: ["opaque", "memory", "pipeline"], nodeIds: [entry.id],
+    });
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => []),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === origin.id
+        ? [
+          { node: propagatedA, edge: originToA },
+          { node: propagatedB, edge: originToB },
+          { node: propagatedC, edge: originToC },
+        ]
+        : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [
+        hit(origin, 0),
+        { ...hit(origin, 1), startLine: 2, endLine: 19 },
+        { ...hit(origin, 2), startLine: 3, endLine: 18 },
+        hit(direct, 3),
+        hit(propagatedA, 4),
+        hit(propagatedB, 5),
+        hit(propagatedC, 6),
+      ],
+    };
+
+    const selection = selectScope(graph, "opaque memory pipeline", 12, 4);
+    const selectedPaths = selection.files.map((file) => file.filePath);
+    expect(selectedPaths).toEqual(expect.arrayContaining([
+      origin.filePath, direct.filePath,
+    ]));
+    expect(selectedPaths.filter((path) => path.startsWith("src/propagated-"))).toHaveLength(2);
+  });
+
+  it("preserves three independent source-channel files before the hybrid fill", () => {
+    const sourceA = node("function:source-a", "firstAnchor", 1, { filePath: "src/a.ts" });
+    const sourceB = node("function:source-b", "secondAnchor", 1, { filePath: "src/b.ts" });
+    const sourceC = node("function:source-c", "thirdAnchor", 1, { filePath: "src/c.ts" });
+    const broad = node("function:broad", "alphaBetaGammaPipeline", 1, {
+      filePath: "src/broad.ts", signature: "function alphaBetaGammaPipeline(alpha: Alpha, beta: Beta, gamma: Gamma): void",
+    });
+    const nodes = [sourceA, sourceB, sourceC, broad];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [broad]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [sourceA, sourceB, sourceC].map((entry, index) => ({
+        filePath: entry.filePath, startLine: 1, endLine: 20, contentHash: entry.id,
+        rank: -0.05 + index * 0.001, matchedTerms: ["alpha", "beta"], nodeIds: [entry.id],
+      })),
+    };
+
+    const selection = selectScope(graph, "alpha beta gamma", 16, 4);
+    expect(selection.files.map((file) => file.filePath)).toEqual(expect.arrayContaining([
+      sourceA.filePath, sourceB.filePath, sourceC.filePath, broad.filePath,
+    ]));
+  });
+
+  it("reserves a rare compound declaration ahead of files with broader common-term scores", () => {
+    const framework = node("class:framework", "Framework", 1, {
+      kind: "class", filePath: "src/framework.ts",
+    });
+    const rare = node("class:smart-router", "SmartRouter", 1, {
+      kind: "class", filePath: "src/smart-router.ts",
+    });
+    const broad = Array.from({ length: 5 }, (_, index) => node(
+      `class:broad-${index}`,
+      "RegisteredPathsMatcher",
+      1,
+      { kind: "class", filePath: `src/broad-${index}.ts` },
+    ));
+    const nodes = [framework, rare, ...broad];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => {
+        const normalized = query.toLowerCase();
+        if (normalized.includes("framework's")) return [...broad, framework, rare];
+        if (normalized === "framework") return [framework];
+        if (normalized === "smart" || normalized === "router") return [rare];
+        if (normalized.includes("register") || normalized.includes("path")
+          || normalized.includes("match")) return broad;
+        return [...broad, framework, rare];
+      }),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => broad.slice(0, 2).map((entry, index) => ({
+        filePath: entry.filePath, startLine: 1, endLine: 20, contentHash: entry.id,
+        rank: -0.2 + index * 0.001,
+        matchedTerms: ["registered", "path", "paths", "match", "matches"],
+        nodeIds: [entry.id],
+      })),
+    };
+
+    const selection = selectScope(
+      graph,
+      "How does Framework's smart router support registered paths and later matches?",
+      16,
+      4,
+    );
+    const selectedPaths = selection.files.map((file) => file.filePath);
+    expect(selectedPaths).toEqual(expect.arrayContaining([
+      framework.filePath, rare.filePath, broad[0]!.filePath, broad[1]!.filePath,
+    ]));
+    expect(selectedPaths.filter((filePath) => broad.slice(2)
+      .some((entry) => entry.filePath === filePath))).toEqual([]);
+    expect(selection.candidates.map((candidate) => candidate.id)).toContain(rare.id);
+  });
+
+  it("does not let weak single-concept source hits evict strong graph files", () => {
+    const graphA = node("function:graph-a", "alphaBetaHandler", 1, { filePath: "src/graph-a.ts" });
+    const graphB = node("function:graph-b", "gammaDeltaHandler", 1, { filePath: "src/graph-b.ts" });
+    const weakFiles = ["src/weak-a.ts", "src/weak-b.ts", "src/weak-c.ts"];
+    const nodes = [graphA, graphB];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => nodes),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [...nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })), ...weakFiles.map((path) => ({
+        path, contentHash: path, parseStatus: "failed" as const,
+        diagnosticCount: 1, errorCoverage: 1, nodeCount: 0,
+      }))],
+      searchSource: () => weakFiles.map((filePath, index) => ({
+        filePath, startLine: 1, endLine: 20, contentHash: filePath,
+        rank: -0.001 + index * 0.0001, matchedTerms: ["alpha"],
+      })),
+    };
+
+    const selection = selectScope(graph, "alpha beta gamma delta", 16, 4);
+    expect(selection.files.map((file) => file.filePath)).toEqual(expect.arrayContaining([
+      graphA.filePath, graphB.filePath,
+    ]));
+    expect(selection.files.filter((file) => weakFiles.includes(file.filePath))).toHaveLength(2);
+  });
+
+  it("uses conservative inflection stems for path candidates", () => {
+    const target = node("function:assemble", "assemble", 1, { filePath: "src/runtime/assemble.ts" });
+    const distractor = node("function:stages", "stages", 1, { filePath: "src/runtime/core.ts" });
+    const nodes = [distractor, target];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => nodes),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [
+        { path: "src/runtime/core.ts", contentHash: "core", parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1 },
+        { path: "src/runtime/assemble.ts", contentHash: "assemble", parseStatus: "ok", diagnosticCount: 0, errorCoverage: 0, nodeCount: 1 },
+      ],
+    };
+
+    const selection = selectScope(graph, "where are request stages assembled", 10, 2);
+    expect(selection.files[0]).toMatchObject({
+      filePath: "src/runtime/assemble.ts", reasons: expect.arrayContaining(["path-match"]),
+    });
+  });
+
   it("ranks an exact identifier match first with reasons and category", () => {
     const { graph } = fixture();
-    const { candidates, matchedCount } = selectScope(graph, "seed task", 10);
+    const { candidates, flows, matchedCount } = selectScope(graph, "Seed task", 10);
     expect(matchedCount).toBe(3);
-    expect(candidates[0]).toMatchObject({ id: "function:seed", score: 1, category: "direct" });
-    expect(candidates[0].reasons).toEqual(["exact-name-match", "semantic-match"]);
+    expect(candidates[0]).toMatchObject({ id: "function:seed", category: "direct" });
+    expect(candidates[0]!.score).toBeGreaterThan(candidates[1]!.score);
+    expect(candidates[0]!.reasons).toEqual(expect.arrayContaining(["bm25-node", "exact:Seed", "term:seed"]));
     const neighbors = candidates.filter((c) => c.category === "neighbor").map((c) => c.id).sort();
     expect(neighbors).toEqual(["function:callee", "function:caller"]);
+    expect(flows).toEqual([{
+      steps: [expect.objectContaining({
+        source: "function:seed", target: "function:callee", kind: "calls", confidence: 1,
+      })],
+    }]);
+  });
+
+  it("propagates a reliable exact seed through two typed relevance hops", () => {
+    const leaf = node("function:leaf", "Leaf", 3);
+    const parent = node("function:parent", "parent", 2);
+    const top = node("function:top", "top", 1);
+    const nodes = [leaf, parent, top];
+    const parentToLeaf: GraphEdge = {
+      source: parent.id, target: leaf.id, kind: "calls", line: 2, column: 2,
+      confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+    };
+    const topToParent: GraphEdge = {
+      source: top.id, target: parent.id, kind: "calls", line: 1, column: 2,
+      confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+    };
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [leaf]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === leaf.id
+        ? [{ node: parent, edge: parentToLeaf }]
+        : id === parent.id ? [{ node: top, edge: topToParent }] : [],
+      getOutgoing: (id) => id === parent.id
+        ? [{ node: leaf, edge: parentToLeaf }]
+        : id === top.id ? [{ node: parent, edge: topToParent }] : [],
+    };
+
+    const selection = selectScope(graph, "Leaf", 10);
+    expect(selection.candidates.map((candidate) => candidate.id)).toEqual([
+      leaf.id, parent.id, top.id,
+    ]);
+    expect(selection.candidates[0]!.reasons).toContain("exact:Leaf");
+    expect(selection.candidates.slice(1).map((candidate) => candidate.category)).toEqual([
+      "neighbor", "neighbor",
+    ]);
   });
 
   it("caps returned candidates at maxNodes while reporting the full match count", () => {
     const { graph } = fixture();
-    const { candidates, matchedCount } = selectScope(graph, "seed", 1);
+    const { candidates, matchedCount } = selectScope(graph, "Seed", 1);
     expect(candidates).toHaveLength(1);
     expect(candidates[0].id).toBe("function:seed");
     expect(matchedCount).toBeGreaterThan(1);
+  });
+
+  it("does not expand or display flows from an incidental BM25-only hit", () => {
+    const { graph } = fixture();
+    graph.getIndexedFiles = () => [{
+      path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+      modifiedAt: 1, nodeCount: 5, parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+    }];
+    const selection = selectScope(graph, "documentation architecture topic", 10);
+    expect(selection.flows).toEqual([]);
+    expect(selection.files[0]).toMatchObject({ filePath: "src/sample.ts", textOnly: true });
+  });
+
+  it("emits only contiguous directed paths with seven hops and eight total steps at most", () => {
+    const seed = node("function:seed", "Seed", 1);
+    const a = node("function:a", "alpha", 2);
+    const b = node("function:b", "beta", 3);
+    const c = node("function:c", "gamma", 4);
+    const d = node("function:d", "delta", 5);
+    const nodes = [seed, a, b, c, d];
+    const calls = (source: GraphNode, target: GraphNode): { node: GraphNode; edge: GraphEdge } => ({
+      node: target,
+      edge: { source: source.id, target: target.id, kind: "calls", confidence: 1 },
+    });
+    const outgoing = new Map([
+      [seed.id, [calls(seed, a), calls(seed, b)]],
+      [a.id, [calls(a, c)]],
+      [b.id, [calls(b, d)]],
+    ]);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [seed]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => outgoing.get(id) ?? [],
+      getIndexedFiles: () => [{
+        path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+        modifiedAt: 1, nodeCount: 5, parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+      }],
+    };
+    const { flows } = selectScope(graph, "Seed", 10);
+    expect(flows.map((flow) => flow.steps.map((step) => `${step.source}->${step.target}`))).toEqual([
+      ["function:seed->function:a", "function:a->function:c"],
+      ["function:seed->function:b", "function:b->function:d"],
+    ]);
+    expect(flows.flatMap((flow) => flow.steps)).toHaveLength(4);
+    const semanticEdges = flows.flatMap((flow) => flow.steps)
+      .map((step) => `${step.source}\0${step.target}\0${step.kind}`);
+    expect(new Set(semanticEdges).size).toBe(semanticEdges.length);
+    expect(flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+    for (const flow of flows) {
+      expect(flow.steps.length).toBeLessThanOrEqual(7);
+      for (let index = 1; index < flow.steps.length; index += 1) {
+        expect(flow.steps[index - 1]!.target).toBe(flow.steps[index]!.source);
+      }
+    }
+  });
+
+  it("traverses A to C through a lexically invisible B file and promotes B for source", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-cross-file-flow-"));
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "src/bridge.ts"), "export function relay() {\n  return Gamma();\n}\n");
+    try {
+      const alpha = node("function:alpha", "Alpha", 1, { filePath: "src/alpha.ts" });
+      const bridge = node("function:bridge", "relay", 1, {
+        filePath: "src/bridge.ts", startLine: 1, endLine: 3,
+      });
+      const gamma = node("function:gamma", "Gamma", 1, { filePath: "src/gamma.ts" });
+      const distractor = node("function:pipeline", "pipelineGuide", 1, { filePath: "src/guide.ts" });
+      const nodes = [alpha, bridge, gamma, distractor];
+      const alphaBridge: GraphEdge = {
+        source: alpha.id, target: bridge.id, kind: "calls", confidence: 1,
+      };
+      const bridgeGamma: GraphEdge = {
+        source: bridge.id, target: gamma.id, kind: "calls", confidence: 1,
+      };
+      const graph: GraphEngine = {
+        build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+        searchNodes: vi.fn((query) => {
+          const lower = query.toLowerCase();
+          if (lower === "alpha") return [alpha];
+          if (lower === "gamma") return [gamma];
+          if (lower.includes("pipeline")) return [distractor];
+          return [alpha, gamma, distractor];
+        }),
+        getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+        getCallers: () => [], getCallees: () => [],
+        getIncoming: (id) => id === bridge.id ? [{ node: alpha, edge: alphaBridge }]
+          : id === gamma.id ? [{ node: bridge, edge: bridgeGamma }] : [],
+        getOutgoing: (id) => id === alpha.id ? [{ node: bridge, edge: alphaBridge }]
+          : id === bridge.id ? [{ node: gamma, edge: bridgeGamma }] : [],
+        getIndexedFiles: () => nodes.map((entry) => ({
+          path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+          diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        })),
+        // Force a lexical-only file into the initial three-file budget. The
+        // flow promotion must evict it in favor of the bridge.
+        searchSource: () => [{
+          filePath: distractor.filePath, startLine: 1, endLine: 1,
+          contentHash: "guide", rank: -5, matchedTerms: ["pipeline"],
+        }],
+      };
+
+      const selection = selectScope(graph, "Alpha Gamma pipeline", 10, 3);
+      expect(selection.files).toHaveLength(3);
+      expect(selection.files.map((file) => file.filePath)).toEqual(expect.arrayContaining([
+        alpha.filePath, bridge.filePath, gamma.filePath,
+      ]));
+      expect(selection.files.map((file) => file.filePath)).not.toContain(distractor.filePath);
+      expect(selection.files.find((file) => file.filePath === bridge.filePath)).toMatchObject({
+        nodeIds: expect.arrayContaining([bridge.id]), textOnly: false,
+        reasons: expect.arrayContaining(["flow-spine"]),
+      });
+      expect(selection.candidates.map((candidate) => candidate.id)).toContain(bridge.id);
+      expect(selection.flows[0]?.steps).toEqual([alphaBridge, bridgeGamma]);
+
+      const bridgeRanges = planFileSource(bridge.filePath, [bridge], [], root, "Alpha Gamma", 160);
+      expect(bridgeRanges[0]).toMatchObject({ nodeIds: [bridge.id], reason: "whole-file" });
+      expect(bridgeRanges[0]!.content).toContain("return Gamma()");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers a query-region callsite into an outside file over an in-budget incidental flow", () => {
+    const source = node("function:source", "pipelineEntry", 1, {
+      filePath: "src/source.ts", startLine: 1, endLine: 40,
+    });
+    const target = node("function:target", "semanticTarget", 1, { filePath: "src/target.ts" });
+    const incidental = node("function:incidental", "pipelineDispatchCoordinator", 1, {
+      filePath: "src/incidental.ts", startLine: 1, endLine: 100,
+    });
+    const helper = node("function:helper", "internalHelper", 80, { filePath: "src/incidental.ts" });
+    const nodes = [source, target, incidental, helper];
+    const sourceTarget: GraphEdge = {
+      source: source.id, target: target.id, kind: "calls", line: 10, column: 2, confidence: 1,
+    };
+    const incidentalHelper: GraphEdge = {
+      source: incidental.id, target: helper.id, kind: "calls", line: 80, column: 2, confidence: 1,
+    };
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [incidental]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === source.id ? [{ node: target, edge: sourceTarget }]
+        : id === incidental.id ? [{ node: helper, edge: incidentalHelper }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: source.filePath, startLine: 1, endLine: 20, contentHash: "source",
+        rank: -0.2, matchedTerms: ["pipeline", "dispatch"], nodeIds: [source.id],
+      }, {
+        filePath: incidental.filePath, startLine: 1, endLine: 20, contentHash: "incidental",
+        rank: -0.19, matchedTerms: ["pipeline", "dispatch"], nodeIds: [incidental.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "pipeline dispatch", 12, 2);
+    expect(selection.flows[0]?.steps).toEqual([sourceTarget]);
+    expect(selection.files.map((file) => file.filePath)).toEqual(expect.arrayContaining([
+      source.filePath, target.filePath,
+    ]));
+    expect(selection.files.map((file) => file.filePath)).not.toContain(incidental.filePath);
+    expect(selection.candidates.find((candidate) => candidate.id === target.id)).toMatchObject({
+      reasons: expect.arrayContaining(["graph:calls", "source-region:callsite"]),
+    });
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(incidental.id);
+  });
+
+  it("promotes the cohesive destination of a broad query-region callsite set", () => {
+    const origin = node("function:origin", "entry", 1, {
+      filePath: "src/origin.ts", startLine: 1, endLine: 100,
+    });
+    const incidental = node("function:incidental", "opaquePackagePipeline", 1, {
+      filePath: "src/incidental.ts", isExported: true,
+    });
+    const noise = node("function:noise", "packagePipelineHelper", 1, {
+      filePath: "src/noise.ts", isExported: true,
+    });
+    const prepare = node("function:prepare", "prepareState", 1, {
+      filePath: "src/resolver.ts", isExported: true,
+    });
+    const load = node("function:load", "loadScope", 2, {
+      filePath: "src/resolver.ts", isExported: true,
+    });
+    const resolve = node("function:resolve", "resolveDependency", 3, {
+      filePath: "src/resolver.ts", isExported: true,
+    });
+    const helpers = Array.from({ length: 6 }, (_, index) => node(
+      `function:helper-${index}`, `helper${index}`, 1,
+      { filePath: `src/helper-${index}.ts`, isExported: true },
+    ));
+    const nodes = [origin, incidental, noise, prepare, load, resolve, ...helpers];
+    const call = (target: GraphNode, line: number): GraphEdge => ({
+      source: origin.id, target: target.id, kind: "calls", line, column: 2, confidence: 1,
+      resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    });
+    // Repeated calls to one declaration must count as one cohesive target,
+    // while the resolver destination contributes three distinct declarations.
+    // Put that destination ninth so the eight-way branch cap also has to rank
+    // destination groups by cohesion instead of preserving insertion order.
+    const incidentalCalls = Array.from({ length: 5 }, (_, index) => call(incidental, 5 + index));
+    const noiseCall = call(noise, 10);
+    const helperCalls = helpers.map((helper, index) => call(helper, 20 + index));
+    const resolverCalls = [call(prepare, 40), call(load, 45), call(resolve, 50)];
+    const outgoing = [...incidentalCalls, noiseCall, ...helperCalls, ...resolverCalls];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [incidental, noise, origin]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === origin.id
+        ? outgoing.map((edge) => ({ edge, node: nodes.find((entry) => entry.id === edge.target)! }))
+        : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: origin.filePath, startLine: 1, endLine: 100, contentHash: "origin",
+        rank: -0.2, matchedTerms: ["opaque", "package", "pipeline"], nodeIds: [origin.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "opaque package pipeline", 16, 3);
+    expect(selection.flows[0]?.steps).toEqual([resolverCalls[2]]);
+    expect(selection.files.map((file) => file.filePath)).toEqual(expect.arrayContaining([
+      origin.filePath, incidental.filePath, resolve.filePath,
+    ]));
+    expect(selection.files.map((file) => file.filePath)).not.toContain(noise.filePath);
+    expect(selection.candidates.map((candidate) => candidate.id)).toContain(resolve.id);
+  });
+
+  it("prefers the query-relevant response-construction edge over a later wrapper call", () => {
+    const privateResponse = node("method:new-response", "#newResponse", 608, {
+      kind: "method", filePath: "src/context.ts", startLine: 608, endLine: 656,
+    });
+    const wrapper = node("method:response-wrapper", "newResponse", 658, {
+      kind: "method", filePath: "src/context.ts", startLine: 658, endLine: 658,
+    });
+    const createResponse = node("function:create-response", "createResponseInstance", 288, {
+      filePath: "src/context.ts", startLine: 288, endLine: 291,
+    });
+    const wrapperCall: GraphEdge = {
+      source: wrapper.id, target: privateResponse.id, kind: "calls", line: 658, column: 47,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const constructionCall: GraphEdge = {
+      source: privateResponse.id, target: createResponse.id, kind: "calls", line: 652, column: 11,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [privateResponse, wrapper, createResponse];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => nodes),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === privateResponse.id ? [{ node: wrapper, edge: wrapperCall }]
+        : id === createResponse.id ? [{ node: privateResponse, edge: constructionCall }] : [],
+      getOutgoing: (id) => id === wrapper.id ? [{ node: privateResponse, edge: wrapperCall }]
+        : id === privateResponse.id ? [{ node: createResponse, edge: constructionCall }] : [],
+      getIndexedFiles: () => [{
+        path: "src/context.ts", contentHash: "context", parseStatus: "ok", diagnosticCount: 0,
+        errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: "src/context.ts", startLine: 601, endLine: 680, contentHash: "context",
+        rank: -0.2, matchedTerms: ["context", "response", "headers", "status"],
+        nodeIds: [privateResponse.id, wrapper.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "context constructs response with prepared headers and status", 2, 1);
+    expect(selection.flows[0]?.steps).toEqual([constructionCall]);
+    expect(selection.flows.flatMap((flow) => flow.steps)).toContainEqual(wrapperCall);
+    expect(selection.flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("reserves two relevant same-region targets ahead of the latest incidental helper", () => {
+    const cache = node("function:cache", "cache", 183, {
+      filePath: "src/middleware/cache/index.ts", startLine: 183, endLine: 324,
+    });
+    const digest = node("function:digest", "createQueryDigest", 95, {
+      filePath: cache.filePath, startLine: 95, endLine: 153,
+    });
+    const key = node("function:key", "createCacheKey", 51, {
+      filePath: cache.filePath, startLine: 51, endLine: 70,
+    });
+    const skip = node("function:skip", "shouldSkipCache", 72, {
+      filePath: cache.filePath, startLine: 72, endLine: 80,
+    });
+    const helpers = Array.from({ length: 7 }, (_, index) => node(
+      `function:cache-helper-${index}`, `opaqueHelper${index}`, index + 1,
+      { filePath: cache.filePath },
+    ));
+    const call = (target: GraphNode, line: number): GraphEdge => ({
+      source: cache.id, target: target.id, kind: "calls", line, column: 2, confidence: 1,
+      resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    });
+    const digestCall = call(digest, 277);
+    const keyCall = call(key, 296);
+    const skipCall = call(skip, 313);
+    const helperCalls = helpers.map((helper, index) => call(helper, 300 + index));
+    const edges = [...helperCalls, digestCall, keyCall, skipCall];
+    const nodes = [cache, digest, key, skip, ...helpers];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => nodes),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => edges.filter((edge) => edge.target === id).map((edge) => ({
+        node: cache, edge,
+      })),
+      getOutgoing: (id) => id === cache.id ? edges.map((edge) => ({
+        node: nodes.find((entry) => entry.id === edge.target)!, edge,
+      })) : [],
+      getIndexedFiles: () => [{
+        path: cache.filePath, contentHash: "cache", parseStatus: "ok", diagnosticCount: 0,
+        errorCoverage: 0, nodeCount: nodes.length,
+      }],
+      searchSource: () => [{
+        filePath: cache.filePath, startLine: 241, endLine: 320, contentHash: "cache",
+        rank: -0.2, matchedTerms: ["cache", "query", "digest", "key"], nodeIds: [cache.id],
+      }],
+    };
+
+    const selection = selectScope(graph, "cache query digest key", 3, 1);
+    const firstEdges = selection.flows.slice(0, 2).map((flow) => flow.steps[0]);
+    expect(firstEdges).toEqual([digestCall, keyCall]);
+    expect(firstEdges).not.toContainEqual(skipCall);
+    expect(selection.flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("keeps a query-region callsite flow when its declaration falls below the candidate quota", () => {
+    const alpha = node("function:alpha", "AlphaBeta", 1, { filePath: "src/source.ts" });
+    const gamma = node("function:gamma", "GammaDelta", 2, { filePath: "src/source.ts" });
+    const theta = node("function:theta", "ThetaSigma", 3, { filePath: "src/source.ts" });
+    const callsite = node("function:callsite", "hiddenDispatcher", 40, {
+      filePath: "src/source.ts", startLine: 40, endLine: 60,
+    });
+    const target = node("function:target", "semanticTarget", 1, {
+      filePath: "src/target.ts", isExported: true,
+    });
+    const distractor = node("function:distractor", "unrelatedHelper", 1, { filePath: "src/noise.ts" });
+    const callsiteTarget: GraphEdge = {
+      source: callsite.id, target: target.id, kind: "calls", line: 55, column: 2, confidence: 1,
+    };
+    const competingFlow: GraphEdge = {
+      source: alpha.id, target: distractor.id, kind: "calls", line: 1, column: 2, confidence: 1,
+    };
+    const nodes = [alpha, gamma, theta, callsite, target, distractor];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => {
+        const exact = nodes.find((entry) => entry.name.toLowerCase() === query.toLowerCase());
+        return exact ? [exact] : [alpha, gamma, theta];
+      }),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => id === callsite.id ? [{ node: target, edge: callsiteTarget }]
+        : id === alpha.id ? [{ node: distractor, edge: competingFlow }] : [],
+      getIndexedFiles: () => nodes.map((entry) => ({
+        path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+        diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+      })),
+      searchSource: () => [{
+        filePath: callsite.filePath, startLine: 40, endLine: 60, contentHash: "source",
+        rank: -0.2, matchedTerms: ["pipeline", "target", "operation"], nodeIds: [callsite.id],
+      }],
+    };
+
+    const selection = selectScope(
+      graph,
+      "AlphaBeta GammaDelta ThetaSigma pipeline target operation",
+      3,
+      3,
+    );
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(callsite.id);
+    expect(selection.flows[0]?.steps).toEqual([callsiteTarget]);
+    expect(selection.flows.flatMap((flow) => flow.steps)).toContainEqual(competingFlow);
+  });
+
+  it("reserves one bounded whole-query call-pair callback completion across file limits", () => {
+    const { graph, task, spine, entry, planner } = callPairCallbackCompletionFixture();
+
+    const selections = [4, 5, 6].map((maxFiles) => selectScope(graph, task, 16, maxFiles));
+
+    for (const selection of selections) {
+      const pairCandidates = selection.candidates
+        .filter((candidate) => candidate.id === entry.id || candidate.id === planner.id);
+      expect(pairCandidates.map((candidate) => candidate.id))
+        .toEqual(expect.arrayContaining([entry.id, planner.id]));
+      expect(pairCandidates.every((candidate) => candidate.reasons.includes("bm25-call-pair"))).toBe(true);
+      expect(selection.flows[0]?.steps).toEqual(spine);
+      expect(selection.flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+    }
+    expect(selections[1]!.flows).toEqual(selections[0]!.flows);
+    expect(selections[2]!.flows).toEqual(selections[0]!.flows);
+  });
+
+  it("does not reserve a selected same-file callback prefix without whole-query call-pair proof", () => {
+    const { graph, task, spine, entry, planner } = callPairCallbackCompletionFixture({ proveCallPair: false });
+
+    const selection = selectScope(graph, task, 16, 4);
+
+    expect(selection.candidates.map((candidate) => candidate.id))
+      .toEqual(expect.arrayContaining([entry.id, planner.id]));
+    expect(selection.candidates.filter((candidate) => candidate.id === entry.id || candidate.id === planner.id)
+      .every((candidate) => !candidate.reasons.includes("bm25-call-pair"))).toBe(true);
+    expect(selection.flows).not.toContainEqual({ steps: spine });
+    expect(selection.flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it.each([
+    { label: "query-irrelevant terminal", options: { terminalName: "flushCache" } },
+    { label: "weak containment", options: { containmentConfidence: 0.79 } },
+    { label: "mismatched callback container", options: { callbackContainerId: "function:other-owner" } },
+  ])("does not reserve a selected planner callback completion with $label", ({ options }) => {
+    const { graph, task, spine } = callPairCallbackCompletionFixture(options);
+
+    const { flows } = selectScope(graph, task, 16, 12);
+
+    // Ordinary traversal may still discover the shape later; the failed trust
+    // gate must prevent it from consuming the priority-reserve position.
+    expect(flows[0]?.steps).not.toEqual(spine);
+    expect(flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("does not let a pair-only BFS seed displace a query-region callback owner", () => {
+    const task = "request validation input header makes validated data available to handlers";
+    const requestPath = "src/request.ts";
+    const validationPath = "src/validation.ts";
+    const pairTarget = node("method:pair-target", "requestHeader", 1, {
+      kind: "method", filePath: requestPath,
+      signature: "(request: Request, header: string): string",
+    });
+    const owner = node("function:validation-owner", "validateInput", 1, {
+      filePath: validationPath, startLine: 1, endLine: 100,
+    });
+    const callback = node("function:validation-callback", "<callback:validateInput[0]>", 10, {
+      filePath: validationPath, startLine: 10, endLine: 30,
+      qualifiedName: "validateInput::<callback:validateInput[0]>", containerId: owner.id,
+    });
+    const terminal = node("method:validated-data", "addValidatedData", 40, {
+      kind: "method", filePath: requestPath, isExported: true,
+    });
+    const selectedFillers = Array.from({ length: 15 }, (_, index) => node(
+      `function:selected-${String(index).padStart(2, "0")}`,
+      `inputHandler${index}`,
+      index + 50,
+      { filePath: index % 2 === 0 ? validationPath : requestPath },
+    ));
+    const pairSource = node("function:pair-source", "validationRequestMiddleware", 1, {
+      filePath: "src/guard.ts", startLine: 1, endLine: 20, isExported: true,
+      signature: "(): MiddlewareHandler",
+      docstring: "Validation checks the request header and makes validated input available to handlers.",
+    });
+    const provenanceSeeds = Array.from({ length: 13 }, (_, index) => node(
+      `function:provenance-${String(index).padStart(2, "0")}`,
+      `opaqueRegion${index}`,
+      1,
+      { filePath: `src/region-${String(index).padStart(2, "0")}.ts`, startLine: 1, endLine: 10 },
+    ));
+    const sink = node("function:provenance-sink", "opaqueSink", 1, { filePath: "src/sink.ts" });
+    const contains: GraphEdge = {
+      source: owner.id, target: callback.id, kind: "contains", line: 10, column: 2,
+      confidence: 1, resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+    };
+    const validatedCall: GraphEdge = {
+      source: callback.id, target: terminal.id, kind: "calls", line: 20, column: 4,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const pairCall: GraphEdge = {
+      source: pairSource.id, target: pairTarget.id, kind: "calls", line: 5, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const provenanceCalls = provenanceSeeds.map((source): GraphEdge => ({
+      source: source.id, target: sink.id, kind: "calls", line: 5, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    }));
+    const fillerCalls = selectedFillers.map((target, index): GraphEdge => ({
+      source: owner.id, target: target.id, kind: "calls", line: 50 + index, column: 2,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    }));
+    const nodes = [
+      pairTarget, owner, terminal, ...selectedFillers, pairSource, ...provenanceSeeds, callback, sink,
+    ];
+    const byId = new Map(nodes.map((entry) => [entry.id, entry]));
+    const edges = [contains, validatedCall, pairCall, ...provenanceCalls, ...fillerCalls];
+    const neighbors = (id: string, direction: "incoming" | "outgoing", kinds?: GraphEdge["kind"][]) => (
+      edges.filter((edge) => (direction === "incoming" ? edge.target : edge.source) === id
+        && (!kinds || kinds.includes(edge.kind)))
+        .map((edge) => ({
+          edge,
+          node: byId.get(direction === "incoming" ? edge.source : edge.target)!,
+        }))
+    );
+    const wholeQuery = [pairTarget, owner, terminal, ...selectedFillers, pairSource, ...provenanceSeeds];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => wholeQuery),
+      getNode: (id) => byId.get(id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id, kinds) => neighbors(id, "incoming", kinds),
+      getOutgoing: (id, kinds) => neighbors(id, "outgoing", kinds),
+      getIndexedFiles: () => [...new Set(nodes.map((entry) => entry.filePath))].map((path) => ({
+        path, contentHash: path, parseStatus: "ok" as const, diagnosticCount: 0,
+        errorCoverage: 0, nodeCount: nodes.filter((entry) => entry.filePath === path).length,
+      })),
+      searchSource: () => [{
+        filePath: validationPath, startLine: 1, endLine: 30, contentHash: "validation",
+        rank: -0.3, matchedTerms: ["request", "validation", "input", "validated", "data"],
+        nodeIds: [owner.id],
+      }, ...provenanceSeeds.map((entry, index) => ({
+        filePath: entry.filePath, startLine: 1, endLine: 10, contentHash: entry.id,
+        rank: -0.2 + index / 1_000, matchedTerms: ["request", "validation", "input"],
+        nodeIds: [entry.id],
+      }))],
+    };
+
+    const selection = selectScope(graph, task, 18, 2);
+
+    expect(selection.flows[0]?.steps).toEqual([contains, validatedCall]);
+    expect(selection.candidates.find((candidate) => candidate.id === pairTarget.id)?.reasons)
+      .toContain("bm25-call-pair");
+    expect(selection.candidates.map((candidate) => candidate.id)).not.toContain(pairSource.id);
+    expect(selection.flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("uses one real containment edge to enter an anonymous callback flow", () => {
+    const outer = node("function:outer", "compose", 1);
+    const callback = node("function:callback", "<callback:ReturnStatement>", 2, {
+      qualifiedName: "compose::<callback:ReturnStatement>",
+    });
+    const inner = node("function:inner", "dispatch", 3, {
+      qualifiedName: "compose::<callback:ReturnStatement>::dispatch",
+    });
+    const nodes = [outer, callback, inner];
+    const contains: GraphEdge = { source: outer.id, target: callback.id, kind: "contains", confidence: 1 };
+    const calls: GraphEdge = { source: callback.id, target: inner.id, kind: "calls", confidence: 1 };
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase() === "compose" ? [outer]
+        : query.toLowerCase() === "dispatch" ? [inner] : [outer, inner]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === inner.id ? [{ node: callback, edge: calls }]
+        : id === callback.id ? [{ node: outer, edge: contains }] : [],
+      getOutgoing: (id) => id === outer.id ? [{ node: callback, edge: contains }]
+        : id === callback.id ? [{ node: inner, edge: calls }] : [],
+      getIndexedFiles: () => [{
+        path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+        modifiedAt: 1, nodeCount: 3, parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+      }],
+    };
+
+    const { flows } = selectScope(graph, "compose dispatch", 10);
+    expect(flows[0]?.steps).toEqual([contains, calls]);
+    expect(flows[0]?.steps.every((edge, index, steps) => index === 0 || steps[index - 1]!.target === edge.source))
+      .toBe(true);
+  });
+
+  it("replaces an anonymous callback provenance suffix with its named-owner flow", () => {
+    const validator = node("function:validator", "validator", 10, {
+      startLine: 10, endLine: 35,
+    });
+    const callback = node("function:validator-callback", "<callback:validator[0]>", 20, {
+      qualifiedName: "validator::<callback:validator[0]>", startLine: 20, endLine: 30,
+    });
+    const addValidatedData = node("method:add-validated-data", "addValidatedData", 40);
+    const contains: GraphEdge = {
+      source: validator.id, target: callback.id, kind: "contains", line: 20, column: 2,
+      confidence: 1, resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+    };
+    const calls: GraphEdge = {
+      source: callback.id, target: addValidatedData.id, kind: "calls", line: 25, column: 4,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [validator, callback, addValidatedData];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => [callback]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === callback.id ? [{ node: validator, edge: contains }]
+        : id === addValidatedData.id ? [{ node: callback, edge: calls }] : [],
+      getOutgoing: (id) => id === validator.id ? [{ node: callback, edge: contains }]
+        : id === callback.id ? [{ node: addValidatedData, edge: calls }] : [],
+      getIndexedFiles: () => [{
+        path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+        modifiedAt: 1, nodeCount: nodes.length, parseStatus: "ok", diagnosticCount: 0,
+        missingCount: 0, errorCoverage: 0,
+      }],
+      searchSource: () => [{
+        filePath: "src/sample.ts", startLine: 10, endLine: 30, contentHash: "hash",
+        rank: -0.2, matchedTerms: ["validator", "validated", "data"], nodeIds: [validator.id],
+      }],
+    };
+
+    const { flows } = selectScope(graph, "validator adds validated data", 10, 1);
+    expect(flows[0]?.steps).toEqual([contains, calls]);
+    expect(flows).not.toContainEqual({ steps: [calls] });
+    expect(flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("prefers a non-recursive named owner over a later callback suffix to the same target", () => {
+    const compose = node("function:compose", "compose", 15, { startLine: 15, endLine: 73 });
+    const composeCallback = node("function:compose-callback", "<callback:ReturnStatement>", 20, {
+      qualifiedName: "compose::<callback:ReturnStatement>", containerId: compose.id,
+      startLine: 20, endLine: 30,
+    });
+    const dispatch = node("function:dispatch", "dispatch", 32, { startLine: 32, endLine: 71 });
+    const recursiveCallback = node("function:dispatch-callback", "<callback:handler[1]>", 45, {
+      qualifiedName: "dispatch::<callback:handler[1]>", containerId: dispatch.id,
+      startLine: 45, endLine: 55,
+    });
+    const containsCompose: GraphEdge = {
+      source: compose.id, target: composeCallback.id, kind: "contains", line: 20, column: 2,
+      confidence: 1, resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+    };
+    const composeDispatch: GraphEdge = {
+      source: composeCallback.id, target: dispatch.id, kind: "calls", line: 23, column: 4,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const containsRecursive: GraphEdge = {
+      source: dispatch.id, target: recursiveCallback.id, kind: "contains", line: 45, column: 2,
+      confidence: 1, resolutionMethod: "lexical-containment", provenance: "typescript-compiler",
+    };
+    const recursiveDispatch: GraphEdge = {
+      source: recursiveCallback.id, target: dispatch.id, kind: "calls", line: 51, column: 4,
+      confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+    };
+    const nodes = [compose, composeCallback, dispatch, recursiveCallback];
+    const incoming = new Map<string, Array<{ node: GraphNode; edge: GraphEdge }>>([
+      [composeCallback.id, [{ node: compose, edge: containsCompose }]],
+      [recursiveCallback.id, [{ node: dispatch, edge: containsRecursive }]],
+      [dispatch.id, [
+        { node: composeCallback, edge: composeDispatch },
+        { node: recursiveCallback, edge: recursiveDispatch },
+      ]],
+    ]);
+    const outgoing = new Map<string, Array<{ node: GraphNode; edge: GraphEdge }>>([
+      [compose.id, [{ node: composeCallback, edge: containsCompose }]],
+      [composeCallback.id, [{ node: dispatch, edge: composeDispatch }]],
+      [dispatch.id, [{ node: recursiveCallback, edge: containsRecursive }]],
+      [recursiveCallback.id, [{ node: dispatch, edge: recursiveDispatch }]],
+    ]);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn(() => [compose, dispatch]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => incoming.get(id) ?? [],
+      getOutgoing: (id) => outgoing.get(id) ?? [],
+      getIndexedFiles: () => [{
+        path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+        modifiedAt: 1, nodeCount: nodes.length, parseStatus: "ok", diagnosticCount: 0,
+        missingCount: 0, errorCoverage: 0,
+      }],
+      searchSource: () => [{
+        filePath: "src/sample.ts", startLine: 15, endLine: 60, contentHash: "hash",
+        rank: -0.2, matchedTerms: ["compose", "dispatch", "middleware"],
+        nodeIds: [compose.id, dispatch.id],
+      }],
+    };
+
+    const { flows } = selectScope(graph, "compose middleware dispatch", 10, 1);
+    expect(flows[0]?.steps).toEqual([containsCompose, composeDispatch]);
+    expect(flows.flatMap((flow) => flow.steps)).not.toContainEqual(recursiveDispatch);
+    expect(flows[0]?.steps.every((edge, index, steps) => index === 0 || steps[index - 1]!.target === edge.source))
+      .toBe(true);
+    expect(flows.flatMap((flow) => flow.steps).length).toBeLessThanOrEqual(8);
+  });
+
+  it("ranks a cohesive caller-to-relevant-target fork ahead of a lexical leaf's downstream branch", () => {
+    const cache = node("function:cache", "cache", 1);
+    const digest = node("function:digest", "createQueryDigest", 2);
+    const key = node("function:key", "createCacheKey", 3);
+    const downstream = node("function:downstream", "cloneRawRequest", 4);
+    const nodes = [cache, digest, key, downstream];
+    const edge = (source: GraphNode, target: GraphNode): GraphEdge => ({
+      source: source.id, target: target.id, kind: "calls", confidence: 1,
+    });
+    const cacheDigest = edge(cache, digest);
+    const cacheKey = edge(cache, key);
+    const digestDownstream = edge(digest, downstream);
+    const outgoing = new Map<string, Array<{ node: GraphNode; edge: GraphEdge }>>([
+      [cache.id, [{ node: digest, edge: cacheDigest }, { node: key, edge: cacheKey }]],
+      [digest.id, [{ node: downstream, edge: digestDownstream }]],
+    ]);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => {
+        const lower = query.toLowerCase();
+        if (lower === "cache") return [cache, key];
+        if (lower === "digest") return [digest];
+        if (lower === "key") return [key];
+        return [digest, key, cache];
+      }),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [],
+      getOutgoing: (id) => outgoing.get(id) ?? [],
+      getIndexedFiles: () => [{
+        path: "src/sample.ts", contentHash: "hash", language: "typescript", size: 1,
+        modifiedAt: 1, nodeCount: 4, parseStatus: "ok", diagnosticCount: 0, missingCount: 0, errorCoverage: 0,
+      }],
+    };
+
+    const { flows } = selectScope(graph, "cache digest key", 10);
+    const firstEdges = flows.map((flow) => flow.steps[0]);
+    expect(firstEdges).toEqual(expect.arrayContaining([cacheDigest, cacheKey]));
   });
 
   it("routes test-file nodes into the test quota bucket", () => {
@@ -113,8 +1856,237 @@ describe("scored scope selection", () => {
       searchNodes: vi.fn(() => [testNode]),
       getNode: (id) => id === testNode.id ? testNode : null,
       getCallers: () => [], getCallees: () => [],
+      getIncoming: () => [], getOutgoing: () => [],
     };
     const { candidates } = selectScope(graph, "seed", 10);
     expect(candidates[0].category).toBe("test");
+  });
+
+  it("promotes an owning type and reconstructs a matched function's call flow", () => {
+    const plan = node("function:plan", "planSource", 10, {
+      filePath: "src/source.ts", docstring: "Plan bounded source expansion for selected graph node identifiers.",
+    });
+    const owner = node("class:ledger", "BudgetLedger", 1, { kind: "class", filePath: "src/budget.ts" });
+    const method = node("method:tokens", "estimatedTokens", 2, {
+      kind: "method", qualifiedName: "BudgetLedger.estimatedTokens", filePath: "src/budget.ts",
+    });
+    const caller = node("function:get", "runGraphGet", 4, { filePath: "src/get.ts" });
+    const callee = node("function:read", "readNodeSource", 20, { filePath: "src/read.ts" });
+    const nodes = [plan, owner, method, caller, callee];
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query.toLowerCase().includes("token") ? [method] : [plan]),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [],
+      getIncoming: (id) => id === method.id
+        ? [{ node: owner, edge: { source: owner.id, target: method.id, kind: "contains" } }]
+        : id === plan.id
+          ? [{ node: caller, edge: { source: caller.id, target: plan.id, kind: "calls" } }]
+          : [],
+      getOutgoing: (id) => id === plan.id
+        ? [{ node: callee, edge: { source: plan.id, target: callee.id, kind: "calls" } }]
+        : [],
+    };
+
+    const budget = selectScope(graph, "maximum output tokens", 5).candidates.map((entry) => entry.id);
+    expect(budget).toContain(owner.id);
+    const flow = selectScope(graph, "planSource expands selected identifiers into bounded source", 5)
+      .candidates.map((entry) => entry.id);
+    expect(flow).toEqual(expect.arrayContaining([plan.id, caller.id, callee.id]));
+  });
+
+  it("reserves an externally invoked declaration for a distinct strong intent facet", () => {
+    const run = (externalBoundary: boolean) => {
+      const aligned = node("function:aligned", "scopeRecord", 10, {
+        filePath: "src/service.ts", startLine: 10, endLine: 30,
+      });
+      const boundary = node("function:boundary", "serveGraphScope", 40, {
+        filePath: "src/service.ts", isExported: true,
+      });
+      const external = node("function:external", "commandRoute", 1, { filePath: "src/command.ts" });
+      const alignedBoundary: GraphEdge = {
+        source: aligned.id, target: boundary.id, kind: "calls", line: 20, column: 2, confidence: 1,
+      };
+      const externalBoundaryEdge: GraphEdge = {
+        source: external.id, target: boundary.id, kind: "calls", line: 2, column: 2, confidence: 1,
+      };
+      const nodes = [aligned, boundary, external];
+      const graph: GraphEngine = {
+        build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => [aligned]),
+        getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+        getCallers: () => [], getCallees: () => [],
+        getIncoming: (id) => id === boundary.id ? [
+          { node: aligned, edge: alignedBoundary },
+          ...(externalBoundary ? [{ node: external, edge: externalBoundaryEdge }] : []),
+        ] : [],
+        getOutgoing: (id) => id === aligned.id ? [{ node: boundary, edge: alignedBoundary }]
+          : id === external.id && externalBoundary ? [{ node: boundary, edge: externalBoundaryEdge }] : [],
+        getIndexedFiles: () => nodes.map((entry) => ({
+          path: entry.filePath, contentHash: entry.id, parseStatus: "ok" as const,
+          diagnosticCount: 0, errorCoverage: 0, nodeCount: 1,
+        })),
+        searchSource: () => [{
+          filePath: aligned.filePath, startLine: 10, endLine: 30, contentHash: "service",
+          rank: -0.2, matchedTerms: ["build", "graph", "answer", "scope", "request"],
+          nodeIds: [aligned.id],
+        }],
+      };
+      return { selection: selectScope(graph, "build graph answer scope request", 4, 2), aligned, boundary };
+    };
+
+    const positive = run(true);
+    expect(positive.selection.candidates[0]?.id).toBe(positive.boundary.id);
+    expect(positive.selection.files.find((file) => file.filePath === positive.boundary.filePath)?.nodeIds[0])
+      .toBe(positive.boundary.id);
+
+    const inverse = run(false);
+    expect(inverse.selection.candidates[0]?.id).toBe(inverse.aligned.id);
+  });
+
+  it("admits only a whole-query call pair whose callee adds independent low-signal concepts", () => {
+    const run = (addsConcepts: boolean) => {
+      const entry = node("function:entry", "openGraphItem", 1, {
+        filePath: "src/adapter.ts", isExported: true,
+        signature: "(client: AgentClient): void", docstring: "Node source operation.",
+      });
+      const target = node("function:target", addsConcepts ? "stageNodeSource" : "stageGraphAgent", 20, {
+        filePath: "src/adapter.ts",
+        signature: addsConcepts ? "(node: GraphNode): SourceRange" : "(client: AgentClient): void",
+      });
+      const distractors = Array.from({ length: 35 }, (_, index) => node(
+        `function:noise-${index}`, `opaque${index}`, index + 40, { filePath: `src/noise-${index}.ts` },
+      ));
+      const nodes = [entry, target, ...distractors];
+      const call: GraphEdge = {
+        source: entry.id, target: target.id, kind: "calls", line: 8, column: 2,
+        confidence: 1, resolutionMethod: "typescript-signature", provenance: "typescript-compiler",
+      };
+      const task = "agent graph node source";
+      const graph: GraphEngine = {
+        build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+        searchNodes: vi.fn((query) => query === task ? [...distractors, entry, target] : []),
+        getNode: (id) => nodes.find((candidate) => candidate.id === id) ?? null,
+        getCallers: () => [], getCallees: () => [],
+        getIncoming: (id) => id === target.id ? [{ node: entry, edge: call }] : [],
+        getOutgoing: (id) => id === entry.id ? [{ node: target, edge: call }] : [],
+        getIndexedFiles: () => [{
+          path: entry.filePath, contentHash: "adapter", parseStatus: "ok",
+          diagnosticCount: 0, errorCoverage: 0, nodeCount: 2,
+        }],
+        searchSource: () => [],
+      };
+      return { selection: selectScope(graph, task, 4, 1), entry, target };
+    };
+
+    const positive = run(true);
+    expect(positive.selection.candidates.slice(0, 2).map((candidate) => candidate.id))
+      .toEqual([positive.entry.id, positive.target.id]);
+    expect(positive.selection.candidates.slice(0, 2).every((candidate) => (
+      candidate.reasons.includes("bm25-call-pair")
+    ))).toBe(true);
+
+    const inverse = run(false);
+    expect(inverse.selection.candidates.map((candidate) => candidate.id))
+      .not.toEqual(expect.arrayContaining([inverse.entry.id, inverse.target.id]));
+  });
+
+  it("bounds whole-query call-pair adjacency before loading outgoing edges", () => {
+    const task = "agent graph node source";
+    const nodes = Array.from({ length: 80 }, (_, index) => node(
+      `function:pair-bound-${String(index).padStart(2, "0")}`,
+      `agentGraphNodeSource${index}`,
+      index + 1,
+      { filePath: `src/pair-${index}.ts`, isExported: true },
+    ));
+    const getOutgoing = vi.fn((_id: string, _kinds?: GraphEdge["kind"][]) => []);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(),
+      searchNodes: vi.fn((query) => query === task ? nodes : []),
+      getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing,
+    };
+
+    selectScope(graph, task, 4, 1);
+
+    const pairLookups = getOutgoing.mock.calls.filter(([, kinds]) => (
+      kinds?.length === 2 && kinds[0] === "calls" && kinds[1] === "instantiates"
+    ));
+    expect(pairLookups).toHaveLength(64);
+    expect(pairLookups.map(([id]) => id)).toEqual(nodes.slice(0, 64).map((entry) => entry.id));
+  });
+
+  it("deduplicates node searches by normalized query text", () => {
+    const seed = node("function:seed", "Seed", 1);
+    const searchNodes = vi.fn((_query: string) => [seed]);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes,
+      getNode: (id) => id === seed.id ? seed : null,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+    };
+
+    selectScope(graph, "Seed", 10);
+    const normalized = searchNodes.mock.calls.map(([query]) => query.trim().replace(/\s+/g, " ").toLowerCase());
+    expect(new Set(normalized).size).toBe(normalized.length);
+    expect(normalized.filter((query) => query === "seed")).toHaveLength(1);
+  });
+
+  it("loads repeated source-region node ids once per selection", () => {
+    const source = node("function:source", "processPipeline", 1, {
+      filePath: "src/pipeline.ts", startLine: 1, endLine: 20,
+    });
+    const getNode = vi.fn((id: string) => id === source.id ? source : null);
+    const graph: GraphEngine = {
+      build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => []), getNode,
+      getCallers: () => [], getCallees: () => [], getIncoming: () => [], getOutgoing: () => [],
+      getIndexedFiles: () => [{
+        path: source.filePath, contentHash: "source", parseStatus: "ok", diagnosticCount: 0,
+        errorCoverage: 0, nodeCount: 1,
+      }],
+      searchSource: () => [1, 2, 3].map((startLine) => ({
+        filePath: source.filePath, startLine, endLine: startLine + 5, contentHash: "source",
+        rank: -0.2, matchedTerms: ["process", "pipeline"], nodeIds: [source.id, source.id],
+      })),
+    };
+
+    selectScope(graph, "process pipeline", 10);
+    expect(getNode).toHaveBeenCalledTimes(1);
+    expect(getNode).toHaveBeenCalledWith(source.id);
+  });
+
+  it("keeps adjacency work fixed when an exact seed has hundreds of callers", () => {
+    const run = (fanIn: number): number => {
+      const seed = node("function:seed", "Seed", 1);
+      const callers = Array.from({ length: fanIn }, (_, index) => node(
+        `function:caller-${String(index).padStart(4, "0")}`,
+        `caller${String(index).padStart(4, "0")}`,
+        index + 2,
+      ));
+      const children = new Map(callers.map((caller) => [caller.id, Array.from({ length: 8 }, (_, index) => node(
+        `${caller.id}:child-${index}`,
+        `child${index}`,
+        index + 1,
+      ))]));
+      const incoming = vi.fn((id: string) => id === seed.id ? callers.map((caller) => ({
+        node: caller,
+        edge: { source: caller.id, target: seed.id, kind: "calls" as const, confidence: 1 },
+      })) : []);
+      const outgoing = vi.fn((id: string) => (children.get(id) ?? []).map((child) => ({
+        node: child,
+        edge: { source: id, target: child.id, kind: "calls" as const, confidence: 1 },
+      })));
+      const graph: GraphEngine = {
+        build: vi.fn(), sync: vi.fn(), close: vi.fn(), searchNodes: vi.fn(() => [seed]),
+        getNode: (id) => id === seed.id ? seed : callers.find((caller) => caller.id === id) ?? null,
+        getCallers: () => [], getCallees: () => [], getIncoming: incoming, getOutgoing: outgoing,
+      };
+
+      selectScope(graph, "Seed", 1);
+      return incoming.mock.calls.length + outgoing.mock.calls.length;
+    };
+
+    const boundedFanIn = run(40);
+    const extremeFanIn = run(500);
+    expect(extremeFanIn).toBe(boundedFanIn);
+    expect(extremeFanIn).toBeLessThanOrEqual(220);
   });
 });

--- a/src/graph/__tests__/store-fts.test.ts
+++ b/src/graph/__tests__/store-fts.test.ts
@@ -54,4 +54,126 @@ describe("GraphStore FTS maintenance", () => {
       db.close();
     }
   });
+
+  it("ranks a compound declaration above an incidental signature mention", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-store-ranking-"));
+    roots.push(root);
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    const base: Omit<GraphNode, "id" | "kind" | "name" | "qualifiedName" | "filePath"> = {
+      language: "typescript", startLine: 1, endLine: 2, startColumn: 0, endColumn: 1,
+      isExported: true, isAsync: false, isStatic: false, isAbstract: false, updatedAt: 1,
+    };
+    try {
+      store.insertNode({
+        ...base, id: "class:ledger", kind: "class", name: "BudgetLedger",
+        qualifiedName: "BudgetLedger", filePath: "src/budget.ts",
+      });
+      store.insertNode({
+        ...base, id: "function:report", kind: "function", name: "writeReport",
+        qualifiedName: "writeReport", filePath: "src/report.ts", signature: "(ledger: string): void",
+      });
+      expect(store.search("ledger", { limit: 2 }).map((node) => node.name)).toEqual(["BudgetLedger", "writeReport"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prefers production declarations and returns nothing for boilerplate-only queries", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-store-production-"));
+    roots.push(root);
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    const make = (id: string, filePath: string): GraphNode => ({
+      id, kind: "function", name: "resolveAccount", qualifiedName: "resolveAccount", filePath,
+      language: "typescript", startLine: 1, endLine: 2, startColumn: 0, endColumn: 1,
+      isExported: true, isAsync: false, isStatic: false, isAbstract: false, updatedAt: 1,
+    });
+    try {
+      store.insertNode(make("function:test", "test/resolve.test.ts"));
+      store.insertNode(make("function:prod", "src/resolve.ts"));
+      expect(store.search("resolveAccount", { limit: 2 }).map((node) => node.id)).toEqual([
+        "function:prod", "function:test",
+      ]);
+      expect(store.search("how does it work")).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("maps a source hit to bounded named structural declarations deterministically", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-store-source-bridge-"));
+    roots.push(root);
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    const filePath = "src/bridge.ts";
+    const make = (
+      id: string,
+      kind: GraphNode["kind"],
+      name: string,
+      startLine: number,
+      endLine: number,
+    ): GraphNode => ({
+      id, kind, name, qualifiedName: name, filePath, language: "typescript",
+      startLine, endLine, startColumn: 0, endColumn: 1, updatedAt: 1,
+    });
+    try {
+      store.insertNode(make("file:bridge", "file", "bridge.ts", 1, 120));
+      store.insertNode(make("class:owner", "class", "Owner", 1, 120));
+      store.insertNode(make("method:execute", "method", "execute", 10, 90));
+      store.insertNode(make("function:target", "function", "target", 20, 30));
+      store.insertNode(make("function:callback", "function", "<callback:argument-0>", 40, 45));
+      store.insertNode(make("variable:local", "variable", "localValue", 25, 25));
+      store.insertNode(make("interface:contract", "interface", "Contract", 60, 70));
+      store.insertNode(make("type:result", "type_alias", "Result", 70, 70));
+      const lines = Array.from({ length: 100 }, (_, index) => `// bridge line ${index + 1}`);
+      lines[69] = "const deterministicStructuralNeedle = true;";
+      store.replaceSourceChunks(filePath, lines.join("\n"), "bridge-hash");
+
+      const readIds = (): string[] | undefined => store.searchSourceChunks("deterministicStructuralNeedle")
+        .find((hit) => hit.filePath === filePath && hit.startLine === 1)?.nodeIds;
+      const firstRead = readIds();
+      expect(firstRead).toEqual([
+        "class:owner", "method:execute", "function:target", "interface:contract", "type:result",
+      ]);
+      expect(readIds()).toEqual(firstRead);
+      expect(firstRead).not.toContain("file:bridge");
+      expect(firstRead).not.toContain("function:callback");
+      expect(firstRead).not.toContain("variable:local");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("prefers a substantive declaration over tiny wrappers sharing its source chunk", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-store-source-coverage-"));
+    roots.push(root);
+    const db = openGraphDatabase(join(root, "graph.db"));
+    const store = new GraphStore(db);
+    const filePath = "src/resolver.ts";
+    const make = (id: string, name: string, startLine: number, endLine: number): GraphNode => ({
+      id, kind: "function", name, qualifiedName: name, filePath, language: "typescript",
+      startLine, endLine, startColumn: 0, endColumn: 1, updatedAt: 1,
+    });
+    try {
+      store.insertNode(make("function:substantive", "resolveModuleName", 20, 97));
+      store.insertNode(make("function:wrapper-a", "resolveLibrary", 62, 63));
+      store.insertNode(make("function:wrapper-b", "resolvePackage", 66, 67));
+      store.insertNode(make("function:wrapper-c", "resolveSource", 70, 71));
+      const lines = Array.from({ length: 100 }, (_, index) => `// resolver line ${index + 1}`);
+      lines[69] = "const substantiveCoverageNeedle = true;";
+      store.replaceSourceChunks(filePath, lines.join("\n"), "resolver-hash");
+
+      const hit = store.searchSourceChunks("substantiveCoverageNeedle")
+        .find((entry) => entry.filePath === filePath && entry.startLine === 61);
+      expect(hit?.nodeIds).toEqual([
+        "function:substantive", "function:wrapper-a", "function:wrapper-b", "function:wrapper-c",
+      ]);
+      expect(store.searchSourceChunks("substantiveCoverageNeedle")
+        .find((entry) => entry.filePath === filePath && entry.startLine === 61)?.nodeIds)
+        .toEqual(hit?.nodeIds);
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/src/graph/agent-protocol.ts
+++ b/src/graph/agent-protocol.ts
@@ -5,18 +5,22 @@
 // The agent-facing commands (`graph scope` / `query` / `get`, `impact`) stream
 // newline-delimited JSON. Every stream is framed by a `meta` record first and a
 // `summary` record last, with `fact` / `edge` / `source` data records between.
-// Source is opt-in; the default `minimal` detail returns structure + relationship
-// counts only. A hard token budget is enforced WHILE emitting, not after.
+// Scope is source-bearing by default so one response can replace a Grep/Read
+// loop. A hard token budget is enforced while planning and emitting.
 
 import type { CompactFact, DetailLevel, SourceRange } from "./scope.js";
 
-export const SCHEMA_VERSION = 1;
+export const AGENT_PROTOCOL_VERSION = 3;
+/** @deprecated Prefer AGENT_PROTOCOL_VERSION; this is not the DB schema. */
+export const SCHEMA_VERSION = AGENT_PROTOCOL_VERSION;
 const CHARS_PER_TOKEN = 4;
 
 /** Tunable retrieval controls shared by every agent command. */
 export interface AgentOptions {
   detail: DetailLevel;
   maxNodes: number;
+  maxFiles: number;
+  maxFlowSteps: number;
   maxOutputTokens: number;
   maxSourceLines: number;
   depth: number;
@@ -27,6 +31,8 @@ export interface AgentOptions {
 export const DEFAULT_OPTIONS: AgentOptions = {
   detail: "minimal",
   maxNodes: 10,
+  maxFiles: 4,
+  maxFlowSteps: 8,
   maxOutputTokens: 1500,
   maxSourceLines: 120,
   depth: 2,
@@ -43,11 +49,34 @@ export function resolveOptions(raw: Partial<Record<keyof AgentOptions, unknown>>
   return {
     detail,
     maxNodes: num(raw.maxNodes, DEFAULT_OPTIONS.maxNodes),
+    maxFiles: num(raw.maxFiles, DEFAULT_OPTIONS.maxFiles),
+    maxFlowSteps: num(raw.maxFlowSteps, DEFAULT_OPTIONS.maxFlowSteps),
     maxOutputTokens: num(raw.maxOutputTokens, DEFAULT_OPTIONS.maxOutputTokens),
     maxSourceLines: num(raw.maxSourceLines, DEFAULT_OPTIONS.maxSourceLines),
     depth: num(raw.depth, DEFAULT_OPTIONS.depth),
     fingerprint: raw.fingerprint === true || raw.fingerprint === "true",
   };
+}
+
+/** Adaptive one-call defaults used only by broad Scope retrieval. */
+export function resolveScopeOptions(
+  raw: Partial<Record<keyof AgentOptions, unknown>> = {},
+  indexedFiles: number,
+): AgentOptions {
+  const adaptive = indexedFiles < 150
+    ? { maxOutputTokens: 3500, maxFiles: 4 }
+    : indexedFiles < 500
+      ? { maxOutputTokens: 4500, maxFiles: 5 }
+      : { maxOutputTokens: 6000, maxFiles: 6 };
+  return resolveOptions({
+    ...raw,
+    detail: raw.detail ?? "source",
+    maxNodes: raw.maxNodes ?? 24,
+    maxFiles: raw.maxFiles ?? adaptive.maxFiles,
+    maxFlowSteps: raw.maxFlowSteps ?? 8,
+    maxOutputTokens: raw.maxOutputTokens ?? adaptive.maxOutputTokens,
+    maxSourceLines: raw.maxSourceLines ?? 200,
+  });
 }
 
 /** Deterministic, model-agnostic token estimate. Conservative, labeled "estimated". */
@@ -59,11 +88,15 @@ export function estimateTokens(value: unknown): number {
 
 export interface MetaRecord {
   type: "meta";
+  protocolVersion: number;
+  /** Compatibility mirror for older preview clients; this is not the DB schema. */
   schemaVersion: number;
   command: string;
   task?: string;
   detail: DetailLevel;
   maxNodes: number;
+  maxFiles: number;
+  maxFlowSteps: number;
   maxOutputTokens: number;
 }
 
@@ -72,7 +105,42 @@ export interface EdgeRecord {
   kind: string;
   source: string;
   target: string;
-  provenance: "static";
+  line?: number;
+  column?: number;
+  confidence?: number;
+  resolutionMethod?: string;
+  provenance?: string;
+}
+
+export interface HealthRecord {
+  type: "health";
+  indexedFiles: number;
+  okFiles: number;
+  partialFiles: number;
+  failedFiles: number;
+  staleFiles: string[];
+}
+
+export interface FlowRecord {
+  type: "flow";
+  /**
+   * Compact endpoint metadata makes a flow independently interpretable even
+   * when lower-priority fact records do not fit the response budget.
+   */
+  nodes: Array<{
+    id: string;
+    name: string;
+    filePath: string;
+  }>;
+  steps: Array<{
+    source: string;
+    target: string;
+    kind: string;
+    line?: number;
+    confidence: number;
+    resolutionMethod?: string;
+    provenance?: string;
+  }>;
 }
 
 export interface SourceRecord {
@@ -90,9 +158,24 @@ export interface SummaryRecord {
   maxOutputTokens: number;
   truncated: boolean;
   suggestedNextCommands: string[];
+  status: "ok" | "partial" | "degraded" | "no-match";
+  evidenceStrength: "strong" | "moderate" | "weak" | "none";
+  coveredTerms: string[];
+  returnedFiles: string[];
+  sourceBackedNodes: string[];
+  textFallbackFiles: string[];
+  warnings: string[];
+  omittedCounts: Partial<Record<
+    "sourceBackedNodes" | "coveredTerms" | "returnedFiles" | "textFallbackFiles" | "suggestedNextCommands" | "warnings",
+    number
+  >>;
 }
 
-export type FactRecord = CompactFact & { type: "fact" };
+export type FactRecord = Omit<CompactFact, "detail" | "sourceIncluded" | "bodyHash" | "qualifiedName"> & {
+  type: "fact";
+  qualifiedName?: string;
+  bodyHash?: string;
+};
 
 /** Tokens reserved for the mandatory trailing `summary` record. */
 export const FRAMING_RESERVE = 140;

--- a/src/graph/cli-agent.ts
+++ b/src/graph/cli-agent.ts
@@ -1,16 +1,23 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
-import { createGraphEngine } from "./engine-impl.js";
-import type { GraphEngine } from "./engine.js";
-import { openSqlite, type SqliteDatabase } from "./db/sqlite.js";
-import type { GraphNode } from "./types.js";
+import { globSync } from "glob";
+import { createGraphEngine, graphManifest } from "./engine-impl.js";
+import type { GraphEngine, GraphNeighbor, IndexedFileInfo } from "./engine.js";
+import { openGraphDatabase } from "./db/database.js";
+import type { SqliteDatabase } from "./db/sqlite.js";
+import { isSupportedSourceFile, SUPPORTED_SOURCE_GLOB } from "./extraction/index.js";
+import type { GraphEdge, GraphNode } from "./types.js";
 import {
-  compactFact, groupByFile, readNodeSource, selectScope,
-  type CompactFact, type DetailLevel, type SourceRange,
+  compactFact, groupByFile, planFileSource, readNodeSource, selectScope, sourceHash,
+  type CompactFact, type DetailLevel, type RankedScopeFile, type ScopedCandidate, type SourceRange,
 } from "./scope.js";
 import { FingerprintStore } from "./fingerprint-store.js";
 import { serializeFingerprint } from "./fingerprint.js";
-import { BudgetLedger, estimateTokens, resolveOptions, SCHEMA_VERSION, type AgentOptions } from "./agent-protocol.js";
+import {
+  BudgetLedger, estimateTokens, resolveOptions, resolveScopeOptions, SCHEMA_VERSION, type AgentOptions,
+} from "./agent-protocol.js";
+import { identifierComponents, isLowValueGraphPath, planGraphQuery } from "./retrieval/query.js";
+import { GraphRebuildRequiredError } from "./errors.js";
 
 type QueryRelation = "who-calls" | "what-calls" | "where-defined";
 
@@ -70,7 +77,7 @@ export function runImpact(
       if (emittedNodes.length >= opts.maxNodes) { truncated = true; break; }
       const fact = factFor(session, root.id, opts.detail, opts.fingerprint);
       if (!fact) continue;
-      const record: Rec = { type: "defines", ...fact };
+      const record: Rec = { type: "defines", ...agentFactFields(fact, opts) };
       if (!ledger.tryAdd(record)) { truncated = true; break; }
       factRecords.push(record);
       emittedNodes.push(root);
@@ -88,13 +95,13 @@ export function runImpact(
       if (emittedNodes.length >= opts.maxNodes) { truncated = true; break; }
       const fact = factFor(session, entry.node.id, opts.detail, opts.fingerprint);
       if (!fact) continue;
-      const record: Rec = { type: "caller", depth: entry.depth, root: entry.root, ...fact };
+      const record: Rec = { type: "caller", depth: entry.depth, root: entry.root, ...agentFactFields(fact, opts) };
       if (!ledger.tryAdd(record)) { truncated = true; break; }
       factRecords.push(record);
       emittedNodes.push(entry.node);
     }
 
-    const sourceRecords = planSource(ledger, emittedNodes, rootDir, opts, factRecords);
+    const sourceRecords = planSource(ledger, emittedNodes, rootDir, opts);
 
     const affectedIds = [...new Set([...roots.map((node) => node.id), ...impacted.keys()])];
     const groundingRecords: Rec[] = [];
@@ -145,9 +152,7 @@ export function runGraphQuery(
     const pairs: Array<{ targetId: string; node: GraphNode }> = [];
     const seen = new Set<string>();
     for (const queried of nodes.sort(byId)) {
-      const related = relation === "where-defined"
-        ? [queried]
-        : (relation === "who-calls" ? session.graph.getCallers(queried.id) : session.graph.getCallees(queried.id)).sort(byId);
+      const related = relation === "where-defined" ? [queried] : relatedCallNodes(session.graph, queried, relation);
       for (const node of related) {
         const key = `${queried.id} ${node.id}`;
         if (seen.has(key)) continue;
@@ -168,12 +173,12 @@ export function runGraphQuery(
       if (entries.length >= opts.maxNodes) { truncated = true; break; }
       const fact = factFor(session, pair.node.id, opts.detail, opts.fingerprint);
       if (!fact) continue;
-      const record: Rec = { type: "result", relation, target: pair.targetId, ...fact };
+      const record: Rec = { type: "result", relation, target: pair.targetId, ...agentFactFields(fact, opts) };
       if (!ledger.tryAdd(record)) { truncated = true; break; }
       entries.push({ record, node: pair.node });
     }
 
-    const sourceRecords = planSource(ledger, entries.map((e) => e.node), rootDir, opts, entries.map((e) => e.record));
+    const sourceRecords = planSource(ledger, entries.map((e) => e.node), rootDir, opts);
 
     emitAll(write, meta, [...entries.map((e) => e.record), ...sourceRecords]);
     write(JSON.stringify(summaryRecord(ctx, {
@@ -190,7 +195,7 @@ export function runGraphQuery(
   }
 }
 
-/** Broad graph retrieval for an agent task. Compact JSONL manifest by default. */
+/** Broad graph retrieval. One source-bearing response is the normal success path. */
 export function runGraphScope(
   task: string,
   rootDir = process.cwd(),
@@ -198,50 +203,485 @@ export function runGraphScope(
   rawOptions: RawOptions = {},
 ): void {
   const write = deps.write ?? console.log;
-  const opts = resolveOptions(rawOptions);
   const session = openSession(rootDir, deps, write);
   if (!session) return;
   try {
-    const { candidates, matchedCount } = selectScope(session.graph, task, opts.maxNodes);
-    const firstNode = candidates.length > 0 ? session.graph.getNode(candidates[0]!.id) : null;
-    const ctx = beginResponse("graph scope", opts, task, buildScopeSuggestions(firstNode ? [firstNode] : [], opts.detail));
+    const indexedFiles = session.graph.getIndexedFiles?.() ?? [];
+    const opts = resolveScopeOptions(rawOptions, indexedFiles.length);
+    const staleFiles = indexedFiles.filter((file) => {
+      const liveHash = sourceHash(file.path, rootDir);
+      return liveHash !== file.contentHash;
+    }).map((file) => file.path);
+    const unindexedFiles = liveUnindexedFiles(indexedFiles, rootDir);
+    const stale = new Set(staleFiles);
+    const unindexed = new Set(unindexedFiles);
+    const selection = selectScope(session.graph, task, opts.maxNodes, opts.maxFiles);
+    // Indexed node/chunk hits describe the previous atomic snapshot. Once a
+    // file's content hash changes, discard those file candidates completely;
+    // only a fresh live-text match may admit the file back as text-only.
+    selection.files = selection.files.filter((file) => !stale.has(file.filePath));
+    for (const fallback of liveStaleFallbacks(
+      indexedFiles, [...new Set([...staleFiles, ...unindexedFiles])], task, rootDir,
+    )) {
+      const existing = selection.files.find((file) => file.filePath === fallback.filePath);
+      if (existing) {
+        existing.score = Math.max(existing.score, fallback.score);
+        existing.reasons = [...new Set([...existing.reasons, ...fallback.reasons])].sort();
+        existing.textHits = dedupeTextHits([...fallback.textHits, ...existing.textHits]);
+        existing.textOnly = true;
+      } else selection.files.push(fallback);
+      for (const term of fallback.textHits.flatMap((hit) => hit.matchedTerms ?? [])) {
+        if (!selection.coveredTerms.includes(term)) selection.coveredTerms.push(term);
+      }
+    }
+    selection.files.sort((left, right) => right.score - left.score || left.filePath.localeCompare(right.filePath));
+    selection.files.splice(opts.maxFiles);
+    const ctx = beginResponse("graph scope", opts, task, []);
     const ledger = ctx.ledger;
     const meta = ctx.meta;
+    const health = {
+      type: "health",
+      indexedFiles: indexedFiles.length,
+      okFiles: indexedFiles.filter((file) => file.parseStatus === "ok").length,
+      partialFiles: indexedFiles.filter((file) => file.parseStatus === "partial").length,
+      failedFiles: indexedFiles.filter((file) => file.parseStatus === "failed").length,
+      staleFiles: [...new Set([...staleFiles, ...unindexedFiles])],
+    } satisfies Rec;
+    const healthRecords: Rec[] = ledger.tryAdd(health) ? [health] : [];
+    let truncated = healthRecords.length === 0;
 
-    const facts: Array<{ record: Rec; node: GraphNode }> = [];
-    const returnedIds = new Set<string>();
-    let truncated = candidates.length < matchedCount;
-    for (const candidate of candidates) {
-      const fact = factFor(session, candidate.id, opts.detail, opts.fingerprint);
-      if (!fact) continue;
+    const nodeById = new Map<string, GraphNode>();
+    for (const candidate of selection.candidates) {
       const node = session.graph.getNode(candidate.id);
-      if (!node) continue;
-      const record: Rec = { type: "fact", ...fact, score: candidate.score, selectionReasons: candidate.reasons };
-      if (!ledger.tryAdd(record)) { truncated = true; break; }
-      facts.push({ record, node });
-      returnedIds.add(candidate.id);
+      if (node) nodeById.set(node.id, node);
     }
-
-    const edgeRecords: Rec[] = [];
-    if (opts.detail !== "minimal") {
-      for (const { node } of facts) {
-        for (const callee of session.graph.getCallees(node.id)) {
-          if (!returnedIds.has(callee.id)) continue;
-          const record: Rec = { type: "edge", kind: "calls", source: node.id, target: callee.id, provenance: "static" };
-          if (ledger.tryAdd(record)) edgeRecords.push(record); else truncated = true;
+    const allFlowNodeIds = new Set(selection.flows.flatMap((flow) => flow.steps)
+      .flatMap((edge) => [edge.source, edge.target]));
+    for (const id of allFlowNodeIds) {
+      if (nodeById.has(id)) continue;
+      const node = session.graph.getNode(id);
+      if (node) nodeById.set(id, node);
+    }
+    for (const file of selection.files) {
+      for (const id of file.nodeIds) {
+        if (nodeById.has(id)) continue;
+        const node = session.graph.getNode(id);
+        if (node) nodeById.set(id, node);
+      }
+    }
+    // A changed file invalidates the locations and bindings of every structural
+    // claim touching it. Keep those rows in the old atomic snapshot for other
+    // queries, but Scope may only expose the live file as text-only evidence.
+    const trustworthyFlows = capFlowSteps(selection.flows.filter((flow) => flow.steps.every((edge) => {
+      const source = nodeById.get(edge.source);
+      const target = nodeById.get(edge.target);
+      return source && target && !stale.has(source.filePath) && !stale.has(target.filePath);
+    })), opts.maxFlowSteps);
+    const exactNodeOrder = new Map(selection.candidates
+      .filter((candidate) => candidate.reasons.some((reason) => reason.startsWith("exact:")))
+      .map((candidate, index) => [candidate.id, index]));
+    const sourceRegionCandidateIds = new Set(selection.candidates
+      .filter((candidate) => candidate.reasons.some((reason) => reason === "source-region"
+        || reason.startsWith("source-region:")))
+      .map((candidate) => candidate.id));
+    const authoritativeSourceRegionIds = new Set(selection.candidates
+      .filter((candidate) => candidate.reasons.includes("source-region"))
+      .map((candidate) => candidate.id));
+    // Scope supplies file.nodeIds in region-relevance order. Preserve that
+    // order for every declaration-aligned source hit so direct source evidence
+    // precedes an inferred flow body. These regions affect source order only;
+    // they do not all become mandatory omission checks below.
+    const sourceRegionNodeOrder = new Map<string, number>();
+    for (const file of selection.files) {
+      for (const id of file.nodeIds) {
+        if (sourceRegionCandidateIds.has(id) && !sourceRegionNodeOrder.has(id)) {
+          sourceRegionNodeOrder.set(id, sourceRegionNodeOrder.size);
         }
       }
     }
+    const flowNodeOrder = new Map([...new Set(trustworthyFlows.flatMap((flow) => flow.steps)
+      .flatMap((edge) => [edge.source, edge.target]))].map((id, index) => [id, index]));
+    const highPriorityFlowNodeIds = [...new Set((trustworthyFlows[0]?.steps ?? [])
+      .flatMap((edge) => [edge.source, edge.target]))];
+    const namedHighPriorityFlowNodeIds = highPriorityFlowNodeIds
+      .filter((id) => isNamedSourceNode(nodeById.get(id)));
+    const semanticQuerySourceId = bestSemanticQuerySourceCandidate(
+      task, selection.candidates, selection.files, nodeById,
+    );
+    const authoritativeSourceNodeOrder = new Map([...sourceRegionNodeOrder]
+      .filter(([id]) => authoritativeSourceRegionIds.has(id)));
+    const primaryAuthoritativeNodeIds = cappedPrimaryNodeIds(
+      [authoritativeSourceNodeOrder.keys()], nodeById, RESERVED_PRIMARY_DECLARATIONS_PER_FILE,
+    );
+    // PascalCase words inside a rich NL question can look exact while being
+    // only incidental context. Globally pin one exact winner only when the
+    // request contains at most one other repository concept; all exact matches
+    // remain reserved within their ordinary file order below.
+    const rawQueryConcepts = new Set(planGraphQuery(task).terms.map((term) => term.raw.toLowerCase()));
+    const globalExactIds = rawQueryConcepts.size <= 2 ? [...exactNodeOrder.keys()].slice(0, 1) : [];
+    const flowAnswerCandidateIds = new Set(trustworthyFlows.flatMap((flow) => flow.steps)
+      .flatMap((edge) => [edge.source, edge.target])
+      .filter((id) => isNamedSourceNode(nodeById.get(id))));
+    // The displayed path's terminal target is the result the flow explains.
+    // Reserve at most that one named declaration globally; anonymous callback
+    // bridges remain visible without consuming a complete body.
+    const firstFlowTarget = [...(trustworthyFlows[0]?.steps ?? [])].reverse()
+      .map((edge) => edge.target)
+      .find((id) => isHealthySourceNode(id, selection.files, nodeById));
+    const namedFirstFlowTargetIds = firstFlowTarget ? [firstFlowTarget] : [];
+    const reservedPrimaryNodeIds = new Set([
+      ...exactNodeOrder.keys(), ...namedFirstFlowTargetIds,
+      ...(semanticQuerySourceId ? [semanticQuerySourceId] : []),
+      ...primaryAuthoritativeNodeIds,
+    ]);
+    const globallyReservedSourceOrder = new Map<string, number>();
+    for (const id of globalExactIds) {
+      if (!globallyReservedSourceOrder.has(id)) {
+        globallyReservedSourceOrder.set(id, globallyReservedSourceOrder.size);
+      }
+    }
+    for (const id of namedFirstFlowTargetIds) {
+      if (!globallyReservedSourceOrder.has(id)) {
+        globallyReservedSourceOrder.set(id, globallyReservedSourceOrder.size);
+      }
+    }
+    if (semanticQuerySourceId && !globallyReservedSourceOrder.has(semanticQuerySourceId)) {
+      globallyReservedSourceOrder.set(semanticQuerySourceId, globallyReservedSourceOrder.size);
+    }
 
-    const sourceRecords = planSource(ledger, facts.map((f) => f.node), rootDir, opts, facts.map((f) => f.record));
+    // The source planner uses the same authority order. Additional trusted
+    // flow and source-region nodes remain eligible as bounded, non-mandatory
+    // answers after the reserved declarations.
+    const primaryNodeOrder = new Map<string, number>();
+    for (const id of exactNodeOrder.keys()) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
+    for (const id of namedFirstFlowTargetIds) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
+    if (semanticQuerySourceId && !primaryNodeOrder.has(semanticQuerySourceId)) {
+      primaryNodeOrder.set(semanticQuerySourceId, primaryNodeOrder.size);
+    }
+    for (const id of primaryAuthoritativeNodeIds) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
+    // Displayed flows retain their directed order: endpoints on the first flow
+    // lead the remaining named semantic nodes.
+    for (const id of namedHighPriorityFlowNodeIds) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
+    for (const id of flowNodeOrder.keys()) {
+      if (flowAnswerCandidateIds.has(id) && !primaryNodeOrder.has(id)) {
+        primaryNodeOrder.set(id, primaryNodeOrder.size);
+      }
+    }
+    for (const id of authoritativeSourceNodeOrder.keys()) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
+    for (const id of sourceRegionNodeOrder.keys()) {
+      if (!primaryNodeOrder.has(id)) primaryNodeOrder.set(id, primaryNodeOrder.size);
+    }
 
-    emitAll(write, meta, [...facts.map((f) => f.record), ...edgeRecords, ...sourceRecords]);
+    const plannedSources: Rec[] = [];
+    const highPrioritySourceFiles = new Set<string>();
+    // Source coverage is mandatory for the strongest cohesive graph file and
+    // the bounded global reservations (dominant exact lookup, one terminal
+    // flow target, one corroborated NL candidate). Other bridge/helper bodies
+    // may still be omitted while their trustworthy relationship remains in the
+    // displayed flow record.
+    const highPrioritySourceExpectations = new Map<string, SourceRange[]>();
+    if (opts.detail === "source") {
+      const sourceFiles = [...selection.files].sort((left, right) => {
+        // File cohesion is the primary retrieval decision. Exact-symbol and
+        // flow-spine order break ties, but must not let a weak project-name hit
+        // consume the source budget ahead of a substantially stronger region.
+        const scoreDelta = right.score - left.score;
+        if (Math.abs(scoreDelta) > 1e-9) return scoreDelta;
+        const leftExact = firstNodeOrderInFile(exactNodeOrder, nodeById, left.filePath);
+        const rightExact = firstNodeOrderInFile(exactNodeOrder, nodeById, right.filePath);
+        if (leftExact !== rightExact) return leftExact - rightExact;
+        const leftFlow = firstNodeOrderInFile(flowNodeOrder, nodeById, left.filePath);
+        const rightFlow = firstNodeOrderInFile(flowNodeOrder, nodeById, right.filePath);
+        return leftFlow - rightFlow || left.filePath.localeCompare(right.filePath);
+      });
+      // The strongest healthy graph-backed file is the unnamed-query fallback
+      // primary. A text-only top hit cannot satisfy graph trust by itself and
+      // must instead produce a degraded response when no named graph answer is
+      // available.
+      const primaryGraphFile = sourceFiles.find((file) => (
+        !file.textOnly && file.parseStatus === "ok" && file.nodeIds.length > 0
+      ));
+      if (primaryGraphFile) highPrioritySourceFiles.add(primaryGraphFile.filePath);
+      for (const id of globallyReservedSourceOrder.keys()) {
+        const node = nodeById.get(id);
+        if (node) highPrioritySourceFiles.add(node.filePath);
+      }
+      for (const file of sourceFiles) {
+        // Admission quotas decide which declarations are serialized first;
+        // they must not remove declarations before source planning. In
+        // particular, a later authoritative region or displayed-flow endpoint
+        // may be the only complete source answer in the file.
+        const orderedIds = [...new Set([
+          ...[...primaryNodeOrder.keys()]
+            .filter((id) => nodeById.get(id)?.filePath === file.filePath),
+          ...file.nodeIds,
+        ])];
+        const fileNodes = file.textOnly || stale.has(file.filePath) || unindexed.has(file.filePath) ? []
+          : dedupeById(orderedIds.map((id) => nodeById.get(id))
+            .filter((node): node is GraphNode => Boolean(node)));
+        const callsites = trustworthyFlows.flatMap((flow) => flow.steps)
+          .filter((edge) => nodeById.get(edge.source)?.filePath === file.filePath)
+          .map((edge) => edge.line).filter((line): line is number => line !== undefined);
+        // `maxSourceLines` is a per-symbol override. A cohesive file can carry
+        // more than one complete symbol; the response ledger remains the hard
+        // aggregate output bound.
+        const fileLineBudget = Math.min(400, opts.maxSourceLines * Math.max(1, Math.min(fileNodes.length, 2)));
+        const ranges = planFileSource(
+          file.filePath, fileNodes, file.textHits, rootDir, task, fileLineBudget, callsites,
+        );
+        if (ranges.length === 0) continue;
+        if (highPrioritySourceFiles.has(file.filePath)) {
+          const expectations: SourceRange[] = [];
+          if (file.filePath === primaryGraphFile?.filePath) {
+            mergeAdmissionRange(expectations, ranges[0]!);
+          }
+          for (const id of globallyReservedSourceOrder.keys()) {
+            const node = nodeById.get(id);
+            if (!node || node.filePath !== file.filePath) continue;
+            const rangeIndex = bestDeclarationRangeIndex(ranges, node);
+            const expected = rangeIndex >= 0
+              ? completeDeclarationRange(ranges[rangeIndex]!, node)
+                ?? declarationAnchor(ranges[rangeIndex]!, node, SOURCE_DECLARATION_ANCHOR_LINES)
+              : null;
+            if (expected) mergeAdmissionRange(expectations, expected);
+          }
+          if (expectations.length > 0) highPrioritySourceExpectations.set(file.filePath, expectations);
+        }
+        const textOnly = file.textOnly || file.parseStatus !== "ok" || stale.has(file.filePath)
+          || selection.evidenceStrength === "weak";
+        plannedSources.push({
+          type: "source", filePath: file.filePath, ranges,
+          evidence: textOnly ? "text-only" : "graph",
+          ...(stale.has(file.filePath) ? { stale: true } : {}),
+          ...(unindexed.has(file.filePath) ? { unindexed: true } : {}),
+        });
+      }
+    }
+
+    // Source is the high-value payload. Give it 75% first, then let unused
+    // flow/fact capacity spill back into deferred source records.
+    const plannedFlowRecords = trustworthyFlows.flatMap((flow) => {
+      const record = scopeFlowRecord(flow, nodeById, opts.maxFlowSteps);
+      return record ? [record] : [];
+    });
+    const summaryTokenReserve = estimateTokens(summarySkeleton([])) + RESERVE_PAD;
+    const sourceRecords: Rec[] = [];
+    const deferredSources: Array<{
+      record: Rec; atomic: boolean; phase: SourceAdmissionPhase;
+    }> = [];
+    let sourceTokens = 0;
+    // Percentages apply to the payload after mandatory meta/health/summary
+    // framing. Applying 75% to the whole response silently consumed the flow
+    // allotment because the summary reserve is deliberately conservative.
+    const remainingPayload = Math.max(
+      0,
+      ctx.effectiveMax - ledger.estimatedTokens - estimateTokens(summarySkeleton([])) - RESERVE_PAD,
+    );
+    const sourceShare = Math.floor(remainingPayload * 0.75);
+    const boundedFlowShare = Math.floor(remainingPayload * 0.15);
+    let flowTokenReserve = 0;
+    for (const [index, planned] of plannedFlowRecords.entries()) {
+      const tokens = estimateTokens(planned.record);
+      if (index > 0 && flowTokenReserve + tokens > boundedFlowShare) break;
+      flowTokenReserve += tokens;
+    }
+    // Schedule bounded answer declarations before cross-file fairness. Once an
+    // answer reaches the source-share boundary, hold every lower-priority
+    // header/body until all other compact answers have had a chance to fit.
+    let deferLowerPrioritySources = false;
+    const sourceAdmissions = coalesceSourceAdmissions(prioritizeSourceAdmissions(
+      plannedSources, primaryNodeOrder, exactNodeOrder, flowAnswerCandidateIds,
+      reservedPrimaryNodeIds, globallyReservedSourceOrder, nodeById,
+    ), nodeById);
+    for (const planned of sourceAdmissions) {
+      const { record, phase } = planned;
+      // A large atomic answer may fail the source-share fit while a later
+      // compact answer still fits. Continue trying answer admissions, but hold
+      // every secondary-file fairness/header/body admission until primary
+      // answers have had their reserved hard-ledger spill opportunity.
+      if (deferLowerPrioritySources && phase !== "answer") {
+        deferredSources.push({ record, atomic: planned.atomic, phase });
+        continue;
+      }
+      const admission = admitSourceWithinShare(
+        record, sourceShare - sourceTokens, ledger, planned.atomic,
+      );
+      sourceRecords.push(...admission.admitted);
+      sourceTokens += admission.tokens;
+      truncated ||= admission.trimmed;
+      let unresolved = admission.deferred;
+      // A complete answer that only crossed the 75% source-share boundary gets
+      // its hard-ledger opportunity immediately. Letting later small answers
+      // spend that capacity first starved the earlier, stronger declaration.
+      if (phase === "answer" && planned.atomic && unresolved.length > 0) {
+        const stillDeferred: Rec[] = [];
+        for (const deferred of unresolved) {
+          const spill = admitSourceWithinShare(
+            deferred,
+            Math.max(
+              0,
+              ctx.effectiveMax - ledger.estimatedTokens - summaryTokenReserve - flowTokenReserve,
+            ),
+            ledger,
+            true,
+          );
+          sourceRecords.push(...spill.admitted);
+          sourceTokens += spill.tokens;
+          stillDeferred.push(...spill.deferred);
+          truncated ||= spill.trimmed;
+        }
+        unresolved = stillDeferred;
+      }
+      deferredSources.push(...unresolved.map((deferred) => ({
+        record: deferred, atomic: planned.atomic, phase,
+      })));
+      // Once a complete answer declaration reaches the source-share boundary,
+      // lower-priority signatures/bodies must not consume the hard ledger before
+      // that declaration gets its whole-record spill opportunity.
+      if (phase === "answer" && unresolved.length > 0) {
+        deferLowerPrioritySources = true;
+      }
+    }
+
+    // Complete answer declarations are more valuable than secondary-file
+    // fairness. If one crossed only the 75% source-share boundary, give it one
+    // whole-record hard-ledger spill opportunity now while reserving the first
+    // directed flow and summary. Ordinary source (including atomic whole-file
+    // fairness records) stays deferred until after flows.
+    const ordinaryDeferredSources: Array<{
+      record: Rec; atomic: boolean;
+    }> = [];
+    for (const deferred of deferredSources) {
+      if (!deferred.atomic || deferred.phase !== "answer") {
+        ordinaryDeferredSources.push(deferred);
+        continue;
+      }
+      const spill = admitSourceWithinShare(
+        deferred.record,
+        Math.max(
+          0,
+          ctx.effectiveMax - ledger.estimatedTokens - summaryTokenReserve - flowTokenReserve,
+        ),
+        ledger,
+        true,
+      );
+      sourceRecords.push(...spill.admitted);
+      if (spill.trimmed || spill.deferred.length > 0) truncated = true;
+    }
+
+    const flowRecords: Rec[] = [];
+    let returnedEdges = 0;
+    for (const { record, stepCount } of plannedFlowRecords) {
+      if (ledger.tryAdd(record)) {
+        flowRecords.push(record);
+        returnedEdges += stepCount;
+      } else truncated = true;
+    }
+
+    for (const deferred of ordinaryDeferredSources) {
+      const spill = admitSourceWithinShare(
+        deferred.record, ctx.effectiveMax, ledger, deferred.atomic,
+      );
+      sourceRecords.push(...spill.admitted);
+      if (spill.trimmed || spill.deferred.length > 0) truncated = true;
+    }
+    const sourcedIds = new Set(sourceRecords.flatMap((record) =>
+      (record.ranges as SourceRange[]).flatMap((range) => range.nodeIds)));
+    const flowIds = new Set(flowRecords.flatMap((record) =>
+      (record.steps as Array<{ source: string; target: string }>).flatMap((step) => [step.source, step.target])));
+    const facts: Array<{ record: Rec; node: GraphNode }> = [];
+    for (const candidate of selection.candidates) {
+      if (opts.detail === "source" && !sourcedIds.has(candidate.id) && !flowIds.has(candidate.id)) continue;
+      const fact = factFor(session, candidate.id, opts.detail, opts.fingerprint);
+      const node = nodeById.get(candidate.id);
+      if (!fact || !node || stale.has(node.filePath)) continue;
+      const record = scopeFactRecord(fact, candidate.score, candidate.reasons, opts);
+      if (ledger.tryAdd(record)) facts.push({ record, node }); else truncated = true;
+    }
+
+    const finalSourcedIds = new Set(sourceRecords.flatMap((record) =>
+      (record.ranges as SourceRange[]).flatMap((range) => range.nodeIds)));
+    const returnedFiles = [...new Set(sourceRecords.map((record) => record.filePath as string))];
+    const textFallbackFiles = [...new Set(sourceRecords.filter((record) => record.evidence === "text-only")
+      .map((record) => record.filePath as string))];
+    const omittedHighPrioritySourceFiles = [...highPrioritySourceFiles].filter((filePath) => {
+      const expected = highPrioritySourceExpectations.get(filePath);
+      if (!expected || expected.length === 0) return true;
+      const emitted = sourceRecords.filter((record) => record.filePath === filePath)
+        .flatMap((record) => record.ranges as SourceRange[]);
+      return expected.some((wanted) => !sourceRangesCover(emitted, wanted));
+    });
+    const highPriorityFlowKeys = new Set((trustworthyFlows[0]?.steps ?? []).map(scopeEdgeKey));
+    const returnedFlowKeys = new Set(flowRecords.flatMap((record) => (
+      record.steps as GraphEdge[]
+    )).map(scopeEdgeKey));
+    const omittedHighPriorityFlowSteps = [...highPriorityFlowKeys]
+      .filter((key) => !returnedFlowKeys.has(key)).length;
+    const highPriorityEvidenceOmitted = omittedHighPrioritySourceFiles.length > 0
+      || omittedHighPriorityFlowSteps > 0;
+    const returnedGraphSourceFiles = new Set(sourceRecords
+      .filter((record) => record.evidence === "graph")
+      .map((record) => record.filePath as string));
+    const omittedHighPrioritySourceSet = new Set(omittedHighPrioritySourceFiles);
+    const hasTrustworthyGraphPrimary = [...highPrioritySourceFiles].some((filePath) => (
+      returnedGraphSourceFiles.has(filePath) && !omittedHighPrioritySourceSet.has(filePath)
+    ));
+    // Text-only context is useful corroborating metadata, but it is also a
+    // lossy fallback channel. Report that truncation without authorizing the
+    // caller to abandon a complete graph-backed answer.
+    if (textFallbackFiles.length > 0) truncated = true;
+    const materiallyReliesOnTextOnly = textFallbackFiles.length > 0
+      && !hasTrustworthyGraphPrimary;
+    const warnings = [
+      ...(health.failedFiles > 0 ? [`${health.failedFiles} indexed file(s) have failed structural parsing.`] : []),
+      ...(health.partialFiles > 0 ? [`${health.partialFiles} indexed file(s) have partial structural parsing.`] : []),
+      ...(staleFiles.length > 0
+        ? [`${staleFiles.length} indexed file(s) differ from live source; matching live files use text-only evidence.`]
+        : []),
+      ...(unindexedFiles.length > 0
+        ? [`${unindexedFiles.length} live source file(s) are not indexed; matching files use text-only evidence.`]
+        : []),
+      ...(highPriorityEvidenceOmitted
+        ? [`High-priority evidence omitted: ${omittedHighPrioritySourceFiles.length} source file(s), ${omittedHighPriorityFlowSteps} flow step(s).`]
+        : []),
+    ];
+    const status = returnedFiles.length === 0 && facts.length === 0 && flowRecords.length === 0
+      ? "no-match"
+      : highPriorityEvidenceOmitted ? "partial"
+        : materiallyReliesOnTextOnly ? "degraded"
+          : "ok";
+    const suggestions = status === "partial" && facts.length > 0
+      ? [`mex graph get ${facts[0]!.node.id} --detail source`] : [];
+
+    emitAll(write, meta, [
+      ...healthRecords,
+      ...sourceRecords,
+      ...flowRecords,
+      ...facts.map((fact) => fact.record),
+    ]);
     write(JSON.stringify(summaryRecord(ctx, {
-      matchedNodes: matchedCount,
+      matchedNodes: selection.matchedCount,
       returnedNodes: facts.length,
-      returnedEdges: edgeRecords.length,
+      returnedEdges,
       truncated,
-      suggestedNextCommands: buildScopeSuggestions(facts.map((f) => f.node), opts.detail),
+      suggestedNextCommands: suggestions,
+      status,
+      evidenceStrength: selection.evidenceStrength,
+      coveredTerms: selection.coveredTerms,
+      returnedFiles,
+      sourceBackedNodes: [...finalSourcedIds],
+      textFallbackFiles,
+      warnings,
     })));
   } catch (error) {
     unavailable(write, error);
@@ -262,17 +702,8 @@ export function runGraphGet(
   const session = openSession(rootDir, deps, write);
   if (!session) return;
   try {
-    const requested = opts.maxOutputTokens;
-    const reserve = estimateTokens(summarySkeleton([])) + RESERVE_PAD;
-    const buildMeta = (max: number): Rec => ({
-      type: "meta", schemaVersion: SCHEMA_VERSION, command: "graph get",
-      detail: "source", maxNodes: ids.length, maxOutputTokens: max,
-    });
-    const effectiveMax = Math.max(requested, estimateTokens(buildMeta(SIZE_PROBE)) + reserve);
-    const meta = buildMeta(effectiveMax);
-    const ledger = new BudgetLedger(effectiveMax, reserve);
-    ledger.frame(meta);
-    const ctx: ResponseCtx = { ledger, meta, effectiveMax, requested };
+    const ctx = beginResponse("graph get", { ...opts, maxNodes: ids.length, maxFlowSteps: 0 }, undefined, []);
+    const { ledger, meta } = ctx;
 
     const nodes: GraphNode[] = [];
     const errorRecords: Rec[] = [];
@@ -312,88 +743,192 @@ export function runGraphGet(
 const SIZE_PROBE = 9_999_999;
 /** Slack over the anticipated summary size (covers node-id/name length variance). */
 const RESERVE_PAD = 16;
+const SUMMARY_LIST_KEYS = [
+  "sourceBackedNodes", "coveredTerms", "returnedFiles", "textFallbackFiles",
+  "suggestedNextCommands", "warnings",
+] as const;
+type SummaryListKey = typeof SUMMARY_LIST_KEYS[number];
+const SUMMARY_LIST_LIMITS: Record<SummaryListKey, number> = {
+  sourceBackedNodes: 24,
+  coveredTerms: 12,
+  returnedFiles: 6,
+  textFallbackFiles: 6,
+  suggestedNextCommands: 3,
+  warnings: 3,
+};
 
 interface ResponseCtx {
   ledger: BudgetLedger;
   meta: Rec;
   effectiveMax: number;
-  requested: number;
+}
+
+class OutputBudgetTooSmallError extends Error {
+  readonly code = "INVALID_OUTPUT_BUDGET";
+
+  constructor(requested: number, minimum: number) {
+    super(`--max-output-tokens ${requested} cannot fit protocol framing; use at least ${minimum}.`);
+    this.name = "OutputBudgetTooSmallError";
+  }
 }
 
 /**
  * Set up a response so the token ceiling is genuinely hard. The summary reserve is
  * sized from the ACTUAL summary shape (its suggested commands can carry long node
- * ids/names), and the ceiling is clamped up to a framing floor (one meta + one
- * summary) so mandatory framing can never silently exceed the reported budget.
+ * ids/names). A requested ceiling below mandatory protocol framing is rejected:
+ * silently increasing it would make budget-compliance results dishonest.
  * `anticipatedSuggestions` sizes the reserve; the final summary recomputes them
  * from what was actually returned (same fixed-width ids, so the reserve holds).
- * A clamp is surfaced as truncation.
  */
 function beginResponse(command: string, opts: AgentOptions, task: string | undefined, anticipatedSuggestions: string[]): ResponseCtx {
   const requested = opts.maxOutputTokens;
   const reserve = estimateTokens(summarySkeleton(anticipatedSuggestions)) + RESERVE_PAD;
   const framingFloor = estimateTokens(metaRecord(command, { ...opts, maxOutputTokens: SIZE_PROBE }, task)) + reserve;
-  const effectiveMax = Math.max(requested, framingFloor);
+  if (requested < framingFloor) throw new OutputBudgetTooSmallError(requested, framingFloor);
+  const effectiveMax = requested;
   const meta = metaRecord(command, { ...opts, maxOutputTokens: effectiveMax }, task);
   const ledger = new BudgetLedger(effectiveMax, reserve);
   ledger.frame(meta);
-  return { ledger, meta, effectiveMax, requested };
+  return { ledger, meta, effectiveMax };
 }
 
 function summarySkeleton(suggestions: string[]): Rec {
   return {
     type: "summary", matchedNodes: SIZE_PROBE, returnedNodes: SIZE_PROBE, returnedEdges: SIZE_PROBE,
     maxOutputTokens: SIZE_PROBE, truncated: true, suggestedNextCommands: suggestions, estimatedOutputTokens: SIZE_PROBE,
+    status: "degraded", evidenceStrength: "moderate",
+    coveredTerms: Array(12).fill("identifier-component"),
+    returnedFiles: Array(6).fill("path/to/a/representative/source-file.ts"),
+    sourceBackedNodes: Array(24).fill("method:0123456789abcdef0123456789abcdef"),
+    textFallbackFiles: Array(6).fill("path/to/a/representative/source-file.ts"),
+    warnings: Array(3).fill("Representative graph health warning."),
+    omittedCounts: Object.fromEntries(SUMMARY_LIST_KEYS.map((key) => [key, SIZE_PROBE])),
   };
 }
 
 function metaRecord(command: string, opts: AgentOptions, task?: string): Rec {
   return {
-    type: "meta", schemaVersion: SCHEMA_VERSION, command,
+    type: "meta", protocolVersion: SCHEMA_VERSION, schemaVersion: SCHEMA_VERSION, command,
     ...(task !== undefined ? { task } : {}),
-    detail: opts.detail, maxNodes: opts.maxNodes, maxOutputTokens: opts.maxOutputTokens,
+    detail: opts.detail, maxNodes: opts.maxNodes, maxFiles: opts.maxFiles,
+    maxFlowSteps: opts.maxFlowSteps, maxOutputTokens: opts.maxOutputTokens,
   };
 }
 
 function summaryRecord(
   ctx: ResponseCtx,
-  fields: { matchedNodes: number; returnedNodes: number; returnedEdges: number; truncated: boolean; suggestedNextCommands: string[] },
+  fields: {
+    matchedNodes: number;
+    returnedNodes: number;
+    returnedEdges: number;
+    truncated: boolean;
+    suggestedNextCommands: string[];
+    status?: "ok" | "partial" | "degraded" | "no-match";
+    evidenceStrength?: "strong" | "moderate" | "weak" | "none";
+    coveredTerms?: string[];
+    returnedFiles?: string[];
+    sourceBackedNodes?: string[];
+    textFallbackFiles?: string[];
+    warnings?: string[];
+  },
 ): Rec {
+  const capped = capSummaryLists({
+    sourceBackedNodes: fields.sourceBackedNodes ?? [],
+    coveredTerms: fields.coveredTerms ?? [],
+    returnedFiles: fields.returnedFiles ?? [],
+    textFallbackFiles: fields.textFallbackFiles ?? [],
+    suggestedNextCommands: fields.suggestedNextCommands,
+    warnings: fields.warnings ?? [],
+  });
+  const omitted = Object.keys(capped.omittedCounts).length > 0;
+  const defaultStatus = fields.status ?? (fields.returnedNodes > 0 ? "ok" : "no-match");
   const base: Rec = {
     type: "summary",
     matchedNodes: fields.matchedNodes,
     returnedNodes: fields.returnedNodes,
     returnedEdges: fields.returnedEdges,
     maxOutputTokens: ctx.effectiveMax,
-    truncated: fields.truncated || ctx.ledger.droppedAny || ctx.ledger.overBudget || ctx.effectiveMax > ctx.requested,
-    suggestedNextCommands: fields.suggestedNextCommands,
+    truncated: fields.truncated || omitted || ctx.ledger.droppedAny || ctx.ledger.overBudget,
+    suggestedNextCommands: capped.values.suggestedNextCommands,
+    // Summary-list clipping is metadata truncation, not missing retrieval
+    // evidence. The caller owns status based on graph health and whether any
+    // high-priority source or flow evidence was actually omitted.
+    status: defaultStatus,
+    evidenceStrength: fields.evidenceStrength ?? (fields.returnedNodes > 0 ? "strong" : "none"),
+    coveredTerms: capped.values.coveredTerms,
+    returnedFiles: capped.values.returnedFiles,
+    sourceBackedNodes: capped.values.sourceBackedNodes,
+    textFallbackFiles: capped.values.textFallbackFiles,
+    warnings: capped.values.warnings,
+    omittedCounts: capped.omittedCounts,
   };
-  return { ...base, estimatedOutputTokens: ctx.ledger.estimatedTokens + estimateTokens({ ...base, estimatedOutputTokens: SIZE_PROBE }) };
+  const working = Object.fromEntries(Object.entries(base).map(([key, value]) =>
+    [key, Array.isArray(value) ? [...value] : value])) as Rec;
+  working.omittedCounts = { ...(base.omittedCounts as Record<string, number>) };
+  let summary = finalizedSummary(ctx.ledger.estimatedTokens, working);
+  let pruned = false;
+  while (ctx.ledger.estimatedTokens + estimateTokens(summary) > ctx.effectiveMax) {
+    const candidates = SUMMARY_LIST_KEYS
+      .map((key) => ({ key, values: working[key] as unknown[] }))
+      .filter((entry) => entry.values.length > 0)
+      .sort((left, right) => {
+        const leftSize = estimateTokens(left.values.at(-1));
+        const rightSize = estimateTokens(right.values.at(-1));
+        return rightSize - leftSize || SUMMARY_LIST_KEYS.indexOf(left.key) - SUMMARY_LIST_KEYS.indexOf(right.key);
+      });
+    const candidate = candidates[0];
+    if (!candidate) break;
+    candidate.values.pop();
+    const omittedCounts = working.omittedCounts as Record<string, number>;
+    omittedCounts[candidate.key] = (omittedCounts[candidate.key] ?? 0) + 1;
+    pruned = true;
+    working.truncated = true;
+    summary = finalizedSummary(ctx.ledger.estimatedTokens, working);
+  }
+  if (pruned) summary.truncated = true;
+  // The framing floor guarantees the minimal summary fits. Account the actual
+  // record so tests and consumers can compare the declared total to the stream.
+  ctx.ledger.frame(summary);
+  return summary;
+}
+
+function capSummaryLists(values: Record<SummaryListKey, string[]>): {
+  values: Record<SummaryListKey, string[]>;
+  omittedCounts: Partial<Record<SummaryListKey, number>>;
+} {
+  const capped = {} as Record<SummaryListKey, string[]>;
+  const omittedCounts: Partial<Record<SummaryListKey, number>> = {};
+  for (const key of SUMMARY_LIST_KEYS) {
+    const unique = [...new Set(values[key])];
+    const limit = SUMMARY_LIST_LIMITS[key];
+    capped[key] = unique.slice(0, limit);
+    if (unique.length > limit) omittedCounts[key] = unique.length - limit;
+  }
+  return { values: capped, omittedCounts };
+}
+
+function finalizedSummary(usedTokens: number, base: Rec): Rec {
+  let estimatedOutputTokens = usedTokens + estimateTokens({ ...base, estimatedOutputTokens: SIZE_PROBE });
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const record = { ...base, estimatedOutputTokens };
+    const exact = usedTokens + estimateTokens(record);
+    if (exact === estimatedOutputTokens) return record;
+    estimatedOutputTokens = exact;
+  }
+  return { ...base, estimatedOutputTokens };
 }
 
 /**
  * Plan grouped-per-file source records for `nodes` (deduped by id) under the
- * ledger, only when detail is "source". Sets `sourceIncluded` on the already-built
- * `facts` records to reflect whether each node's source actually fit the budget.
- * Returns the source records to emit.
+ * ledger, only when detail is "source". Source ranges carry their node ids, so
+ * facts do not repeat a mutable `sourceIncluded` flag.
  */
-function planSource(
-  ledger: BudgetLedger,
-  nodes: GraphNode[],
-  rootDir: string,
-  opts: AgentOptions,
-  facts: Rec[] = [],
-): Rec[] {
-  if (opts.detail !== "source") {
-    for (const fact of facts) fact.sourceIncluded = false;
-    return [];
-  }
+function planSource(ledger: BudgetLedger, nodes: GraphNode[], rootDir: string, opts: AgentOptions): Rec[] {
+  if (opts.detail !== "source") return [];
   const sourceRecords: Rec[] = [];
-  const sourcedIds = new Set<string>();
-  const emit = (record: Rec, ids: string[]): void => {
+  const emit = (record: Rec): void => {
     if (!ledger.tryAdd(record)) return;
     sourceRecords.push(record);
-    for (const id of ids) sourcedIds.add(id);
   };
   for (const [filePath, fileNodes] of groupByFile(dedupeById(nodes))) {
     const ranges = fileNodes
@@ -403,10 +938,9 @@ function planSource(
     const grouped: Rec = { type: "source", filePath, ranges };
     // Prefer one grouped record per file (dedups shared context); if it doesn't
     // fit, degrade to per-range records so partial source still lands.
-    if (ledger.fits(grouped)) emit(grouped, ranges.flatMap((range) => range.nodeIds));
-    else for (const range of ranges) emit({ type: "source", filePath, ranges: [range] }, range.nodeIds);
+    if (ledger.fits(grouped)) emit(grouped);
+    else for (const range of ranges) emit({ type: "source", filePath, ranges: [range] });
   }
-  for (const fact of facts) fact.sourceIncluded = typeof fact.id === "string" && sourcedIds.has(fact.id);
   return sourceRecords;
 }
 
@@ -415,12 +949,34 @@ function emitAll(write: (line: string) => void, meta: Rec, records: Rec[]): void
   for (const record of records) write(JSON.stringify(record));
 }
 
-function buildScopeSuggestions(nodes: GraphNode[], detail: DetailLevel): string[] {
-  if (nodes.length === 0) return [];
-  const suggestions: string[] = [];
-  if (detail !== "source") suggestions.push(`mex graph get ${nodes[0]!.id} --detail source`);
-  suggestions.push(`mex graph query who-calls ${nodes[0]!.name}`);
-  return suggestions;
+/**
+ * Scope is the high-frequency discovery command, so its default manifest avoids
+ * repeating response-level state on every fact. Source records already carry
+ * node ids; `detail` lives in meta; hashes/reasons remain opt-in diagnostics.
+ */
+function agentFactFields(fact: CompactFact, opts: AgentOptions): Rec {
+  const { detail: _detail, sourceIncluded: _sourceIncluded, bodyHash, qualifiedName, signature, ...core } = fact;
+  const compactSignature = signature?.replace(/\s+/g, " ").trim();
+  const signatureLimit = opts.detail === "standard" ? 320 : 180;
+  return {
+    ...core,
+    ...(qualifiedName !== fact.name ? { qualifiedName } : {}),
+    ...(compactSignature ? {
+      signature: compactSignature.length <= signatureLimit
+        ? compactSignature
+        : `${compactSignature.slice(0, signatureLimit - 1)}…`,
+    } : {}),
+    ...(opts.fingerprint && bodyHash ? { bodyHash } : {}),
+  };
+}
+
+function scopeFactRecord(fact: CompactFact, score: number, reasons: string[], opts: AgentOptions): Rec {
+  return {
+    type: "fact",
+    ...agentFactFields(fact, opts),
+    score,
+    ...(opts.detail === "standard" ? { selectionReasons: reasons } : {}),
+  };
 }
 
 function factFor(session: AgentGraphSession, id: string, detail: DetailLevel, includeFingerprint: boolean): CompactFact | null {
@@ -441,6 +997,800 @@ function dedupeById(nodes: GraphNode[]): GraphNode[] {
   return out;
 }
 
+function cappedPrimaryNodeIds(
+  groups: Iterable<string>[],
+  nodes: Map<string, GraphNode>,
+  perFileLimit: number,
+): Set<string> {
+  const selected = new Set<string>();
+  const counts = new Map<string, number>();
+  for (const group of groups) {
+    for (const id of group) {
+      if (selected.has(id)) continue;
+      const node = nodes.get(id);
+      if (!node) continue;
+      const count = counts.get(node.filePath) ?? 0;
+      if (count >= perFileLimit) continue;
+      selected.add(id);
+      counts.set(node.filePath, count + 1);
+    }
+  }
+  return selected;
+}
+
+const SOURCE_GRAPH_SEMANTIC_REASONS = new Set([
+  "graph:calls", "graph:instantiates", "graph:references",
+]);
+
+/**
+ * Reserve one globally corroborated declaration for natural-language queries.
+ * `term:*` reasons are produced only when Scope matched an indexed identifier
+ * component. Requiring both a trusted callsite and its semantic edge prevents
+ * lexical-only or merely enclosing helpers from becoming source answers.
+ * Query inflections count once by their original raw concept.
+ */
+export function bestSemanticQuerySourceCandidate(
+  task: string,
+  candidates: ScopedCandidate[],
+  files: RankedScopeFile[],
+  nodes: Map<string, GraphNode>,
+): string | undefined {
+  const plan = planGraphQuery(task);
+  const termConcept = new Map<string, {
+    key: string; weight: number; literal: boolean; stem: boolean;
+  }>();
+  for (const term of plan.terms) {
+    const key = term.raw.toLowerCase();
+    const current = termConcept.get(term.term);
+    if (!current || term.weight > current.weight) {
+      termConcept.set(term.term, {
+        key, weight: term.weight, literal: !term.stem, stem: term.stem,
+      });
+    }
+  }
+  const fileOrder = new Map(files.map((file, index) => [file.filePath, index]));
+  const nodeOrder = new Map(files.flatMap((file) => file.nodeIds
+    .map((id, index) => [id, index] as const)));
+  const scored = candidates.flatMap((candidate, candidateIndex) => {
+    const node = nodes.get(candidate.id);
+    const selectedFile = node ? files[fileOrder.get(node.filePath) ?? -1] : undefined;
+    if (!isNamedSourceNode(node) || !selectedFile || selectedFile.textOnly
+      || selectedFile.parseStatus !== "ok" || node.endLine - node.startLine + 1 > 160
+      || (!plan.asksForTests && isLowValueGraphPath(node.filePath))) return [];
+    if (!candidate.reasons.includes("source-region:callsite")
+      || !candidate.reasons.some((reason) => SOURCE_GRAPH_SEMANTIC_REASONS.has(reason))) return [];
+    const identifierParts = new Set([node.name, node.qualifiedName, node.signature ?? ""]
+      .flatMap((value) => (value.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? [])
+        .flatMap(identifierComponents)));
+    const leafIdentifierParts = new Set(identifierComponents(node.name));
+    const identifierMatches = (term: string, stem: boolean): boolean => (
+      identifierParts.has(term)
+      || (stem && [...identifierParts].some((part) => part.startsWith(term)))
+    );
+    // At least one Scope term channel must independently land on the
+    // declaration. Once that corroboration exists, score every query concept
+    // visible in the declaration identity/signature. A channel records only
+    // its first matching variant, so restricting the count to `term:*`
+    // reasons can hide equally direct concepts (for example `planFileSource`
+    // records `term:plan`, while `source` is still explicit in its name).
+    const corroboratedConcepts = new Set<string>();
+    for (const reason of candidate.reasons) {
+      if (!reason.startsWith("term:")) continue;
+      const reasonTerm = reason.slice("term:".length);
+      const match = termConcept.get(reasonTerm);
+      if (match && identifierMatches(reasonTerm, match.stem)) corroboratedConcepts.add(match.key);
+    }
+    if (corroboratedConcepts.size === 0) return [];
+    const concepts = new Map<string, { weight: number; literal: boolean }>();
+    const leafConcepts = new Set<string>();
+    for (const term of plan.terms) {
+      if (!identifierMatches(term.term, term.stem)) continue;
+      const key = term.raw.toLowerCase();
+      if (leafIdentifierParts.has(term.term)
+        || (term.stem && [...leafIdentifierParts].some((part) => part.startsWith(term.term)))) {
+        leafConcepts.add(key);
+      }
+      const current = concepts.get(key);
+      const literal = !term.stem;
+      if (!current || term.weight > current.weight || (term.weight === current.weight && literal)) {
+        concepts.set(key, { weight: term.weight, literal });
+      }
+    }
+    if (concepts.size < 2) return [];
+    const semanticKind = candidate.reasons.includes("graph:calls") ? 3
+      : candidate.reasons.includes("graph:instantiates") ? 2 : 1;
+    return [{
+      id: candidate.id,
+      conceptCount: concepts.size,
+      corroboratedConceptCount: corroboratedConcepts.size,
+      leafConceptCount: leafConcepts.size,
+      literalConceptCount: [...concepts.values()].filter((concept) => concept.literal).length,
+      conceptWeight: [...concepts.values()].reduce((sum, concept) => sum + concept.weight, 0),
+      semanticKind,
+      bm25: candidate.reasons.includes("bm25-node"),
+      fileOrder: fileOrder.get(node.filePath)!,
+      nodeOrder: nodeOrder.get(candidate.id) ?? Number.MAX_SAFE_INTEGER,
+      score: candidate.score,
+      candidateIndex,
+    }];
+  });
+  scored.sort((left, right) => right.leafConceptCount - left.leafConceptCount
+    || right.corroboratedConceptCount - left.corroboratedConceptCount
+    || right.conceptCount - left.conceptCount
+    || right.literalConceptCount - left.literalConceptCount
+    || right.conceptWeight - left.conceptWeight
+    || right.semanticKind - left.semanticKind
+    || Number(right.bm25) - Number(left.bm25)
+    || right.score - left.score
+    || left.fileOrder - right.fileOrder
+    || left.nodeOrder - right.nodeOrder
+    || left.candidateIndex - right.candidateIndex
+    || left.id.localeCompare(right.id));
+  return scored[0]?.id;
+}
+
+function isNamedSourceNode(node: GraphNode | undefined): node is GraphNode {
+  return Boolean(node && node.name.length > 0 && !node.name.startsWith("<"));
+}
+
+function isHealthySourceNode(
+  id: string,
+  files: RankedScopeFile[],
+  nodes: Map<string, GraphNode>,
+): boolean {
+  const node = nodes.get(id);
+  if (!isNamedSourceNode(node)) return false;
+  const file = files.find((entry) => entry.filePath === node.filePath);
+  return Boolean(file && !file.textOnly && file.parseStatus === "ok");
+}
+
+function scopeFlowRecord(
+  flow: { steps: GraphEdge[] },
+  nodesById: Map<string, GraphNode>,
+  maxSteps: number,
+): { record: Rec; stepCount: number } | null {
+  const steps = flow.steps.slice(0, maxSteps).map((edge) => ({
+    source: edge.source, target: edge.target, kind: edge.kind,
+    ...(edge.line !== undefined ? { line: edge.line } : {}),
+    ...(edge.column !== undefined ? { column: edge.column } : {}),
+    confidence: edge.confidence ?? 1,
+    ...(edge.resolutionMethod ? { resolutionMethod: edge.resolutionMethod } : {}),
+    ...(edge.provenance ? { provenance: edge.provenance } : {}),
+  }));
+  if (steps.length === 0) return null;
+  const endpointIds = [...new Set(steps.flatMap((step) => [step.source, step.target]))];
+  const nodes = endpointIds.flatMap((id) => {
+    const node = nodesById.get(id);
+    return node ? [{ id: node.id, name: node.name, filePath: node.filePath }] : [];
+  });
+  return { record: { type: "flow", nodes, steps }, stepCount: steps.length };
+}
+
+const RESERVED_PRIMARY_DECLARATIONS_PER_FILE = 3;
+const PRIMARY_DECLARATION_ANCHORS_PER_FILE = 3;
+const PRIMARY_FLOW_ANCHORS_PER_FILE = 3;
+const SOURCE_DECLARATION_ANCHOR_LINES = 6;
+type SourceAdmissionPhase = "fairness" | "answer" | "secondary" | "optional";
+interface PlannedSourceAdmission {
+  record: Rec;
+  phase: SourceAdmissionPhase;
+  atomic: boolean;
+}
+
+/**
+ * Turn each selected file into round-robin declaration admissions followed by
+ * optional bodies. A source-region hit can rank a nearby caller just ahead of
+ * the declaration that actually answers the query; emitting the first complete
+ * body in that case used to exhaust the file's only fair admission. Compact
+ * declaration headers let the first three direct candidates, plus three
+ * displayed-flow targets, compete without spending the budget on a
+ * decoy body. Every file receives one compact admission first; then complete
+ * source-aligned answers up to 160 lines are admitted round-robin before
+ * remaining anchors and ordinary bodies. Explicit exact matches retain their
+ * original complete range.
+ */
+function prioritizeSourceAdmissions(
+  records: Rec[],
+  primaryOrder: Map<string, number>,
+  exactOrder: Map<string, number>,
+  flowAnswerIds: Set<string>,
+  reservedPrimaryIds: Set<string>,
+  globallyReservedOrder: Map<string, number>,
+  nodes: Map<string, GraphNode>,
+): PlannedSourceAdmission[] {
+  const plans = records.flatMap((record, recordIndex) => {
+    const ranges = Array.isArray(record.ranges) ? record.ranges as SourceRange[] : [];
+    const filePath = typeof record.filePath === "string" ? record.filePath : undefined;
+    if (!filePath || ranges.length === 0) return [];
+
+    // A planned whole file is already the smallest truthful source unit. Do
+    // not turn a <=200-line answer back into signatures and tails during
+    // cross-file fairness; either admit the complete record or omit it.
+    const wholeFile = ranges.length === 1 && ranges[0]!.reason === "whole-file"
+      && ranges[0]!.endLine - ranges[0]!.startLine + 1 <= 200;
+    if (wholeFile) {
+      const primary = recordIndex === 0
+        || ranges[0]!.nodeIds.some((id) => reservedPrimaryIds.has(id));
+      const directAnswer = !primary
+        && ranges[0]!.nodeIds.some((id) => flowAnswerIds.has(id));
+      const compactNodeId = [...primaryOrder.keys()].find((id) => (
+        ranges[0]!.nodeIds.includes(id) && nodes.get(id)?.filePath === filePath
+      )) ?? ranges[0]!.nodeIds[0];
+      const compactNode = compactNodeId ? nodes.get(compactNodeId) : undefined;
+      const compactAnchor = !primary && !directAnswer && compactNode
+        ? declarationAnchor(ranges[0]!, compactNode, SOURCE_DECLARATION_ANCHOR_LINES)
+        : null;
+      const optionalRanges = compactAnchor
+        ? subtractSourceIntervals(ranges[0]!, [{
+          startLine: compactAnchor.startLine, endLine: compactAnchor.endLine,
+        }], nodes)
+        : [];
+      return [{
+        record,
+        anchors: primary || directAnswer ? [] as SourceRange[] : [compactAnchor ?? ranges[0]!],
+        answerRanges: primary ? [ranges[0]!] : [] as SourceRange[],
+        directAnswerRanges: directAnswer ? [ranges[0]!] : [] as SourceRange[],
+        optionalRanges,
+      }];
+    }
+
+    const orderedIds = [...primaryOrder.keys()].filter((id) => nodes.get(id)?.filePath === filePath);
+    let directAnchors = 0;
+    let flowAnchors = 0;
+    const selectedAsFlow = new Set<string>();
+    const selectedIds = orderedIds.filter((id) => {
+      if (reservedPrimaryIds.has(id)) return true;
+      if (flowAnswerIds.has(id)) {
+        flowAnchors += 1;
+        if (flowAnchors <= PRIMARY_FLOW_ANCHORS_PER_FILE) {
+          selectedAsFlow.add(id);
+          return true;
+        }
+        return false;
+      }
+      directAnchors += 1;
+      return directAnchors <= PRIMARY_DECLARATION_ANCHORS_PER_FILE;
+    });
+    const anchors: SourceRange[] = [];
+    const answerRanges: SourceRange[] = [];
+    const directAnswerRanges: SourceRange[] = [];
+    const cuts = new Map<number, Array<{ startLine: number; endLine: number }>>();
+    // Reserve every bounded named/first-flow declaration in this file (up to
+    // the existing three-primary cap), plus one source-aligned fallback. The
+    // fallback preserves later-file recall when its first overlap is an
+    // oversized enclosing decoy.
+    const reservedAnswerIds = selectedIds.filter((id) => {
+      if (!reservedPrimaryIds.has(id)) return false;
+      const node = nodes.get(id);
+      if (!node) return false;
+      const rangeIndex = bestDeclarationRangeIndex(ranges, node);
+      if (rangeIndex < 0) return false;
+      return Boolean(completeDeclarationRange(ranges[rangeIndex]!, node));
+    });
+    const fallbackAnswerId = selectedIds.find((id) => {
+      if (reservedPrimaryIds.has(id) || exactOrder.has(id)
+        || selectedAsFlow.has(id)) return false;
+      const node = nodes.get(id);
+      if (!node) return false;
+      const rangeIndex = bestDeclarationRangeIndex(ranges, node);
+      return rangeIndex >= 0 && Boolean(completeDeclarationRange(ranges[rangeIndex]!, node));
+    });
+    const directAnswerIds = new Set([
+      ...reservedAnswerIds,
+      ...(fallbackAnswerId ? [fallbackAnswerId] : []),
+    ]);
+
+    for (const id of selectedIds) {
+      const node = nodes.get(id);
+      if (!node) continue;
+      const rangeIndex = bestDeclarationRangeIndex(ranges, node);
+      if (rangeIndex < 0) continue;
+      const range = ranges[rangeIndex]!;
+      const exact = exactOrder.has(id);
+      const anchor = exact ? { ...range, nodeIds: [...range.nodeIds] }
+        : declarationAnchor(range, node, SOURCE_DECLARATION_ANCHOR_LINES);
+      if (!anchor) continue;
+      const completeAnswer = !exact && selectedAsFlow.has(id)
+        ? completeDeclarationRange(range, node)
+        : null;
+      const completeDirectAnswer = directAnswerIds.has(id)
+        ? completeDeclarationRange(range, node)
+        : null;
+      const reservedAnchor = reservedPrimaryIds.has(id) && !completeAnswer && !completeDirectAnswer
+        ? anchor : null;
+
+      // Complete primary answers are standalone atomic ranges. A tail that
+      // depends on a later fairness header can never be a truthful unit: under
+      // pressure the tail may fit while the header is dropped. A long reserved
+      // declaration promotes its truthful signature range to the same answer
+      // phase; only non-reserved nodes participate in compact fairness.
+      if (!completeAnswer && !completeDirectAnswer && !reservedAnchor) {
+        mergeAdmissionRange(anchors, anchor);
+      }
+      if (reservedAnchor) mergeAdmissionRange(answerRanges, reservedAnchor);
+      if (completeAnswer) mergeAdmissionRange(
+        reservedPrimaryIds.has(id) ? answerRanges : directAnswerRanges,
+        completeAnswer,
+      );
+      if (completeDirectAnswer) mergeAdmissionRange(
+        reservedPrimaryIds.has(id) || recordIndex === 0 ? answerRanges : directAnswerRanges,
+        completeDirectAnswer,
+      );
+
+      const intervals = cuts.get(rangeIndex) ?? [];
+      const consumed = completeAnswer ?? completeDirectAnswer ?? reservedAnchor ?? anchor;
+      intervals.push({ startLine: consumed.startLine, endLine: consumed.endLine });
+      cuts.set(rangeIndex, intervals);
+    }
+
+    // Text-only and otherwise node-less evidence still participates in the
+    // same one-first-range-per-file fairness contract.
+    if (anchors.length === 0 && answerRanges.length === 0 && directAnswerRanges.length === 0) {
+      const range = ranges[0]!;
+      const fallbackNode = range.nodeIds.map((id) => nodes.get(id))
+        .find((node): node is GraphNode => Boolean(node));
+      const fallback = fallbackNode
+        ? declarationAnchor(range, fallbackNode, SOURCE_DECLARATION_ANCHOR_LINES) ?? range
+        : range;
+      anchors.push(fallback);
+      const completeFallback = recordIndex === 0 && fallbackNode
+        ? completeDeclarationRange(range, fallbackNode)
+        : null;
+      if (completeFallback && fallbackNode) {
+        anchors.length = 0;
+        directAnswerRanges.push(completeFallback);
+      }
+      const consumed = completeFallback ?? fallback;
+      cuts.set(0, [{ startLine: consumed.startLine, endLine: consumed.endLine }]);
+    }
+
+    const optionalRanges = ranges.flatMap((range, index) => (
+      subtractSourceIntervals(range, cuts.get(index) ?? [], nodes)
+    ));
+    return [{ record, anchors, answerRanges, directAnswerRanges, optionalRanges }];
+  });
+
+  const ordered: PlannedSourceAdmission[] = [];
+  // The one terminal-flow target and one corroborated NL-query declaration are
+  // the only cross-file source reservations. Admit them before any file can
+  // spend the source share on multiple local answers.
+  const globallyAdmittedRanges = new Set<SourceRange>();
+  const globalAnswers = plans.flatMap((plan, planIndex) => [
+    ...plan.answerRanges,
+    ...plan.directAnswerRanges,
+  ].flatMap((range, rangeIndex) => {
+    const priority = Math.min(...range.nodeIds
+      .map((id) => globallyReservedOrder.get(id) ?? Number.POSITIVE_INFINITY));
+    return Number.isFinite(priority) ? [{ plan, planIndex, range, rangeIndex, priority }] : [];
+  })).sort((left, right) => left.priority - right.priority
+    || left.planIndex - right.planIndex
+    || left.rangeIndex - right.rangeIndex);
+  for (const answer of globalAnswers) {
+    if (globallyAdmittedRanges.has(answer.range)) continue;
+    globallyAdmittedRanges.add(answer.range);
+    ordered.push({ record: { ...answer.plan.record, ranges: [answer.range] }, phase: "answer", atomic: true });
+  }
+
+  // Keep the strongest cohesive file together, then round-robin the remaining
+  // reserved and displayed-flow answers across later files.
+  const primaryPlan = plans[0];
+  for (const range of primaryPlan?.answerRanges ?? []) {
+    if (globallyAdmittedRanges.has(range)) continue;
+    ordered.push({ record: { ...primaryPlan!.record, ranges: [range] }, phase: "answer", atomic: true });
+  }
+  for (const range of primaryPlan?.directAnswerRanges ?? []) {
+    if (globallyAdmittedRanges.has(range)) continue;
+    ordered.push({ record: { ...primaryPlan!.record, ranges: [range] }, phase: "answer", atomic: true });
+  }
+  const secondaryPlans = plans.slice(1);
+  const answerWaves = Math.max(0, ...secondaryPlans.map((plan) => plan.answerRanges.length));
+  for (let wave = 0; wave < answerWaves; wave += 1) {
+    for (const plan of secondaryPlans) {
+      const range = plan.answerRanges[wave];
+      if (range && !globallyAdmittedRanges.has(range)) {
+        ordered.push({ record: { ...plan.record, ranges: [range] }, phase: "answer", atomic: true });
+      }
+    }
+  }
+  const directAnswerWaves = Math.max(0, ...secondaryPlans.map((plan) => plan.directAnswerRanges.length));
+  for (let wave = 0; wave < directAnswerWaves; wave += 1) {
+    for (const plan of secondaryPlans) {
+      const range = plan.directAnswerRanges[wave];
+      if (range && !globallyAdmittedRanges.has(range)) {
+        ordered.push({ record: { ...plan.record, ranges: [range] }, phase: "answer", atomic: true });
+      }
+    }
+  }
+  for (const plan of plans) {
+    const range = plan.anchors[0];
+    if (range) ordered.push({
+      record: { ...plan.record, ranges: [range] },
+      phase: "fairness",
+      atomic: range.reason === "whole-file" && range.endLine - range.startLine + 1 <= 200,
+    });
+  }
+  const waves = Math.max(0, ...plans.map((plan) => plan.anchors.length));
+  for (let wave = 1; wave < waves; wave += 1) {
+    for (const plan of plans) {
+      const range = plan.anchors[wave];
+      if (range) ordered.push({ record: { ...plan.record, ranges: [range] }, phase: "secondary", atomic: false });
+    }
+  }
+  for (const plan of plans) {
+    if (plan.optionalRanges.length > 0) {
+      ordered.push({
+        record: { ...plan.record, ranges: plan.optionalRanges }, phase: "optional", atomic: false,
+      });
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Normalize source admissions before they touch the ledger. Planning can attach
+ * several relevant node ids to one containing declaration, after which the
+ * admission scheduler may split that declaration back into one record per id.
+ * Coalesce same-phase overlaps and subtract higher-priority coverage from later
+ * phases so every source line is serialized at most once while covered node ids
+ * remain available for fact and summary accounting.
+ */
+function coalesceSourceAdmissions(
+  admissions: PlannedSourceAdmission[],
+  nodes: Map<string, GraphNode>,
+): PlannedSourceAdmission[] {
+  type Entry = PlannedSourceAdmission & {
+    filePath: string;
+    range: SourceRange;
+    order: number;
+  };
+  const flattened: Entry[] = [];
+  let order = 0;
+  for (const admission of admissions) {
+    const filePath = typeof admission.record.filePath === "string" ? admission.record.filePath : undefined;
+    const ranges = Array.isArray(admission.record.ranges) ? admission.record.ranges as SourceRange[] : [];
+    if (!filePath || ranges.length === 0) continue;
+    for (const range of ranges) flattened.push({ ...admission, filePath, range, order: order++ });
+  }
+
+  // Merge connected overlaps only within one admission phase. This removes
+  // duplicate complete parent/child answers without letting a later optional
+  // tail enlarge a mandatory answer record.
+  const samePhase: Entry[] = [];
+  const phaseGroups = new Map<string, Entry[]>();
+  for (const entry of flattened) {
+    const key = `${entry.filePath}\0${entry.phase}`;
+    const group = phaseGroups.get(key);
+    if (group) group.push(entry); else phaseGroups.set(key, [entry]);
+  }
+  for (const group of phaseGroups.values()) {
+    const sorted = [...group].sort((left, right) => left.range.startLine - right.range.startLine
+      || right.range.endLine - left.range.endLine || left.order - right.order);
+    const merged: Entry[] = [];
+    for (const entry of sorted) {
+      const prior = merged.at(-1);
+      if (prior && rangesOverlap(prior.range, entry.range)) {
+        prior.range = combineSourceRanges(prior.range, entry.range);
+        prior.record = { ...prior.record, ranges: [prior.range] };
+        prior.atomic = prior.atomic && entry.atomic;
+        prior.order = Math.min(prior.order, entry.order);
+      } else merged.push({ ...entry, record: { ...entry.record, ranges: [entry.range] } });
+    }
+    samePhase.push(...merged);
+  }
+  samePhase.sort((left, right) => left.order - right.order
+    || left.range.startLine - right.range.startLine || left.range.endLine - right.range.endLine);
+
+  const out: Entry[] = [];
+  for (const entry of samePhase) {
+    let pending = [entry.range];
+    for (const prior of out) {
+      if (prior.filePath !== entry.filePath) continue;
+      const next: SourceRange[] = [];
+      for (const range of pending) {
+        if (!rangesOverlap(prior.range, range)) {
+          next.push(range);
+          continue;
+        }
+        if (prior.range.startLine <= range.startLine && prior.range.endLine >= range.endLine) {
+          prior.range.nodeIds = [...new Set([...prior.range.nodeIds, ...range.nodeIds])];
+          prior.record = { ...prior.record, ranges: [prior.range] };
+          continue;
+        }
+        // Preserve node ids whose complete declaration is already covered by
+        // the earlier range. Remaining ids stay attached to the non-overlapping
+        // pieces returned below.
+        const coveredNodeIds = range.nodeIds.filter((id) => {
+          const node = nodes.get(id);
+          return node && prior.range.startLine <= node.startLine && prior.range.endLine >= node.endLine;
+        });
+        prior.range.nodeIds = [...new Set([...prior.range.nodeIds, ...coveredNodeIds])];
+        prior.record = { ...prior.record, ranges: [prior.range] };
+        next.push(...subtractSourceIntervals(range, [{
+          startLine: prior.range.startLine, endLine: prior.range.endLine,
+        }], nodes));
+      }
+      pending = next;
+      if (pending.length === 0) break;
+    }
+    for (const range of pending) {
+      out.push({
+        ...entry,
+        range,
+        record: { ...entry.record, ranges: [range] },
+        atomic: entry.atomic && range.startLine === entry.range.startLine
+          && range.endLine === entry.range.endLine,
+      });
+    }
+  }
+  return out.sort((left, right) => left.order - right.order
+    || left.range.startLine - right.range.startLine || left.range.endLine - right.range.endLine)
+    .map(({ filePath: _filePath, range: _range, order: _order, ...admission }) => admission);
+}
+
+function rangesOverlap(left: SourceRange, right: SourceRange): boolean {
+  return left.startLine <= right.endLine && right.startLine <= left.endLine;
+}
+
+function combineSourceRanges(left: SourceRange, right: SourceRange): SourceRange {
+  const startLine = Math.min(left.startLine, right.startLine);
+  const endLine = Math.max(left.endLine, right.endLine);
+  const sourceLines = new Map<number, string>();
+  for (const range of [left, right]) {
+    for (const [offset, content] of range.content.split("\n").entries()) {
+      const line = range.startLine + offset;
+      if (!sourceLines.has(line)) sourceLines.set(line, content.replace(/^\s*\d+:\s?/, ""));
+    }
+  }
+  const width = String(endLine).length;
+  const content = Array.from({ length: endLine - startLine + 1 }, (_, offset) => {
+    const line = startLine + offset;
+    return `${String(line).padStart(width)}: ${sourceLines.get(line) ?? ""}`;
+  }).join("\n");
+  const leftContains = left.startLine <= right.startLine && left.endLine >= right.endLine;
+  const rightContains = right.startLine <= left.startLine && right.endLine >= left.endLine;
+  const provenance = rightContains && !leftContains ? right : left;
+  return {
+    startLine,
+    endLine,
+    nodeIds: [...new Set([...left.nodeIds, ...right.nodeIds])],
+    content,
+    truncated: leftContains ? left.truncated : rightContains ? right.truncated : left.truncated || right.truncated,
+    reason: provenance.reason,
+  };
+}
+
+function mergeAdmissionRange(ranges: SourceRange[], incoming: SourceRange): void {
+  const duplicate = ranges.find((candidate) => (
+    candidate.startLine === incoming.startLine && candidate.endLine === incoming.endLine
+  ));
+  if (duplicate) duplicate.nodeIds = [...new Set([...duplicate.nodeIds, ...incoming.nodeIds])];
+  else ranges.push(incoming);
+}
+
+function bestDeclarationRangeIndex(ranges: SourceRange[], node: GraphNode): number {
+  return ranges.map((range, index) => ({ range, index }))
+    .filter(({ range }) => range.nodeIds.includes(node.id)
+      && range.startLine <= node.startLine && range.endLine >= node.startLine)
+    .sort((left, right) => (
+      Number(left.range.startLine !== node.startLine) - Number(right.range.startLine !== node.startLine)
+      || (left.range.endLine - left.range.startLine) - (right.range.endLine - right.range.startLine)
+      || left.index - right.index
+    ))[0]?.index ?? -1;
+}
+
+function declarationAnchor(range: SourceRange, node: GraphNode, maxLines: number): SourceRange | null {
+  const startLine = Math.max(range.startLine, node.startLine);
+  const endLine = Math.min(range.endLine, node.endLine, startLine + Math.max(1, maxLines) - 1);
+  if (endLine < startLine) return null;
+  const anchor = sliceSourceRange(range, startLine, endLine, [node.id]);
+  return {
+    ...anchor,
+    reason: endLine >= node.endLine ? "complete-symbol" : "signature",
+    truncated: range.truncated || endLine < node.endLine,
+  };
+}
+
+function completeDeclarationRange(range: SourceRange, node: GraphNode): SourceRange | null {
+  const length = node.endLine - node.startLine + 1;
+  if (length > 160 || range.startLine > node.startLine || range.endLine < node.endLine) return null;
+  return {
+    ...sliceSourceRange(range, node.startLine, node.endLine, [node.id]),
+    reason: "complete-symbol",
+    truncated: false,
+  };
+}
+
+function subtractSourceIntervals(
+  range: SourceRange,
+  intervals: Array<{ startLine: number; endLine: number }>,
+  nodes: Map<string, GraphNode>,
+): SourceRange[] {
+  const clipped = intervals.map((interval) => ({
+    startLine: Math.max(range.startLine, interval.startLine),
+    endLine: Math.min(range.endLine, interval.endLine),
+  })).filter((interval) => interval.endLine >= interval.startLine)
+    .sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine);
+  if (clipped.length === 0) return [range];
+
+  const merged: Array<{ startLine: number; endLine: number }> = [];
+  for (const interval of clipped) {
+    const prior = merged.at(-1);
+    if (prior && interval.startLine <= prior.endLine + 1) prior.endLine = Math.max(prior.endLine, interval.endLine);
+    else merged.push({ ...interval });
+  }
+
+  const pieces: SourceRange[] = [];
+  let cursor = range.startLine;
+  for (const interval of merged) {
+    if (cursor < interval.startLine) pieces.push(sourceInterval(range, cursor, interval.startLine - 1, nodes));
+    cursor = Math.max(cursor, interval.endLine + 1);
+  }
+  if (cursor <= range.endLine) pieces.push(sourceInterval(range, cursor, range.endLine, nodes));
+  return pieces;
+}
+
+function sourceInterval(
+  range: SourceRange,
+  startLine: number,
+  endLine: number,
+  nodes: Map<string, GraphNode>,
+): SourceRange {
+  const nodeIds = range.nodeIds.filter((id) => {
+    const node = nodes.get(id);
+    return !node || (node.startLine <= endLine && node.endLine >= startLine);
+  });
+  return { ...sliceSourceRange(range, startLine, endLine, nodeIds), truncated: true };
+}
+
+function sliceSourceRange(
+  range: SourceRange,
+  startLine: number,
+  endLine: number,
+  nodeIds: string[],
+): SourceRange {
+  const offset = startLine - range.startLine;
+  const lineCount = endLine - startLine + 1;
+  return {
+    ...range,
+    startLine,
+    endLine,
+    nodeIds,
+    content: range.content.split("\n").slice(offset, offset + lineCount).join("\n"),
+  };
+}
+
+function sourceRangesCover(emitted: SourceRange[], wanted: SourceRange): boolean {
+  let cursor = wanted.startLine;
+  for (const range of [...emitted].sort((left, right) => left.startLine - right.startLine || left.endLine - right.endLine)) {
+    if (range.endLine < cursor) continue;
+    if (range.startLine > cursor) return false;
+    cursor = Math.max(cursor, range.endLine + 1);
+    if (cursor > wanted.endLine) return true;
+  }
+  return false;
+}
+
+function firstNodeOrderInFile(
+  order: Map<string, number>,
+  nodes: Map<string, GraphNode>,
+  filePath: string,
+): number {
+  let first = Number.POSITIVE_INFINITY;
+  for (const [id, index] of order) {
+    if (nodes.get(id)?.filePath === filePath) first = Math.min(first, index);
+  }
+  return first;
+}
+
+function admitSourceWithinShare(
+  record: Rec,
+  availableTokens: number,
+  ledger: BudgetLedger,
+  atomic = false,
+): { admitted: Rec[]; deferred: Rec[]; tokens: number; trimmed: boolean } {
+  const admitted: Rec[] = [];
+  const deferred: Rec[] = [];
+  let remaining = Math.max(0, availableTokens);
+  let tokens = 0;
+  let trimmed = false;
+  const fullTokens = estimateTokens(record);
+  if (fullTokens <= remaining && ledger.fits(record)) {
+    ledger.tryAdd(record);
+    return { admitted: [record], deferred, tokens: fullTokens, trimmed };
+  }
+  if (atomic) return { admitted, deferred: [record], tokens, trimmed };
+
+  const ranges = Array.isArray(record.ranges) ? record.ranges as SourceRange[] : [];
+  for (const range of ranges) {
+    const single: Rec = { ...record, ranges: [range] };
+    const singleTokens = estimateTokens(single);
+    if (singleTokens <= remaining && ledger.fits(single)) {
+      ledger.tryAdd(single);
+      admitted.push(single);
+      remaining -= singleTokens;
+      tokens += singleTokens;
+      continue;
+    }
+
+    // A complete declaration is an atomic evidence unit. Prefix-trimming one
+    // at the 75% source-share boundary both loses span recall and falsely labels
+    // a fragment as a complete symbol. Keep it whole for the spill pass; if the
+    // hard response ledger still cannot fit it there, report it as omitted.
+    if (range.reason === "complete-symbol" && !range.truncated
+      && range.endLine - range.startLine + 1 <= 160) {
+      deferred.push(single);
+      continue;
+    }
+
+    const fitted = fitSourceRange(single, remaining, ledger);
+    if (fitted) {
+      const fittedTokens = estimateTokens(fitted);
+      ledger.tryAdd(fitted);
+      admitted.push(fitted);
+      remaining -= fittedTokens;
+      tokens += fittedTokens;
+      trimmed ||= (fitted.ranges as SourceRange[])[0]!.endLine < range.endLine || range.truncated;
+    } else deferred.push(single);
+  }
+  return { admitted, deferred, tokens, trimmed };
+}
+
+/** Find the largest whole-line prefix that fits; never cut a source line. */
+function fitSourceRange(record: Rec, availableTokens: number, ledger: BudgetLedger): Rec | null {
+  if (availableTokens <= 0) return null;
+  const ranges = record.ranges as SourceRange[];
+  const range = ranges[0];
+  if (!range) return null;
+  const contentLines = range.content.split("\n");
+  let low = 1;
+  let high = contentLines.length;
+  let best: Rec | null = null;
+  while (low <= high) {
+    const count = Math.floor((low + high) / 2);
+    const centered = range.reason === "query-hit" || range.reason === "callsite" || range.reason === "text-only";
+    const offset = centered ? Math.floor((contentLines.length - count) / 2) : 0;
+    const candidateRange: SourceRange = {
+      ...range,
+      startLine: range.startLine + offset,
+      endLine: Math.min(range.endLine, range.startLine + offset + count - 1),
+      content: contentLines.slice(offset, offset + count).join("\n"),
+      truncated: count < contentLines.length || range.truncated,
+    };
+    const candidate: Rec = { ...record, ranges: [candidateRange] };
+    if (estimateTokens(candidate) <= availableTokens && ledger.fits(candidate)) {
+      best = candidate;
+      low = count + 1;
+    } else high = count - 1;
+  }
+  return best;
+}
+
+function dedupeTextHits(hits: RankedScopeFile["textHits"]): RankedScopeFile["textHits"] {
+  const unique = new Map<string, RankedScopeFile["textHits"][number]>();
+  for (const hit of hits) {
+    const key = `${hit.filePath}\0${hit.startLine}\0${hit.endLine}\0${hit.contentHash}`;
+    if (!unique.has(key)) unique.set(key, hit);
+  }
+  return [...unique.values()].sort((left, right) =>
+    left.rank - right.rank || left.startLine - right.startLine || left.endLine - right.endLine);
+}
+
+function capFlowSteps<T extends { steps: GraphEdge[] }>(flows: T[], maxSteps: number): T[] {
+  const out: T[] = [];
+  let remaining = maxSteps;
+  for (const flow of flows) {
+    if (remaining <= 0) break;
+    if (flow.steps.length === 0 || flow.steps.length > 7 || flow.steps.length > remaining) continue;
+    out.push(flow);
+    remaining -= flow.steps.length;
+  }
+  return out;
+}
+
+function scopeEdgeKey(edge: Pick<GraphEdge, "source" | "target" | "kind" | "line" | "column">): string {
+  return `${edge.source}\0${edge.target}\0${edge.kind}\0${edge.line ?? -1}\0${edge.column ?? -1}`;
+}
+
 function openSession(rootDir: string, deps: AgentCommandDeps, write: (line: string) => void): AgentGraphSession | null {
   try {
     if (deps.open) return deps.open(rootDir);
@@ -449,8 +1799,16 @@ function openSession(rootDir: string, deps: AgentCommandDeps, write: (line: stri
       writeJson(write, { type: "error", code: "GRAPH_UNAVAILABLE", message: "Run `mex graph` first." });
       return null;
     }
-    const graph = createGraphEngine({ rootDir, dbPath });
-    const db = openSqlite(dbPath);
+    const graph = createGraphEngine({ rootDir, dbPath, readOnly: true });
+    const db = openGraphDatabase(dbPath, { readOnly: true });
+    const storedManifest = db.prepare(
+      "SELECT value FROM project_metadata WHERE key = 'manifest_hash'",
+    ).get() as { value: string } | undefined;
+    if (storedManifest?.value !== graphManifest(resolve(rootDir)).manifestHash) {
+      graph.close();
+      db.close();
+      throw new GraphRebuildRequiredError("The code graph build manifest is stale.");
+    }
     return { graph, db, close: () => { graph.close(); db.close(); } };
   } catch (error) {
     unavailable(write, error);
@@ -462,8 +1820,40 @@ function resolveSymbol(graph: GraphEngine, target: string): GraphNode[] {
   const exactId = graph.getNode(target);
   if (exactId) return [exactId];
   const matches = graph.searchNodes(target, { limit: 100 });
-  const exact = matches.filter((node) => node.name === target || node.qualifiedName === target);
-  return exact.length > 0 ? exact : matches;
+  // Targeted commands must never reinterpret a missing symbol as a fuzzy one.
+  // Broad retrieval belongs to `graph scope`; query/impact either resolve the
+  // requested declaration exactly or abstain with TARGET_NOT_FOUND.
+  return matches.filter((node) => node.name === target || node.qualifiedName === target);
+}
+
+function relatedCallNodes(graph: GraphEngine, queried: GraphNode, relation: Exclude<QueryRelation, "where-defined">): GraphNode[] {
+  const typed = relation === "who-calls"
+    ? (graph.getIncoming?.(queried.id, ["calls"]) ?? [])
+    : (graph.getOutgoing?.(queried.id, ["calls"]) ?? []);
+  if (typed.length > 0) {
+    return dedupeNeighbors(typed)
+      .sort((left, right) => {
+        const pathDelta = Number(isLowValueGraphPath(left.node.filePath)) - Number(isLowValueGraphPath(right.node.filePath));
+        if (pathDelta !== 0) return pathDelta;
+        const lineDelta = (left.edge.line ?? Number.MAX_SAFE_INTEGER) - (right.edge.line ?? Number.MAX_SAFE_INTEGER);
+        if (lineDelta !== 0) return lineDelta;
+        return left.node.id.localeCompare(right.node.id);
+      })
+      .map((entry) => entry.node);
+  }
+  const fallback = relation === "who-calls" ? graph.getCallers(queried.id) : graph.getCallees(queried.id);
+  return fallback.sort((left, right) =>
+    Number(isLowValueGraphPath(left.filePath)) - Number(isLowValueGraphPath(right.filePath)) || left.id.localeCompare(right.id),
+  );
+}
+
+function dedupeNeighbors(entries: GraphNeighbor[]): GraphNeighbor[] {
+  const seen = new Set<string>();
+  return entries.filter((entry) => {
+    if (seen.has(entry.node.id)) return false;
+    seen.add(entry.node.id);
+    return true;
+  });
 }
 
 function nodesForFile(session: AgentGraphSession, rootDir: string, target: string): GraphNode[] {
@@ -495,12 +1885,71 @@ function groundedFiles(db: SqliteDatabase, nodeIds: string[]): Array<{ scaffold_
   if (nodeIds.length === 0) return [];
   const placeholders = nodeIds.map(() => "?").join(",");
   return db.prepare(
-    `SELECT scaffold_file, node_id FROM _mex_grounded_source WHERE node_id IN (${placeholders}) ORDER BY scaffold_file, node_id`,
-  ).all(...nodeIds) as Array<{ scaffold_file: string; node_id: string }>;
+    `SELECT DISTINCT grounded.scaffold_file,
+            COALESCE(aliases.canonical_node_id, grounded.node_id) AS node_id
+     FROM _mex_grounded_source grounded
+     LEFT JOIN node_aliases aliases ON aliases.alias_id = grounded.node_id
+     WHERE grounded.node_id IN (${placeholders})
+        OR aliases.canonical_node_id IN (${placeholders})
+     ORDER BY grounded.scaffold_file, node_id`,
+  ).all(...nodeIds, ...nodeIds) as Array<{ scaffold_file: string; node_id: string }>;
+}
+
+function liveUnindexedFiles(indexedFiles: IndexedFileInfo[], rootDir: string): string[] {
+  const indexed = new Set(indexedFiles.map((file) => file.path));
+  return globSync(SUPPORTED_SOURCE_GLOB, {
+    cwd: rootDir,
+    ignore: [
+      "**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**", "**/.mex/**",
+      "**/coverage/**", "**/.next/**", "**/out/**",
+    ],
+    nodir: true,
+    absolute: false,
+    dot: false,
+  }).map((file) => file.replaceAll("\\", "/"))
+    .filter((file) => isSupportedSourceFile(file) && !indexed.has(file))
+    .sort();
 }
 
 function nodeRef(node: GraphNode): Record<string, string | number> {
   return { id: node.id, kind: node.kind, name: node.name, file: node.filePath, line: node.startLine };
+}
+
+function liveStaleFallbacks(
+  indexedFiles: IndexedFileInfo[],
+  staleFiles: string[],
+  task: string,
+  rootDir: string,
+): RankedScopeFile[] {
+  const terms = [...new Set(planGraphQuery(task).terms.filter((term) => !term.stem).map((term) => term.term))];
+  const info = new Map(indexedFiles.map((file) => [file.path, file]));
+  const out: RankedScopeFile[] = [];
+  for (const filePath of staleFiles) {
+    let lines: string[];
+    try { lines = readFileSync(resolve(rootDir, filePath), "utf-8").split("\n"); }
+    catch { continue; }
+    const matched = terms.filter((term) => lines.some((line) => line.toLowerCase().includes(term)));
+    if (matched.length === 0) continue;
+    const first = Math.max(0, lines.findIndex((line) => matched.some((term) => line.toLowerCase().includes(term))));
+    const indexed = info.get(filePath);
+    out.push({
+      filePath,
+      score: 1 + matched.length * 0.3,
+      reasons: ["live-stale-text"],
+      nodeIds: [],
+      textOnly: true,
+      parseStatus: indexed?.parseStatus ?? "failed",
+      textHits: [{
+        filePath,
+        startLine: Math.max(1, first + 1 - 12),
+        endLine: Math.min(lines.length, first + 1 + 12),
+        contentHash: sourceHash(filePath, rootDir) ?? "",
+        rank: -matched.length,
+        matchedTerms: matched,
+      }],
+    });
+  }
+  return out.sort((left, right) => right.score - left.score || left.filePath.localeCompare(right.filePath));
 }
 
 function byId(left: GraphNode, right: GraphNode): number { return left.id.localeCompare(right.id); }
@@ -509,9 +1958,11 @@ function isRelation(value: string): value is QueryRelation {
 }
 function writeJson(write: (line: string) => void, value: unknown): void { write(JSON.stringify(value)); }
 function unavailable(write: (line: string) => void, error: unknown): void {
+  const coded = error as { code?: unknown; recoveryCommand?: unknown };
   writeJson(write, {
     type: "error",
-    code: "GRAPH_UNAVAILABLE",
+    code: typeof coded?.code === "string" ? coded.code : "GRAPH_UNAVAILABLE",
     message: error instanceof Error ? error.message : String(error),
+    ...(typeof coded?.recoveryCommand === "string" ? { recoveryCommand: coded.recoveryCommand } : {}),
   });
 }

--- a/src/graph/db/database.ts
+++ b/src/graph/db/database.ts
@@ -13,13 +13,23 @@
 //     per-file replace path (sync) relies on ON DELETE CASCADE.
 //   * journal_mode=WAL persists in the file header; re-asserting is harmless.
 
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname } from "node:path";
 import { schemaPath } from "../assets.js";
+import { GraphRebuildRequiredError } from "../errors.js";
 import { openSqlite, type SqliteDatabase } from "./sqlite.js";
 
 /** The schema version this build writes/expects (matches schema.sql's seed). */
-export const CURRENT_SCHEMA_VERSION = 1;
+export const DB_SCHEMA_VERSION = 2;
+/** @deprecated Prefer the explicit DB_SCHEMA_VERSION name. */
+export const CURRENT_SCHEMA_VERSION = DB_SCHEMA_VERSION;
+
+export interface OpenGraphDatabaseOptions {
+  /** Builders may open a migrated database in order to replace its derived rows. */
+  allowRebuild?: boolean;
+  /** Reader-only commands must not mutate pragmas, schema, or version metadata. */
+  readOnly?: boolean;
+}
 
 function configureConnection(db: SqliteDatabase): void {
   db.pragma("busy_timeout = 5000"); // MUST be first
@@ -29,28 +39,95 @@ function configureConnection(db: SqliteDatabase): void {
   db.pragma("temp_store = MEMORY");
 }
 
+function configureReadOnlyConnection(db: SqliteDatabase): void {
+  db.pragma("busy_timeout = 5000");
+  db.pragma("query_only = ON");
+}
+
 /**
  * Open the graph DB at `dbPath`, creating the file + parent dir and applying the
  * schema when absent. Idempotent: re-opening an existing DB re-applies PRAGMAs
  * and re-asserts the schema (all statements are `IF NOT EXISTS`).
  */
-export function openGraphDatabase(dbPath: string): SqliteDatabase {
+export function openGraphDatabase(
+  dbPath: string,
+  options: OpenGraphDatabaseOptions = {},
+): SqliteDatabase {
   const dir = dirname(dbPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  if (!existsSync(dir)) {
+    if (options.readOnly) throw new GraphRebuildRequiredError("The graph index does not exist. Run `mex graph` first.");
+    mkdirSync(dir, { recursive: true });
+  }
 
+  if (options.readOnly) {
+    return openReadOnlyGraphDatabase(dbPath);
+  }
   const db = openSqlite(dbPath);
   configureConnection(db);
 
-  // Load + apply the frozen schema (creates tables/indexes/triggers, and — via
-  // its own INSERT OR IGNORE — seeds the schema_versions row).
-  db.exec(readFileSync(schemaPath(), "utf-8"));
+  const schema = readFileSync(schemaPath(), "utf-8");
+  const hasVersions = tableExists(db, "schema_versions");
+  if (!hasVersions) {
+    db.exec(schema);
+  } else {
+    const current = readSchemaVersion(db) ?? 1;
+    if (current > DB_SCHEMA_VERSION) {
+      db.close();
+      throw new GraphRebuildRequiredError(
+        `This mex build supports graph schema ${DB_SCHEMA_VERSION}, but the index uses ${current}.`,
+      );
+    }
+    if (current < DB_SCHEMA_VERSION) migrateV1ToV2(db, schema);
+    else db.exec(schema);
+  }
 
   // Belt-and-suspenders: guarantee the version row exists even if the SQL seed
   // is ever changed, so the schema_versions table is never dead (migration
   // safety — Phase 0 shipped this table for exactly this reason).
-  writeSchemaVersion(db, CURRENT_SCHEMA_VERSION);
+  writeSchemaVersion(db, DB_SCHEMA_VERSION);
+
+  if (!options.allowRebuild && graphRequiresRebuild(db)) {
+    db.close();
+    throw new GraphRebuildRequiredError();
+  }
 
   return db;
+}
+
+function openReadOnlyGraphDatabase(dbPath: string): SqliteDatabase {
+  const validate = (db: SqliteDatabase): SqliteDatabase => {
+    configureReadOnlyConnection(db);
+    if (!tableExists(db, "schema_versions") || readSchemaVersion(db) !== DB_SCHEMA_VERSION) {
+      throw new GraphRebuildRequiredError();
+    }
+    if (graphRequiresRebuild(db)) throw new GraphRebuildRequiredError();
+    return db;
+  };
+
+  let db = openSqlite(dbPath, { readOnly: true });
+  try {
+    return validate(db);
+  } catch (error) {
+    db.close();
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/read.?only/i.test(message)) throw error;
+    const walPath = `${dbPath}-wal`;
+    if (existsSync(walPath) && statSync(walPath).size > 0) {
+      throw new Error(
+        "The graph has uncheckpointed WAL data and cannot be opened in this read-only sandbox. "
+        + "Run `mex graph` outside the sandbox and retry.",
+      );
+    }
+    // A checkpointed WAL-mode database can still ask SQLite to create -shm on
+    // first read. Immutable mode is safe only when no WAL payload exists.
+    db = openSqlite(dbPath, { readOnly: true, immutable: true });
+    try {
+      return validate(db);
+    } catch (immutableError) {
+      db.close();
+      throw immutableError;
+    }
+  }
 }
 
 /** Ensure a `schema_versions` row for `version` exists (no-op if already there). */
@@ -66,4 +143,92 @@ export function readSchemaVersion(db: SqliteDatabase): number | null {
     .prepare("SELECT version FROM schema_versions ORDER BY version DESC LIMIT 1")
     .get() as { version: number } | undefined;
   return row ? row.version : null;
+}
+
+/** Mark a successfully validated graph snapshot safe for readers. */
+export function markGraphReady(db: SqliteDatabase, manifestHash: string): void {
+  setMetadata(db, "rebuild_required", "0");
+  setMetadata(db, "manifest_hash", manifestHash);
+}
+
+/** Force readers to abstain until a full build publishes a compatible graph. */
+export function markGraphRebuildRequired(db: SqliteDatabase, reason: string): void {
+  setMetadata(db, "rebuild_required", "1");
+  setMetadata(db, "rebuild_reason", reason);
+}
+
+export function graphRequiresRebuild(db: SqliteDatabase): boolean {
+  if (!tableExists(db, "project_metadata")) return false;
+  const row = db.prepare("SELECT value FROM project_metadata WHERE key = 'rebuild_required'").get() as
+    | { value: string }
+    | undefined;
+  return row?.value === "1";
+}
+
+function setMetadata(db: SqliteDatabase, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO project_metadata (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+  ).run(key, value, Date.now());
+}
+
+function tableExists(db: SqliteDatabase, table: string): boolean {
+  return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(table));
+}
+
+function columns(db: SqliteDatabase, table: string): Set<string> {
+  return new Set(
+    (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((row) => row.name),
+  );
+}
+
+function addColumn(db: SqliteDatabase, table: string, name: string, definition: string): void {
+  if (!columns(db, table).has(name)) db.exec(`ALTER TABLE ${table} ADD COLUMN ${name} ${definition}`);
+}
+
+/**
+ * Schema v1 graph facts are not trustworthy under the v2 identity/resolution
+ * contract. The migration is additive so grounding snapshots can be retained,
+ * then marks the derived graph for a mandatory full rebuild.
+ */
+function migrateV1ToV2(db: SqliteDatabase, schema: string): void {
+  db.transaction(() => {
+    addColumn(db, "nodes", "container_id", "TEXT");
+    addColumn(db, "nodes", "identity_key", "TEXT NOT NULL DEFAULT ''");
+    db.exec("UPDATE nodes SET identity_key = id WHERE identity_key = ''");
+
+    addColumn(db, "edges", "confidence", "REAL NOT NULL DEFAULT 1.0");
+    addColumn(db, "edges", "resolution_method", "TEXT");
+    addColumn(db, "edges", "evidence", "TEXT");
+
+    addColumn(db, "files", "parse_status", "TEXT NOT NULL DEFAULT 'ok'");
+    addColumn(db, "files", "diagnostic_count", "INTEGER NOT NULL DEFAULT 0");
+    addColumn(db, "files", "missing_count", "INTEGER NOT NULL DEFAULT 0");
+    addColumn(db, "files", "error_coverage", "REAL NOT NULL DEFAULT 0");
+    addColumn(db, "files", "extractor_version", "TEXT NOT NULL DEFAULT 'legacy-v1'");
+
+    addColumn(db, "unresolved_refs", "ref_key", "TEXT NOT NULL DEFAULT ''");
+    addColumn(db, "unresolved_refs", "receiver", "TEXT");
+    addColumn(db, "unresolved_refs", "qualifier", "TEXT");
+    addColumn(db, "unresolved_refs", "import_source", "TEXT");
+    addColumn(db, "unresolved_refs", "metadata", "TEXT");
+    addColumn(db, "unresolved_refs", "status", "TEXT NOT NULL DEFAULT 'pending'");
+    addColumn(db, "unresolved_refs", "target_id", "TEXT");
+    addColumn(db, "unresolved_refs", "confidence", "REAL");
+    addColumn(db, "unresolved_refs", "resolver", "TEXT");
+    db.exec("UPDATE unresolved_refs SET ref_key = 'legacy:' || id WHERE ref_key = ''");
+
+    // Existing v1 builds can contain duplicate traversal edges. Retain one row
+    // per semantic callsite so the v2 uniqueness invariant can be installed.
+    db.exec(`DELETE FROM edges WHERE id NOT IN (
+      SELECT MIN(id) FROM edges
+      GROUP BY source, target, kind, IFNULL(line, -1), IFNULL(col, -1)
+    )`);
+  });
+
+  // Creates all new tables and indexes after the old tables have the v2 columns.
+  db.exec(schema);
+  db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_unresolved_ref_key ON unresolved_refs(ref_key)");
+  writeSchemaVersion(db, DB_SCHEMA_VERSION);
+  markGraphRebuildRequired(db, "schema-v1");
 }

--- a/src/graph/db/sqlite.ts
+++ b/src/graph/db/sqlite.ts
@@ -12,6 +12,7 @@
 // process warning untouched.
 
 import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 
 const require = createRequire(import.meta.url);
 
@@ -55,9 +56,12 @@ class NodeSqliteAdapter implements SqliteDatabase {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private readonly db: any;
 
-  constructor(dbPath: string) {
+  constructor(dbPath: string, options: { readOnly?: boolean; immutable?: boolean } = {}) {
     const { DatabaseSync } = require("node:sqlite");
-    this.db = new DatabaseSync(dbPath);
+    const location = options.immutable
+      ? `${pathToFileURL(dbPath).href}?mode=ro&immutable=1`
+      : dbPath;
+    this.db = new DatabaseSync(location, { readOnly: options.readOnly === true });
   }
 
   get open(): boolean {
@@ -109,9 +113,12 @@ class NodeSqliteAdapter implements SqliteDatabase {
  * Open (creating if needed) a SQLite database backed by `node:sqlite`. Throws a
  * clear message if the built-in module is unavailable (Node < 22.5).
  */
-export function openSqlite(dbPath: string): SqliteDatabase {
+export function openSqlite(
+  dbPath: string,
+  options: { readOnly?: boolean; immutable?: boolean } = {},
+): SqliteDatabase {
   try {
-    return new NodeSqliteAdapter(dbPath);
+    return new NodeSqliteAdapter(dbPath, options);
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     throw new Error(

--- a/src/graph/db/store.ts
+++ b/src/graph/db/store.ts
@@ -7,11 +7,14 @@
 // edges), and the bulk reads resolution uses. Rows are snake_case in SQLite and
 // decoded to the camelCase `GraphNode`/`GraphEdge` value types here.
 
+import { createHash } from "node:crypto";
 import type { EdgeKind, GraphEdge, GraphNode, Language, NodeKind, ReferenceKind } from "../types.js";
+import { identifierComponents, isLowValueGraphPath, planGraphQuery } from "../retrieval/query.js";
 import type { SqliteDatabase } from "./sqlite.js";
 
 /** An unresolved reference row: a name a node points at, bound after indexing. */
 export interface UnresolvedRefRecord {
+  refKey?: string;
   fromNodeId: string;
   referenceName: string;
   referenceKind: ReferenceKind;
@@ -20,6 +23,14 @@ export interface UnresolvedRefRecord {
   line?: number;
   column?: number;
   candidates?: string[];
+  receiver?: string;
+  qualifier?: string;
+  importSource?: string;
+  metadata?: Record<string, unknown>;
+  status?: "pending" | "resolved" | "ambiguous" | "unresolved";
+  targetId?: string;
+  confidence?: number;
+  resolver?: string;
 }
 
 /** A tracked-file row (drives incremental change detection for `sync`). */
@@ -31,6 +42,60 @@ export interface FileRecord {
   modifiedAt: number;
   indexedAt: number;
   nodeCount: number;
+  errors?: Array<Record<string, unknown>>;
+  parseStatus?: "ok" | "partial" | "failed";
+  diagnosticCount?: number;
+  missingCount?: number;
+  errorCoverage?: number;
+  extractorVersion?: string;
+}
+
+export interface ImportBindingRecord {
+  bindingKey: string;
+  filePath: string;
+  localName: string;
+  importedName: string;
+  moduleSpecifier: string;
+  resolvedFilePath?: string;
+  targetId?: string;
+  isTypeOnly?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SourceChunkHit {
+  id: number;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  contentHash: string;
+  rank: number;
+  matchedTerms: string[];
+  nodeIds?: string[];
+}
+
+const SOURCE_CHUNK_NODE_LIMIT = 8;
+const SOURCE_CHUNK_PRIMARY_KINDS = [
+  "function", "method", "class", "component", "struct", "trait", "route",
+] as const satisfies readonly NodeKind[];
+const SOURCE_CHUNK_SECONDARY_KINDS = [
+  "interface", "type_alias", "protocol", "enum",
+] as const satisfies readonly NodeKind[];
+const SOURCE_CHUNK_NODE_KINDS = [
+  ...SOURCE_CHUNK_PRIMARY_KINDS, ...SOURCE_CHUNK_SECONDARY_KINDS,
+] as const;
+
+export interface GraphHealthSummary {
+  indexedFiles: number;
+  okFiles: number;
+  partialFiles: number;
+  failedFiles: number;
+}
+
+export interface NodeAliasRecord {
+  aliasId: string;
+  canonicalNodeId: string;
+  matchMethod: string;
+  confidence: number;
 }
 
 /** Reference edge kinds — everything except the intra-file `contains` edge.
@@ -54,6 +119,8 @@ interface NodeRow {
   kind: string;
   name: string;
   qualified_name: string;
+  container_id: string | null;
+  identity_key: string;
   file_path: string;
   language: string;
   start_line: number;
@@ -82,6 +149,9 @@ interface EdgeRow {
   line: number | null;
   col: number | null;
   provenance: string | null;
+  confidence: number;
+  resolution_method: string | null;
+  evidence: string | null;
 }
 
 function parseJson<T>(raw: string | null): T | undefined {
@@ -99,6 +169,8 @@ function rowToNode(row: NodeRow): GraphNode {
     kind: row.kind as NodeKind,
     name: row.name,
     qualifiedName: row.qualified_name,
+    containerId: row.container_id ?? undefined,
+    identityKey: row.identity_key,
     filePath: row.file_path,
     language: row.language as Language,
     startLine: row.start_line,
@@ -126,10 +198,55 @@ function rowToEdge(row: EdgeRow): GraphEdge {
     target: row.target,
     kind: row.kind as EdgeKind,
     metadata: parseJson<Record<string, unknown>>(row.metadata),
+    confidence: row.confidence,
+    resolutionMethod: row.resolution_method ?? undefined,
+    evidence: parseJson<Array<Record<string, unknown>>>(row.evidence),
     line: row.line ?? undefined,
     column: row.col ?? undefined,
     provenance: (row.provenance as GraphEdge["provenance"]) ?? undefined,
   };
+}
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entry]) => [key, canonicalJson(entry)]));
+}
+
+function canonicalString(value: unknown): string {
+  return JSON.stringify(canonicalJson(value));
+}
+
+function edgeSupport(edge: GraphEdge): Record<string, unknown> {
+  return canonicalJson({
+    type: "resolution-support",
+    confidence: edge.confidence ?? 1,
+    ...(edge.provenance ? { provenance: edge.provenance } : {}),
+    ...(edge.resolutionMethod ? { resolutionMethod: edge.resolutionMethod } : {}),
+    ...(edge.metadata ? { metadata: edge.metadata } : {}),
+  }) as Record<string, unknown>;
+}
+
+function mergedEdgeEvidence(left: GraphEdge, right: GraphEdge): Array<Record<string, unknown>> {
+  const entries = [
+    ...(left.evidence ?? []),
+    edgeSupport(left),
+    ...(right.evidence ?? []),
+    edgeSupport(right),
+  ];
+  return [...new Map(entries.map((entry) => [canonicalString(entry), canonicalJson(entry) as Record<string, unknown>]))
+    .entries()]
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([, entry]) => entry);
+}
+
+function strongerEdge(left: GraphEdge, right: GraphEdge): GraphEdge {
+  const confidenceDelta = (right.confidence ?? 1) - (left.confidence ?? 1);
+  if (confidenceDelta > 0) return right;
+  if (confidenceDelta < 0) return left;
+  return canonicalString(edgeSupport(right)) < canonicalString(edgeSupport(left)) ? right : left;
 }
 
 export class GraphStore {
@@ -146,16 +263,18 @@ export class GraphStore {
     this.db
       .prepare(
         `INSERT INTO nodes (
-           id, kind, name, qualified_name, file_path, language,
+           id, kind, name, qualified_name, container_id, identity_key, file_path, language,
            start_line, end_line, start_column, end_column,
            docstring, signature, visibility,
            is_exported, is_async, is_static, is_abstract,
            decorators, type_parameters, return_type, body_hash, updated_at
-         ) VALUES (?,?,?,?,?,?, ?,?,?,?, ?,?,?, ?,?,?,?, ?,?,?,?,?)
+         ) VALUES (?,?,?,?,?,?,?,?, ?,?,?,?, ?,?,?, ?,?,?,?, ?,?,?,?,?)
          ON CONFLICT(id) DO UPDATE SET
            kind = excluded.kind,
            name = excluded.name,
            qualified_name = excluded.qualified_name,
+           container_id = excluded.container_id,
+           identity_key = excluded.identity_key,
            file_path = excluded.file_path,
            language = excluded.language,
            start_line = excluded.start_line,
@@ -180,6 +299,8 @@ export class GraphStore {
         node.kind,
         node.name,
         node.qualifiedName ?? node.name,
+        node.containerId ?? null,
+        node.identityKey ?? node.id,
         node.filePath,
         node.language,
         node.startLine,
@@ -207,11 +328,45 @@ export class GraphStore {
   }
 
   /** Insert an edge, skipping it unless both endpoints exist (FK safety). */
-  insertEdge(edge: GraphEdge): void {
-    this.db
+  insertEdge(edge: GraphEdge): boolean {
+    const existingRow = this.db.prepare(
+      `SELECT * FROM edges
+       WHERE source = ? AND target = ? AND kind = ?
+         AND IFNULL(line, -1) = IFNULL(?, -1)
+         AND IFNULL(col, -1) = IFNULL(?, -1)
+       LIMIT 1`,
+    ).get(edge.source, edge.target, edge.kind, edge.line ?? null, edge.column ?? null) as EdgeRow | undefined;
+
+    if (existingRow) {
+      const existing = rowToEdge(existingRow);
+      const winner = strongerEdge(existing, edge);
+      this.db.prepare(
+        `UPDATE edges SET metadata = ?, provenance = ?, confidence = ?,
+           resolution_method = ?, evidence = ?
+         WHERE source = ? AND target = ? AND kind = ?
+           AND IFNULL(line, -1) = IFNULL(?, -1)
+           AND IFNULL(col, -1) = IFNULL(?, -1)`,
+      ).run(
+        winner.metadata ? canonicalString(winner.metadata) : null,
+        winner.provenance ?? null,
+        winner.confidence ?? 1,
+        winner.resolutionMethod ?? null,
+        canonicalString(mergedEdgeEvidence(existing, edge)),
+        edge.source,
+        edge.target,
+        edge.kind,
+        edge.line ?? null,
+        edge.column ?? null,
+      );
+      return false;
+    }
+
+    const result = this.db
       .prepare(
-        `INSERT INTO edges (source, target, kind, metadata, line, col, provenance)
-         SELECT ?,?,?,?,?,?,?
+        `INSERT INTO edges (
+           source, target, kind, metadata, line, col, provenance,
+           confidence, resolution_method, evidence
+         ) SELECT ?,?,?,?,?,?,?,?,?,?
          WHERE EXISTS (SELECT 1 FROM nodes WHERE id = ?)
            AND EXISTS (SELECT 1 FROM nodes WHERE id = ?)`,
       )
@@ -219,21 +374,39 @@ export class GraphStore {
         edge.source,
         edge.target,
         edge.kind,
-        edge.metadata ? JSON.stringify(edge.metadata) : null,
+        edge.metadata ? canonicalString(edge.metadata) : null,
         edge.line ?? null,
         edge.column ?? null,
         edge.provenance ?? null,
+        edge.confidence ?? 1,
+        edge.resolutionMethod ?? null,
+        canonicalString(mergedEdgeEvidence(edge, edge)),
         edge.source,
         edge.target,
       );
+    return result.changes > 0;
   }
 
   upsertFile(file: FileRecord): void {
     this.db
       .prepare(
-        `INSERT OR REPLACE INTO files (
-           path, content_hash, language, size, modified_at, indexed_at, node_count
-         ) VALUES (?,?,?,?,?,?,?)`,
+        `INSERT INTO files (
+           path, content_hash, language, size, modified_at, indexed_at, node_count,
+           errors, parse_status, diagnostic_count, missing_count, error_coverage, extractor_version
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON CONFLICT(path) DO UPDATE SET
+           content_hash = excluded.content_hash,
+           language = excluded.language,
+           size = excluded.size,
+           modified_at = excluded.modified_at,
+           indexed_at = excluded.indexed_at,
+           node_count = excluded.node_count,
+           errors = excluded.errors,
+           parse_status = excluded.parse_status,
+           diagnostic_count = excluded.diagnostic_count,
+           missing_count = excluded.missing_count,
+           error_coverage = excluded.error_coverage,
+           extractor_version = excluded.extractor_version`,
       )
       .run(
         file.path,
@@ -243,6 +416,12 @@ export class GraphStore {
         file.modifiedAt,
         file.indexedAt,
         file.nodeCount,
+        file.errors ? JSON.stringify(file.errors) : null,
+        file.parseStatus ?? "ok",
+        file.diagnosticCount ?? 0,
+        file.missingCount ?? 0,
+        file.errorCoverage ?? 0,
+        file.extractorVersion ?? "tree-sitter",
       );
   }
 
@@ -250,10 +429,23 @@ export class GraphStore {
     this.db
       .prepare(
         `INSERT INTO unresolved_refs (
-           from_node_id, reference_name, reference_kind, line, col, candidates, file_path, language
-         ) VALUES (?,?,?,?,?,?,?,?)`,
+           ref_key, from_node_id, reference_name, reference_kind, line, col,
+           candidates, file_path, language, receiver, qualifier, import_source,
+           metadata, status, target_id, confidence, resolver
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON CONFLICT(ref_key) DO UPDATE SET
+           candidates = excluded.candidates,
+           receiver = excluded.receiver,
+           qualifier = excluded.qualifier,
+           import_source = excluded.import_source,
+           metadata = excluded.metadata,
+           status = excluded.status,
+           target_id = excluded.target_id,
+           confidence = excluded.confidence,
+           resolver = excluded.resolver`,
       )
       .run(
+        ref.refKey ?? referenceKey(ref),
         ref.fromNodeId,
         ref.referenceName,
         ref.referenceKind,
@@ -262,13 +454,188 @@ export class GraphStore {
         ref.candidates ? JSON.stringify(ref.candidates) : null,
         ref.filePath,
         ref.language,
+        ref.receiver ?? null,
+        ref.qualifier ?? null,
+        ref.importSource ?? null,
+        ref.metadata ? JSON.stringify(ref.metadata) : null,
+        ref.status ?? "pending",
+        ref.targetId ?? null,
+        ref.confidence ?? null,
+        ref.resolver ?? null,
       );
+  }
+
+  updateReferenceResolution(ref: UnresolvedRefRecord): void {
+    const key = ref.refKey ?? referenceKey(ref);
+    this.db.prepare(
+      `UPDATE unresolved_refs SET status = ?, target_id = ?, confidence = ?, resolver = ?, candidates = ?
+       WHERE ref_key = ?`,
+    ).run(
+      ref.status ?? "unresolved", ref.targetId ?? null, ref.confidence ?? null,
+      ref.resolver ?? null, ref.candidates ? JSON.stringify(ref.candidates) : null, key,
+    );
+  }
+
+  insertImportBinding(binding: ImportBindingRecord): void {
+    this.db.prepare(
+      `INSERT INTO import_bindings (
+         binding_key, file_path, local_name, imported_name, module_specifier,
+         resolved_file_path, target_id, is_type_only, metadata
+       ) VALUES (?,?,?,?,?,?,?,?,?)
+       ON CONFLICT(binding_key) DO UPDATE SET
+         resolved_file_path = excluded.resolved_file_path,
+         target_id = excluded.target_id,
+         metadata = excluded.metadata`,
+    ).run(
+      binding.bindingKey, binding.filePath, binding.localName, binding.importedName,
+      binding.moduleSpecifier, binding.resolvedFilePath ?? null, binding.targetId ?? null,
+      binding.isTypeOnly ? 1 : 0, binding.metadata ? JSON.stringify(binding.metadata) : null,
+    );
+  }
+
+  insertAlias(aliasId: string, canonicalNodeId: string, matchMethod: string, confidence: number): boolean {
+    if (aliasId === canonicalNodeId) return false;
+    return this.db.prepare(
+      `INSERT INTO node_aliases (alias_id, canonical_node_id, match_method, confidence, created_at)
+       SELECT ?,?,?,?,? WHERE EXISTS (SELECT 1 FROM nodes WHERE id = ?)
+       ON CONFLICT(alias_id) DO UPDATE SET
+         canonical_node_id = excluded.canonical_node_id,
+         match_method = excluded.match_method,
+         confidence = excluded.confidence`,
+    ).run(aliasId, canonicalNodeId, matchMethod, confidence, Date.now(), canonicalNodeId).changes > 0;
+  }
+
+  /** Replace one file's overlapping source windows and contentless FTS rows. */
+  replaceSourceChunks(filePath: string, source: string, contentHash: string): number {
+    this.deleteSourceChunks(filePath);
+    const lines = source.split("\n");
+    const windowSize = 80;
+    const stride = 60;
+    let count = 0;
+    for (let offset = 0; offset < Math.max(1, lines.length); offset += stride) {
+      const chunk = lines.slice(offset, offset + windowSize);
+      if (chunk.length === 0) break;
+      const text = chunk.join("\n");
+      const startLine = offset + 1;
+      const endLine = offset + chunk.length;
+      const pathTerms = splitIndexTerms(filePath).join(" ");
+      const identifierTerms = splitIndexTerms(text).join(" ");
+      const commentTerms = chunk.filter(isCommentLine).join(" ");
+      const inserted = this.db.prepare(
+        `INSERT INTO source_chunks (
+           file_path, start_line, end_line, content_hash, path_terms, identifier_terms, comment_terms
+         ) VALUES (?,?,?,?,?,?,?)`,
+      ).run(filePath, startLine, endLine, contentHash, pathTerms, identifierTerms, commentTerms);
+      this.db.prepare(
+        `INSERT INTO source_chunks_fts (
+           rowid, path_terms, identifier_terms, comment_terms, source_text
+         ) VALUES (?,?,?,?,?)`,
+      ).run(inserted.lastInsertRowid, pathTerms, identifierTerms, commentTerms, text);
+      count++;
+      if (endLine >= lines.length) break;
+    }
+    return count;
+  }
+
+  deleteSourceChunks(filePath: string): void {
+    const rows = this.db.prepare("SELECT id FROM source_chunks WHERE file_path = ?").all(filePath) as Array<{ id: number }>;
+    for (const row of rows) this.db.prepare("DELETE FROM source_chunks_fts WHERE rowid = ?").run(row.id);
+    this.db.prepare("DELETE FROM source_chunks WHERE file_path = ?").run(filePath);
+  }
+
+  searchSourceChunks(query: string, limit = 40): SourceChunkHit[] {
+    const terms = planGraphQuery(query).terms.slice(0, 32);
+    if (terms.length === 0) return [];
+    const fused = new Map<number, SourceChunkHit & { rrf: number }>();
+    for (const term of terms) {
+      const escaped = term.term.replaceAll('"', '');
+      const match = term.term.length <= 3 ? `"${escaped}"` : `"${escaped}"*`;
+      const rows = this.db.prepare(
+        `SELECT c.id, c.file_path, c.start_line, c.end_line, c.content_hash,
+                bm25(source_chunks_fts, 4, 2, 1, 3) AS rank
+         FROM source_chunks_fts JOIN source_chunks c ON c.id = source_chunks_fts.rowid
+         WHERE source_chunks_fts MATCH ? ORDER BY rank, c.file_path, c.start_line LIMIT ?`,
+      ).all(match, Math.max(20, limit)) as Array<{
+        id: number; file_path: string; start_line: number; end_line: number; content_hash: string; rank: number;
+      }>;
+      rows.forEach((row, index) => {
+        const current = fused.get(row.id) ?? {
+          id: row.id, filePath: row.file_path, startLine: row.start_line,
+          endLine: row.end_line, contentHash: row.content_hash, rank: 0,
+          matchedTerms: [], rrf: 0,
+        };
+        current.rrf += term.weight / (60 + index + 1);
+        current.matchedTerms.push(term.term);
+        fused.set(row.id, current);
+      });
+    }
+    return [...fused.values()]
+      .sort((left, right) => right.rrf - left.rrf || left.filePath.localeCompare(right.filePath) || left.startLine - right.startLine)
+      .slice(0, limit)
+      .map(({ rrf, ...hit }) => {
+        const nodeIds = this.sourceChunkNodeIds(hit.filePath, hit.startLine, hit.endLine);
+        return {
+          ...hit,
+          rank: -rrf,
+          matchedTerms: [...new Set(hit.matchedTerms)].sort(),
+          ...(nodeIds.length > 0 ? { nodeIds } : {}),
+        };
+      });
+  }
+
+  private sourceChunkNodeIds(filePath: string, startLine: number, endLine: number): string[] {
+    const kindPlaceholders = SOURCE_CHUNK_NODE_KINDS.map(() => "?").join(",");
+    const primaryPlaceholders = SOURCE_CHUNK_PRIMARY_KINDS.map(() => "?").join(",");
+    const rows = this.db.prepare(
+      `SELECT id FROM nodes
+       WHERE file_path = ?
+         AND start_line <= ? AND end_line >= ?
+         AND kind IN (${kindPlaceholders})
+         AND trim(name) <> '' AND name NOT LIKE '<%'
+       ORDER BY
+         CASE WHEN kind IN (${primaryPlaceholders}) THEN 0 ELSE 1 END,
+         (min(end_line, ?) - max(start_line, ?) + 1) DESC,
+         (end_line - start_line) ASC,
+         start_line ASC,
+         end_line ASC,
+         id ASC
+       LIMIT ?`,
+    ).all(
+      filePath, endLine, startLine,
+      ...SOURCE_CHUNK_NODE_KINDS,
+      ...SOURCE_CHUNK_PRIMARY_KINDS,
+      endLine, startLine,
+      SOURCE_CHUNK_NODE_LIMIT,
+    ) as Array<{ id: string }>;
+    return rows.map((row) => row.id);
   }
 
   /** Delete all nodes for a file (ON DELETE CASCADE clears their edges +
    *  unresolved refs). Used by `sync` before re-indexing a changed file. */
   deleteNodesByFile(filePath: string): void {
     this.db.prepare("DELETE FROM nodes WHERE file_path = ?").run(filePath);
+  }
+
+  deleteFile(filePath: string): void {
+    this.deleteSourceChunks(filePath);
+    this.db.prepare("DELETE FROM import_bindings WHERE file_path = ?").run(filePath);
+    this.db.prepare("DELETE FROM files WHERE path = ?").run(filePath);
+    this.deleteNodesByFile(filePath);
+  }
+
+  /** Clear only derived graph/index rows; authored grounding snapshots survive. */
+  clearDerivedGraph(): void {
+    this.db.exec("DELETE FROM source_chunks_fts");
+    this.db.exec("DELETE FROM source_chunks");
+    this.db.exec("DELETE FROM import_bindings");
+    this.db.exec("DELETE FROM node_aliases");
+    // Clear fingerprint dependents in bulk before deleting nodes. Relying on
+    // the node FK cascade here makes SQLite scan the large LSH table once per
+    // node because its lookup index is band-oriented rather than node-oriented.
+    this.db.exec("DELETE FROM lsh_buckets");
+    this.db.exec("DELETE FROM node_fingerprints");
+    this.db.exec("DELETE FROM nodes");
+    this.db.exec("DELETE FROM files");
   }
 
   /** Wipe every reference edge (keeping intra-file `contains`), so `sync` can
@@ -280,7 +647,12 @@ export class GraphStore {
   // --- Reads ----------------------------------------------------------------
 
   getNodeById(id: string): GraphNode | null {
-    const row = this.db.prepare("SELECT * FROM nodes WHERE id = ?").get(id) as
+    const row = this.db.prepare(
+      `SELECT nodes.* FROM nodes WHERE nodes.id = ?
+       UNION ALL
+       SELECT nodes.* FROM node_aliases JOIN nodes ON nodes.id = node_aliases.canonical_node_id
+       WHERE node_aliases.alias_id = ? LIMIT 1`,
+    ).get(id, id) as
       | NodeRow
       | undefined;
     return row ? rowToNode(row) : null;
@@ -290,8 +662,39 @@ export class GraphStore {
     return (this.db.prepare("SELECT * FROM nodes").all() as NodeRow[]).map(rowToNode);
   }
 
+  /**
+   * Bulk edge read for corpus-wide consumers such as fingerprint generation.
+   * Keeping this as one indexed query avoids an incoming + outgoing SQL pair
+   * for every node while preserving the same edge decoding as point reads.
+   */
+  getAllEdges(kinds?: readonly EdgeKind[]): GraphEdge[] {
+    if (kinds && kinds.length > 0) {
+      const placeholders = kinds.map(() => "?").join(",");
+      return (this.db.prepare(
+        `SELECT * FROM edges WHERE kind IN (${placeholders}) ORDER BY source, target, kind, id`,
+      ).all(...kinds) as EdgeRow[]).map(rowToEdge);
+    }
+    return (this.db.prepare(
+      "SELECT * FROM edges ORDER BY source, target, kind, id",
+    ).all() as EdgeRow[]).map(rowToEdge);
+  }
+
+  getAllAliases(): NodeAliasRecord[] {
+    return (this.db.prepare(
+      "SELECT alias_id, canonical_node_id, match_method, confidence FROM node_aliases ORDER BY alias_id",
+    ).all() as Array<{
+      alias_id: string; canonical_node_id: string; match_method: string; confidence: number;
+    }>).map((row) => ({
+      aliasId: row.alias_id,
+      canonicalNodeId: row.canonical_node_id,
+      matchMethod: row.match_method,
+      confidence: row.confidence,
+    }));
+  }
+
   getAllUnresolvedRefs(): UnresolvedRefRecord[] {
     const rows = this.db.prepare("SELECT * FROM unresolved_refs").all() as Array<{
+      ref_key: string;
       from_node_id: string;
       reference_name: string;
       reference_kind: string;
@@ -300,8 +703,17 @@ export class GraphStore {
       candidates: string | null;
       file_path: string;
       language: string;
+      receiver: string | null;
+      qualifier: string | null;
+      import_source: string | null;
+      metadata: string | null;
+      status: "pending" | "resolved" | "ambiguous" | "unresolved";
+      target_id: string | null;
+      confidence: number | null;
+      resolver: string | null;
     }>;
     return rows.map((r) => ({
+      refKey: r.ref_key,
       fromNodeId: r.from_node_id,
       referenceName: r.reference_name,
       referenceKind: r.reference_kind as ReferenceKind,
@@ -310,6 +722,14 @@ export class GraphStore {
       candidates: parseJson<string[]>(r.candidates),
       filePath: r.file_path,
       language: r.language as Language,
+      receiver: r.receiver ?? undefined,
+      qualifier: r.qualifier ?? undefined,
+      importSource: r.import_source ?? undefined,
+      metadata: parseJson<Record<string, unknown>>(r.metadata),
+      status: r.status,
+      targetId: r.target_id ?? undefined,
+      confidence: r.confidence ?? undefined,
+      resolver: r.resolver ?? undefined,
     }));
   }
 
@@ -323,6 +743,12 @@ export class GraphStore {
           modified_at: number;
           indexed_at: number;
           node_count: number;
+          errors: string | null;
+          parse_status: "ok" | "partial" | "failed";
+          diagnostic_count: number;
+          missing_count: number;
+          error_coverage: number;
+          extractor_version: string;
         }
       | undefined;
     if (!row) return null;
@@ -334,7 +760,69 @@ export class GraphStore {
       modifiedAt: row.modified_at,
       indexedAt: row.indexed_at,
       nodeCount: row.node_count,
+      errors: parseJson<Array<Record<string, unknown>>>(row.errors),
+      parseStatus: row.parse_status,
+      diagnosticCount: row.diagnostic_count,
+      missingCount: row.missing_count,
+      errorCoverage: row.error_coverage,
+      extractorVersion: row.extractor_version,
     };
+  }
+
+  getAllFileRecords(): FileRecord[] {
+    const rows = this.db.prepare("SELECT path FROM files ORDER BY path").all() as Array<{ path: string }>;
+    return rows.map((row) => this.getFileRecord(row.path)).filter((row): row is FileRecord => row !== null);
+  }
+
+  getHealthSummary(): GraphHealthSummary {
+    const row = this.db.prepare(
+      `SELECT COUNT(*) AS indexed,
+              SUM(CASE WHEN parse_status = 'ok' THEN 1 ELSE 0 END) AS ok,
+              SUM(CASE WHEN parse_status = 'partial' THEN 1 ELSE 0 END) AS partial,
+              SUM(CASE WHEN parse_status = 'failed' THEN 1 ELSE 0 END) AS failed
+       FROM files`,
+    ).get() as { indexed: number; ok: number | null; partial: number | null; failed: number | null };
+    return {
+      indexedFiles: row.indexed,
+      okFiles: row.ok ?? 0,
+      partialFiles: row.partial ?? 0,
+      failedFiles: row.failed ?? 0,
+    };
+  }
+
+  setMetadata(key: string, value: string): void {
+    this.db.prepare(
+      `INSERT INTO project_metadata (key, value, updated_at) VALUES (?,?,?)
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    ).run(key, value, Date.now());
+  }
+
+  getMetadata(key: string): string | null {
+    const row = this.db.prepare("SELECT value FROM project_metadata WHERE key = ?").get(key) as
+      | { value: string }
+      | undefined;
+    return row?.value ?? null;
+  }
+
+  validateInvariants(expectedNodes?: number): { nodes: number; duplicateEdges: number; danglingEdges: number } {
+    const nodes = (this.db.prepare("SELECT COUNT(*) AS count FROM nodes").get() as { count: number }).count;
+    const duplicateEdges = (this.db.prepare(
+      `SELECT COUNT(*) AS count FROM (
+         SELECT 1 FROM edges GROUP BY source,target,kind,IFNULL(line,-1),IFNULL(col,-1) HAVING COUNT(*) > 1
+       )`,
+    ).get() as { count: number }).count;
+    const danglingEdges = (this.db.prepare(
+      `SELECT COUNT(*) AS count FROM edges e
+       LEFT JOIN nodes s ON s.id=e.source LEFT JOIN nodes t ON t.id=e.target
+       WHERE s.id IS NULL OR t.id IS NULL`,
+    ).get() as { count: number }).count;
+    if (expectedNodes !== undefined && nodes !== expectedNodes) {
+      throw new Error(`Graph invariant failed: emitted ${expectedNodes} nodes but stored ${nodes}.`);
+    }
+    if (duplicateEdges > 0 || danglingEdges > 0) {
+      throw new Error(`Graph invariant failed: ${duplicateEdges} duplicate and ${danglingEdges} dangling edges.`);
+    }
+    return { nodes, duplicateEdges, danglingEdges };
   }
 
   getIncomingEdges(targetId: string, kinds?: EdgeKind[]): GraphEdge[] {
@@ -393,11 +881,10 @@ export class GraphStore {
     options: { kinds?: NodeKind[]; languages?: Language[]; limit?: number } = {},
   ): GraphNode[] {
     const { kinds, languages, limit = 100 } = options;
-    const ftsQuery = query
-      .replace(/[."'*():^-]/g, " ")
-      .split(/\s+/)
-      .filter((t) => t.length > 0 && !/^(AND|OR|NOT|NEAR)$/i.test(t))
-      .map((t) => `"${t}"*`)
+    const plan = planGraphQuery(query);
+    const searchableTerms = [...new Set(plan.terms.map((entry) => entry.term))];
+    const ftsQuery = searchableTerms
+      .map((term) => `"${term.replaceAll('"', '')}"*`)
       .join(" OR ");
 
     const filterSql: string[] = [];
@@ -412,31 +899,116 @@ export class GraphStore {
     }
     const filterClause = filterSql.length > 0 ? ` AND ${filterSql.join(" AND ")}` : "";
 
-    let rows: NodeRow[] = [];
+    const fetchLimit = Math.max(100, limit * 5);
+    const candidates = new Map<string, { row: NodeRow; ftsRank?: number; exact: boolean }>();
     if (ftsQuery) {
       // bm25 column weights bias toward name matches over incidental docstring
       // mentions. bm25 returns negative scores (more negative = better).
-      rows = this.db
+      const rows = this.db
         .prepare(
-          `SELECT nodes.* FROM nodes_fts
+          `SELECT nodes.*, bm25(nodes_fts, 0, 20, 5, 1, 2) AS fts_rank FROM nodes_fts
              JOIN nodes ON nodes_fts.id = nodes.id
              WHERE nodes_fts MATCH ?${filterClause}
-             ORDER BY bm25(nodes_fts, 0, 20, 5, 1, 2), nodes.id LIMIT ?`,
+             ORDER BY fts_rank, nodes.id LIMIT ?`,
         )
-        .all(ftsQuery, ...filterParams, limit) as NodeRow[];
+        .all(ftsQuery, ...filterParams, fetchLimit) as Array<NodeRow & { fts_rank: number }>;
+      rows.forEach((row, index) => candidates.set(row.id, { row, ftsRank: index, exact: false }));
     }
 
-    if (rows.length === 0 && query.trim().length >= 2) {
-      const like = `%${query.trim()}%`;
-      rows = this.db
-        .prepare(
-          `SELECT * FROM nodes
-             WHERE (name LIKE ? OR qualified_name LIKE ?)${filterClause}
-             ORDER BY length(name), name, id LIMIT ?`,
-        )
-        .all(like, like, ...filterParams, limit) as NodeRow[];
+    // Exact declarations are a separate retrieval channel. They must not be
+    // allowed to fall below an FTS fetch cut because their signatures are short.
+    const exactTerms = [...new Set([
+      ...plan.explicitIdentifiers.map((entry) => entry.toLowerCase()),
+      ...plan.terms.filter((entry) => !entry.stem).map((entry) => entry.term),
+    ])].slice(0, 24);
+    if (exactTerms.length > 0) {
+      const placeholders = exactTerms.map(() => "?").join(",");
+      const rows = this.db.prepare(
+        `SELECT * FROM nodes WHERE lower(name) IN (${placeholders})${filterClause}
+         ORDER BY length(name), name, id LIMIT ?`,
+      ).all(...exactTerms, ...filterParams, fetchLimit) as NodeRow[];
+      for (const row of rows) {
+        const current = candidates.get(row.id);
+        candidates.set(row.id, { row, ftsRank: current?.ftsRank, exact: true });
+      }
     }
 
-    return rows.map(rowToNode);
+    // FTS prefix matching cannot see `ledger` inside `BudgetLedger`. Always
+    // supplement it with component/substring candidates; doing this only when
+    // FTS returned zero is what previously made incidental signature hits win.
+    const componentTerms = [...new Set(plan.terms
+      .filter((entry) => entry.term.length >= 3 && !entry.stem)
+      .map((entry) => entry.term))]
+      .slice(0, 16);
+    if (componentTerms.length > 0) {
+      const clauses = componentTerms.map(() => "(lower(name) LIKE ? OR lower(qualified_name) LIKE ?)");
+      const patterns = componentTerms.flatMap((term) => [`%${term}%`, `%${term}%`]);
+      const rows = this.db.prepare(
+        `SELECT * FROM nodes WHERE (${clauses.join(" OR ")})${filterClause}
+         ORDER BY length(name), name, id LIMIT ?`,
+      ).all(...patterns, ...filterParams, fetchLimit) as NodeRow[];
+      for (const row of rows) {
+        if (!candidates.has(row.id)) candidates.set(row.id, { row, exact: false });
+      }
+    }
+
+    const totalWeight = plan.terms.reduce((sum, entry) => sum + entry.weight, 0) || 1;
+    const kindWeight: Partial<Record<NodeKind, number>> = {
+      function: 1, method: 1, class: 0.95, interface: 0.9, trait: 0.9,
+      component: 0.9, route: 0.9, struct: 0.85, type_alias: 0.75,
+      enum: 0.65, constant: 0.45, variable: 0.35, property: 0.3,
+      field: 0.3, file: 0.15, parameter: 0.1, import: 0.05, export: 0.05,
+    };
+    const explicit = new Set(plan.explicitIdentifiers.map((entry) => entry.toLowerCase()));
+    const scored = [...candidates.values()].map((candidate) => {
+      const node = rowToNode(candidate.row);
+      const name = node.name.toLowerCase();
+      const qualified = node.qualifiedName.toLowerCase();
+      const signature = node.signature?.toLowerCase() ?? "";
+      const docstring = node.docstring?.toLowerCase() ?? "";
+      const components = new Set(identifierComponents(node.name));
+      let matchedWeight = 0;
+      for (const entry of plan.terms) {
+        if (components.has(entry.term) || name.includes(entry.term) || qualified.includes(entry.term)) {
+          matchedWeight += entry.weight;
+        } else if (docstring.includes(entry.term)) {
+          matchedWeight += entry.weight * 0.65;
+        } else if (signature.includes(entry.term)) {
+          matchedWeight += entry.weight * 0.45;
+        }
+      }
+      const coverage = Math.min(1, matchedWeight / totalWeight);
+      const fts = candidate.ftsRank === undefined ? 0 : 1 / Math.log2(candidate.ftsRank + 2);
+      const explicitExact = explicit.has(name) || explicit.has(qualified) ? 1 : 0;
+      const exact = candidate.exact ? 1 : 0;
+      let score = explicitExact * 4 + coverage * 2.4 + fts * 1.2 + exact * 0.35 + (kindWeight[node.kind] ?? 0.2);
+      if (!plan.asksForTests && isLowValueGraphPath(node.filePath)) score *= 0.12;
+      return { node, score };
+    });
+
+    return scored
+      .sort((left, right) => right.score - left.score || left.node.id.localeCompare(right.node.id))
+      .slice(0, limit)
+      .map((entry) => entry.node);
   }
+}
+
+function referenceKey(ref: UnresolvedRefRecord): string {
+  const material = [
+    ref.filePath, ref.fromNodeId, ref.referenceKind, ref.referenceName,
+    ref.receiver ?? "", ref.qualifier ?? "", ref.line ?? 0, ref.column ?? 0,
+  ].join("\0");
+  return `ref:${createHash("sha256").update(material).digest("hex").slice(0, 32)}`;
+}
+
+function splitIndexTerms(value: string): string[] {
+  const terms = new Set<string>();
+  for (const token of value.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? []) {
+    for (const component of identifierComponents(token)) terms.add(component);
+  }
+  return [...terms];
+}
+
+function isCommentLine(line: string): boolean {
+  return /^\s*(?:\/\/|\/\*|\*|#|<!--)/.test(line);
 }

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -748,9 +748,13 @@ function createCompatibilityAliases(
   const freshIds = new Set(fresh.map((node) => node.id));
   const freshById = new Map(fresh.map((node) => [node.id, node]));
   const byQualified = groupUnique(fresh, (node) => `${node.filePath}\0${node.kind}\0${node.qualifiedName}`);
+  const oldBySignature = groupUnique(
+    oldNodes.filter((node) => normalizedSignature(node.signature).length > 0),
+    compatibilitySignatureKey,
+  );
   const bySignature = groupUnique(
     fresh.filter((node) => normalizedSignature(node.signature).length > 0),
-    (node) => `${node.kind}\0${normalizedSignature(node.signature)}`,
+    compatibilitySignatureKey,
   );
   const byBody = groupUnique(fresh.filter((node) => node.bodyHash), (node) => `${node.kind}\0${node.bodyHash}`);
   const canonicalMap = new Map<string, string>();
@@ -760,8 +764,10 @@ function createCompatibilityAliases(
       continue;
     }
     const qualified = byQualified.get(`${old.filePath}\0${old.kind}\0${old.qualifiedName}`);
-    const signatureKey = normalizedSignature(old.signature);
-    const signature = signatureKey ? bySignature.get(`${old.kind}\0${signatureKey}`) : undefined;
+    const signatureKey = normalizedSignature(old.signature) ? compatibilitySignatureKey(old) : undefined;
+    const oldSignature = signatureKey ? oldBySignature.get(signatureKey) : undefined;
+    const signature = oldSignature?.length === 1 && signatureKey
+      ? bySignature.get(signatureKey) : undefined;
     const body = old.bodyHash ? byBody.get(`${old.kind}\0${old.bodyHash}`) : undefined;
     const match = qualified?.length === 1 ? { node: qualified[0]!, method: "qualified-name", confidence: 1 }
       : signature?.length === 1 ? { node: signature[0]!, method: "signature", confidence: 0.98 }
@@ -779,6 +785,11 @@ function createCompatibilityAliases(
 
 function normalizedSignature(signature: string | undefined): string {
   return signature?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+/** Signature-only moves require the same unambiguous symbol in both snapshots. */
+function compatibilitySignatureKey(node: GraphNode): string {
+  return `${node.kind}\0${node.name}\0${normalizedSignature(node.signature)}`;
 }
 
 function fingerprintAliasMatch(

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -1,353 +1,96 @@
-// ============================================================================
-// mex code-graph — GraphEngine implementation  (Track A)
-// ============================================================================
-//
-// The real engine behind the FROZEN `GraphEngine` interface (`./engine.ts`). It
-// ties the pieces together: discover source files → parse+extract (A1) → assign
-// body_hash/updatedAt → persist (A3) → resolve cross-file references (A4). Reads
-// are plain synchronous SQL; build/sync are async only because they lazy-load
-// tree-sitter WASM grammars (the deliberate sync/async split — spec §6).
-//
-// It implements EXACTLY the frozen surface and nothing more. Fingerprints,
-// reconciliation and grounding are Track B and layer on TOP of this — they are
-// not part of this class.
-
 import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { globSync } from "glob";
 import { toPosix } from "../paths.js";
-import type { GraphEdge, GraphNode, Language } from "./types.js";
 import type { BuildResult, GraphEngine, NodeSearchOptions } from "./engine.js";
-import { openGraphDatabase } from "./db/database.js";
-import { GraphStore, type FileRecord, type UnresolvedRefRecord } from "./db/store.js";
+import { DB_SCHEMA_VERSION, markGraphReady, openGraphDatabase } from "./db/database.js";
+import {
+  GraphStore,
+  type FileRecord,
+  type ImportBindingRecord,
+  type NodeAliasRecord,
+  type UnresolvedRefRecord,
+} from "./db/store.js";
 import type { SqliteDatabase } from "./db/sqlite.js";
 import {
+  buildTypeScriptExtraction,
+  canonicalNodeIdentity,
   detectLanguage,
   extractFile,
+  grammarManifestHash,
   isSupportedSourceFile,
   loadGrammars,
   normalizedAstTokens,
+  normalizedCompilerTokens,
   SUPPORTED_SOURCE_GLOB,
+  TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
+  TYPESCRIPT_COMPILER_VERSION,
+  type CompilerExtractedNode,
+  type CompilerExtractionResult,
+  type CompilerFileExtraction,
 } from "./extraction/index.js";
-import { resolveReferences } from "./resolution/resolver.js";
-import { createResolutionContext } from "./resolution/context.js";
-import { FRAMEWORK_RESOLVERS } from "./resolution/frameworks/index.js";
-import { getCallees, getCallers } from "./traversal/traversal.js";
 import { FingerprintStore } from "./fingerprint-store.js";
-import { createFingerprint } from "./fingerprint.js";
+import { createFingerprintBuilder } from "./fingerprint.js";
+import { MIN_TOKENS } from "./config.js";
+import { minhashJaccard } from "./reconcile-engine.js";
+import type { Fingerprint } from "./reconcile.js";
+import { createStagedResolutionContext } from "./resolution/context.js";
+import { FRAMEWORK_RESOLVERS } from "./resolution/frameworks/index.js";
+import { resolveReferences } from "./resolution/resolver.js";
+import { getCallees, getCallers, getIncoming, getOutgoing } from "./traversal/traversal.js";
+import type { GraphEdge, GraphNode, Language, ReferenceKind } from "./types.js";
 
-/** Directories never worth indexing. */
 const IGNORE_GLOBS = [
-  "**/node_modules/**",
-  "**/.git/**",
-  "**/dist/**",
-  "**/build/**",
-  "**/.mex/**",
-  "**/coverage/**",
-  "**/.next/**",
-  "**/out/**",
+  "**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**", "**/.mex/**",
+  "**/coverage/**", "**/.next/**", "**/out/**",
 ];
 
-/** Kinds whose `body_hash` is the drift trigger (spec §3). Others stay null. */
 const BODY_KINDS = new Set<GraphNode["kind"]>([
-  "function",
-  "method",
-  "class",
-  "interface",
-  "enum",
-  "type_alias",
-  "struct",
-  "trait",
-  "protocol",
-  "constant",
-  "variable",
-  "component",
+  "function", "method", "class", "interface", "enum", "type_alias", "struct",
+  "trait", "protocol", "constant", "variable", "component",
 ]);
 
+const COMPILER_LANGUAGES = new Set<Language>(["typescript", "javascript", "tsx", "jsx"]);
+const RESOLVER_VERSION = "compiler-first-v2";
+const TREE_SITTER_EXTRACTOR_VERSION = "tree-sitter-v2";
+const CORPUS_EXTRACTOR_VERSION = `${TYPESCRIPT_COMPILER_EXTRACTOR_VERSION}+${TREE_SITTER_EXTRACTOR_VERSION}`;
+
 export interface GraphEngineOptions {
-  /** Project root to index. */
   rootDir: string;
-  /** Path to the SQLite DB file (defaults to `<rootDir>/.mex/graph.db`). */
   dbPath?: string;
+  /** Query-only engine for sandboxed agent commands. Build/sync are unavailable. */
+  readOnly?: boolean;
+  /** Injectable source-file access for embedders and deterministic fault tests. */
+  sourceFileAccess?: Partial<GraphSourceFileAccess>;
 }
 
-class GraphEngineImpl implements GraphEngine {
-  private readonly rootDir: string;
-  private readonly dbPath: string;
-  private db: SqliteDatabase | null = null;
-  private store: GraphStore | null = null;
+export interface GraphSourceFileAccess {
+  stat(absolutePath: string): { size: number; mtimeMs: number };
+  read(absolutePath: string): string;
+}
 
-  constructor(options: GraphEngineOptions) {
-    this.rootDir = resolve(options.rootDir);
-    this.dbPath = options.dbPath ?? resolve(this.rootDir, ".mex", "graph.db");
-  }
+export interface GraphSourceStagingFailure {
+  filePath: string;
+  operation: "stat" | "read" | "discover";
+  code?: string;
+  message: string;
+}
 
-  /** Lazily open (creating if needed) the DB + store. Shared by reads & writes. */
-  private getStore(): GraphStore {
-    if (!this.store) {
-      this.db = openGraphDatabase(this.dbPath);
-      this.store = new GraphStore(this.db);
-    }
-    return this.store;
-  }
+/** A structural sync never publishes a corpus whose source discovery was incomplete. */
+export class GraphSourceStagingError extends Error {
+  readonly code = "GRAPH_SOURCE_STAGING_FAILED";
 
-  // --- Build / sync (async: lazy-load grammars) -----------------------------
-
-  async build(rootDir?: string): Promise<BuildResult> {
-    const started = Date.now();
-    const root = rootDir ? resolve(rootDir) : this.rootDir;
-    const files = discoverSourceFiles(root);
-
-    // Load grammars for exactly the languages present (lazy — spec §7).
-    const languages = new Set<Language>(files.map((f) => detectLanguage(f.relPath)));
-    await loadGrammars([...languages]);
-
-    const store = this.getStore();
-
-    // Full rebuild: clear existing graph rows (CASCADE clears edges + refs).
-    store.transaction(() => {
-      this.db!.exec("DELETE FROM nodes");
-      this.db!.exec("DELETE FROM files");
-    });
-
-    let nodesCreated = 0;
-    let containsEdges = 0;
-    store.transaction(() => {
-      for (const file of files) {
-        const result = this.indexFile(store, file);
-        nodesCreated += result.nodes;
-        containsEdges += result.contains;
-      }
-    });
-
-    this.extractFrameworkNodes(store, root, files.map((file) => file.relPath));
-    // Second pass: bind every parked cross-file/framework reference to a node id.
-    const refEdges = this.resolveAll(store, root);
-    this.refreshFingerprints(store, root);
-    // Insurance for the external-content FTS table: the trigger-safe writes
-    // above maintain it incrementally, then rebuild from the final node state.
-    store.rebuildSearchIndex();
-
-    return {
-      filesIndexed: files.length,
-      nodesCreated,
-      edgesCreated: containsEdges + refEdges,
-      durationMs: Date.now() - started,
-    };
-  }
-
-  async sync(changedFiles: string[]): Promise<BuildResult> {
-    const started = Date.now();
-    const store = this.getStore();
-
-    // Normalize to project-relative posix paths and keep only source files.
-    const rels = changedFiles
-      .map((f) => toPosix(relative(this.rootDir, resolve(this.rootDir, f))))
-      .filter((rel) => rel && !rel.startsWith("..") && isSupportedSourceFile(rel));
-
-    const languages = new Set<Language>(rels.map((rel) => detectLanguage(rel)));
-    await loadGrammars([...languages]);
-
-    let nodesCreated = 0;
-    store.transaction(() => {
-      for (const rel of rels) {
-        const abs = resolve(this.rootDir, rel);
-        let stat;
-        try {
-          stat = statSync(abs);
-        } catch {
-          // File was deleted — drop its nodes (CASCADE clears edges/refs).
-          store.deleteNodesByFile(rel);
-          continue;
-        }
-        // Replace the file's nodes wholesale (line-independent ids mean a body
-        // edit keeps the same id, so INCOMING edges from unchanged files survive
-        // the re-resolve below).
-        store.deleteNodesByFile(rel);
-        nodesCreated += this.indexFile(store, {
-          relPath: rel,
-          source: readFileSync(abs, "utf-8"),
-          size: stat.size,
-          modifiedAt: stat.mtimeMs,
-        }).nodes;
-      }
-    });
-
-    this.extractFrameworkNodes(store, this.rootDir, rels);
-    // Rebuild ALL reference edges from unresolved_refs (contains edges untouched)
-    // so incoming edges cascade-cleared by the delete above are restored.
-    store.clearReferenceEdges();
-    const refEdges = this.resolveAll(store, this.rootDir);
-    this.refreshFingerprints(store, this.rootDir);
-
-    return {
-      filesIndexed: rels.length,
-      nodesCreated,
-      edgesCreated: refEdges,
-      durationMs: Date.now() - started,
-    };
-  }
-
-  /** Extract + persist one file's nodes, contains edges, and unresolved refs. */
-  private indexFile(
-    store: GraphStore,
-    file: { relPath: string; source: string; size: number; modifiedAt: number },
-  ): { nodes: number; contains: number } {
-    const now = Date.now();
-    const extraction = extractFile(file.relPath, file.source);
-    const language = extraction?.language ?? detectLanguage(file.relPath);
-
-    // Always record the file (even with zero symbols) so change detection and
-    // graceful degradation know it was seen.
-    const record: FileRecord = {
-      path: file.relPath,
-      contentHash: sha256(file.source),
-      language,
-      size: file.size,
-      modifiedAt: file.modifiedAt,
-      indexedAt: now,
-      nodeCount: extraction?.nodes.length ?? 0,
-    };
-    store.upsertFile(record);
-    if (!extraction) return { nodes: 0, contains: 0 };
-
-    const sourceLines = file.source.split("\n");
-
-    for (const extracted of extraction.nodes) {
-      const node: GraphNode = {
-        ...extracted,
-        bodyHash: BODY_KINDS.has(extracted.kind)
-          ? bodyHash(sourceLines, extracted.startLine, extracted.endLine)
-          : undefined,
-        updatedAt: now,
-      };
-      store.insertNode(node);
-    }
-
-    let contains = 0;
-    for (const edge of extraction.edges) {
-      if (edge.target) {
-        // Fully-resolved intra-file edge (contains) — persist directly.
-        store.insertEdge(edge as GraphEdge);
-        contains++;
-      } else if (edge.targetName) {
-        // Cross-file candidate — park for the resolution pass.
-        const ref: UnresolvedRefRecord = {
-          fromNodeId: edge.source,
-          referenceName: edge.targetName,
-          referenceKind: edge.kind,
-          filePath: file.relPath,
-          language,
-          line: edge.line,
-          column: edge.column,
-          candidates: edge.candidates,
-        };
-        store.insertUnresolvedRef(ref);
-      }
-    }
-    return { nodes: extraction.nodes.length, contains };
-  }
-
-  /** Resolve every parked reference to a node id and persist the edges. */
-  private resolveAll(store: GraphStore, root: string): number {
-    const nodes = store.getAllNodes();
-    const refs = store.getAllUnresolvedRefs();
-    const context = createResolutionContext(store, root);
-    const resolvers = FRAMEWORK_RESOLVERS.filter((resolver) => resolver.detect(context));
-    const edges = resolveReferences(nodes, refs, { resolvers, context });
-    store.transaction(() => {
-      for (const edge of edges) store.insertEdge(edge);
-    });
-    return edges.length;
-  }
-
-  /** Run optional framework extraction after language nodes exist. */
-  private extractFrameworkNodes(store: GraphStore, root: string, filePaths: readonly string[]): void {
-    const context = createResolutionContext(store, root);
-    const resolvers = FRAMEWORK_RESOLVERS.filter((resolver) => resolver.detect(context));
-    for (const filePath of filePaths) {
-      let content: string;
-      try { content = readFileSync(resolve(root, filePath), "utf-8"); } catch { continue; }
-      const language = detectLanguage(filePath);
-      for (const resolver of resolvers) {
-        if (!resolver.extract || (resolver.languages && !resolver.languages.includes(language))) continue;
-        const extracted = resolver.extract(filePath, content);
-        for (const node of extracted.nodes) {
-          store.insertNode(node);
-          const fileNode = store.getNodeById(`file:${filePath}`);
-          if (fileNode) store.insertEdge({ source: fileNode.id, target: node.id, kind: "contains", provenance: "heuristic" });
-        }
-        for (const ref of extracted.references) {
-          store.insertUnresolvedRef({
-            fromNodeId: ref.fromNodeId,
-            referenceName: ref.referenceName,
-            referenceKind: ref.referenceKind,
-            filePath: ref.filePath,
-            language: ref.language,
-            line: ref.line,
-            column: ref.column,
-            candidates: ref.candidates,
-          });
-        }
-      }
-    }
-  }
-
-  /** Refresh every body-bearing node after resolution so neighbor ids are final. */
-  private refreshFingerprints(store: GraphStore, root: string): void {
-    const fingerprints = new FingerprintStore(this.db!);
-    const byFile = new Map<string, GraphNode[]>();
-    for (const node of store.getAllNodes().filter((entry) => entry.bodyHash)) {
-      const nodes = byFile.get(node.filePath) ?? [];
-      nodes.push(node);
-      byFile.set(node.filePath, nodes);
-    }
-    for (const [filePath, nodes] of byFile) {
-      let source: string;
-      try { source = readFileSync(resolve(root, filePath), "utf-8"); } catch { continue; }
-      const tokens = normalizedAstTokens(filePath, source, nodes);
-      for (const node of nodes) {
-        const callers = getCallers(store, node.id).map((entry) => entry.id);
-        const callees = getCallees(store, node.id).map((entry) => entry.id);
-        fingerprints.upsert(node.id, createFingerprint(tokens.get(node.id) ?? [], callers, callees));
-      }
-    }
-  }
-
-  // --- Reads (synchronous SQL — no grammar work) ----------------------------
-
-  searchNodes(query: string, options?: NodeSearchOptions): GraphNode[] {
-    return this.getStore().search(query, options);
-  }
-
-  getNode(id: string): GraphNode | null {
-    return this.getStore().getNodeById(id);
-  }
-
-  getCallers(id: string): GraphNode[] {
-    return getCallers(this.getStore(), id);
-  }
-
-  getCallees(id: string): GraphNode[] {
-    return getCallees(this.getStore(), id);
-  }
-
-  close(): void {
-    if (this.db) this.db.close();
-    this.db = null;
-    this.store = null;
+  constructor(readonly failures: GraphSourceStagingFailure[]) {
+    super(`Could not stage ${failures.length} source file(s): ${failures.map((failure) => failure.filePath).join(", ")}`);
+    this.name = "GraphSourceStagingError";
   }
 }
 
-/** Create the real {@link GraphEngine}. The public factory Track B / Phase 2 use. */
-export function createGraphEngine(options: GraphEngineOptions): GraphEngine {
-  return new GraphEngineImpl(options);
-}
-
-// ----------------------------------------------------------------------------
-// Helpers
-// ----------------------------------------------------------------------------
+const NODE_SOURCE_FILE_ACCESS: GraphSourceFileAccess = {
+  stat: (absolutePath) => statSync(absolutePath),
+  read: (absolutePath) => readFileSync(absolutePath, "utf-8"),
+};
 
 interface DiscoveredFile {
   relPath: string;
@@ -356,46 +99,827 @@ interface DiscoveredFile {
   modifiedAt: number;
 }
 
-/** Every indexable source file under `root`, as project-relative posix paths. */
-function discoverSourceFiles(root: string): DiscoveredFile[] {
-  const matches = globSync(SUPPORTED_SOURCE_GLOB, {
-    cwd: root,
-    ignore: IGNORE_GLOBS,
-    nodir: true,
-    absolute: false,
-    dot: false,
-  });
-  const files: DiscoveredFile[] = [];
-  for (const rel of matches) {
-    const posix = toPosix(rel);
-    if (!isSupportedSourceFile(posix)) continue;
-    const abs = resolve(root, rel);
-    try {
-      const stat = statSync(abs);
-      files.push({
-        relPath: posix,
-        source: readFileSync(abs, "utf-8"),
-        size: stat.size,
-        modifiedAt: stat.mtimeMs,
-      });
-    } catch {
-      // Unreadable (race / permissions) — skip; never crash a build (spec §7).
-    }
-  }
-  return files;
+interface StagedFile {
+  discovered: DiscoveredFile;
+  record: FileRecord;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  references: UnresolvedRefRecord[];
+  imports: ImportBindingRecord[];
+  compilerNodes?: CompilerExtractedNode[];
 }
 
-function sha256(text: string): string {
-  return createHash("sha256").update(text).digest("hex");
+interface StagedCorpus {
+  files: StagedFile[];
+  compiler: CompilerExtractionResult;
+  fingerprints: Array<{ nodeId: string; fingerprint: Fingerprint }>;
+  manifestHash: string;
+  configHash: string;
+  grammarHash: string;
+}
+
+export interface GraphManifest {
+  manifestHash: string;
+  configHash: string;
+  grammarHash: string;
+}
+
+class GraphEngineImpl implements GraphEngine {
+  private readonly rootDir: string;
+  private readonly dbPath: string;
+  private readonly readOnly: boolean;
+  private readonly sourceFileAccess: GraphSourceFileAccess;
+  private db: SqliteDatabase | null = null;
+  private store: GraphStore | null = null;
+
+  constructor(options: GraphEngineOptions) {
+    this.rootDir = resolve(options.rootDir);
+    this.dbPath = options.dbPath ?? resolve(this.rootDir, ".mex", "graph.db");
+    this.readOnly = options.readOnly ?? false;
+    this.sourceFileAccess = { ...NODE_SOURCE_FILE_ACCESS, ...options.sourceFileAccess };
+  }
+
+  private getStore(allowRebuild = false): GraphStore {
+    if (!this.store) {
+      this.db = openGraphDatabase(this.dbPath, { allowRebuild, readOnly: this.readOnly });
+      this.store = new GraphStore(this.db);
+    }
+    return this.store;
+  }
+
+  async build(rootDir?: string): Promise<BuildResult> {
+    if (this.readOnly) throw new Error("A read-only graph engine cannot build an index.");
+    const started = Date.now();
+    const root = rootDir ? resolve(rootDir) : this.rootDir;
+    const staged = await stageCorpus(root, undefined, this.sourceFileAccess);
+    const result = this.publish(staged);
+    return { ...result, durationMs: Date.now() - started };
+  }
+
+  async sync(changedFiles: string[]): Promise<BuildResult> {
+    if (this.readOnly) throw new Error("A read-only graph engine cannot synchronize an index.");
+    const started = Date.now();
+    const changed = [...new Set(changedFiles.map((file) =>
+      toPosix(relative(this.rootDir, resolve(this.rootDir, file))),
+    ).filter((file) => file && !file.startsWith("..")))].sort();
+    const changedSources = changed.filter(isSupportedSourceFile);
+    const deletedChangedSources = inspectChangedSources(this.rootDir, changedSources, this.sourceFileAccess);
+    const manifest = graphManifest(this.rootDir);
+    const manifestChanged = this.getStore(true).getMetadata("manifest_hash") !== manifest.manifestHash;
+    if (changedSources.length === 0 && !manifestChanged) {
+      return { filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: Date.now() - started };
+    }
+
+    // Re-stage the whole semantic corpus. This makes an arbitrary sync sequence
+    // converge to the same graph as a clean build and re-resolves cross-file refs.
+    const staged = await stageCorpus(this.rootDir, manifest, this.sourceFileAccess);
+    const stagedByPath = new Map(staged.files.map((file) => [file.record.path, file]));
+    const unstagedExisting = changedSources.filter((file) => (
+      !deletedChangedSources.has(file) && !stagedByPath.has(file)
+    ));
+    if (unstagedExisting.length > 0) {
+      throw new GraphSourceStagingError(unstagedExisting.map((filePath) => ({
+        filePath,
+        operation: "discover",
+        message: "The changed source still exists but was absent from the staged corpus.",
+      })));
+    }
+    const failedChanged = changedSources.filter((file) => stagedByPath.get(file)?.record.parseStatus === "failed");
+    if (failedChanged.length > 0) {
+      // Preserve the previous structural snapshot. Scope notices changed hashes
+      // and can still return the live files as explicitly text-only evidence.
+      const health = healthCounts(staged.files);
+      return {
+        filesIndexed: 0, nodesCreated: 0, edgesCreated: 0,
+        durationMs: Date.now() - started, health,
+      };
+    }
+    const result = this.publish(staged);
+    return { ...result, durationMs: Date.now() - started };
+  }
+
+  private publish(staged: StagedCorpus): Omit<BuildResult, "durationMs"> {
+    const store = this.getStore(true);
+    const oldNodes = store.getAllNodes();
+    const oldAliases = store.getAllAliases();
+    const priorFingerprintStore = new FingerprintStore(this.db!);
+    const oldFingerprints = new Map<string, Fingerprint>();
+    for (const node of oldNodes) {
+      const fingerprint = priorFingerprintStore.get(node.id);
+      if (fingerprint) oldFingerprints.set(node.id, fingerprint);
+    }
+    let edgeCount = 0;
+    const expectedNodes = staged.files.reduce((count, file) => count + file.nodes.length, 0);
+
+    store.transaction(() => {
+      store.clearDerivedGraph();
+      for (const file of staged.files) {
+        store.upsertFile(file.record);
+        store.replaceSourceChunks(file.record.path, file.discovered.source, file.record.contentHash);
+      }
+      for (const file of staged.files) for (const node of file.nodes) store.insertNode(node);
+      for (const file of staged.files) {
+        for (const edge of file.edges) if (store.insertEdge(edge)) edgeCount++;
+        for (const reference of file.references) store.insertUnresolvedRef(reference);
+        for (const binding of file.imports) store.insertImportBinding(binding);
+      }
+
+      new FingerprintStore(this.db!).upsertMany(staged.fingerprints);
+      createCompatibilityAliases(
+        store, oldNodes, oldAliases, oldFingerprints, new FingerprintStore(this.db!),
+      );
+      store.rebuildSearchIndex();
+      store.validateInvariants(expectedNodes);
+      store.setMetadata("compiler_version", staged.compiler.compilerVersion);
+      store.setMetadata("extractor_version", CORPUS_EXTRACTOR_VERSION);
+      store.setMetadata("resolver_version", RESOLVER_VERSION);
+      store.setMetadata("config_hash", staged.configHash);
+      store.setMetadata("grammar_hash", staged.grammarHash);
+      markGraphReady(this.db!, staged.manifestHash);
+    });
+
+    return {
+      filesIndexed: staged.files.length,
+      nodesCreated: expectedNodes,
+      edgesCreated: edgeCount,
+      health: healthCounts(staged.files),
+    };
+  }
+
+  searchNodes(query: string, options?: NodeSearchOptions): GraphNode[] {
+    return this.getStore().search(query, options);
+  }
+
+  searchSource(query: string, limit = 40) {
+    return this.getStore().searchSourceChunks(query, limit).map(({ id: _id, ...hit }) => hit);
+  }
+
+  getIndexedFiles() {
+    return this.getStore().getAllFileRecords().map((file) => ({
+      path: file.path,
+      contentHash: file.contentHash,
+      parseStatus: file.parseStatus ?? "ok",
+      diagnosticCount: file.diagnosticCount ?? 0,
+      errorCoverage: file.errorCoverage ?? 0,
+      nodeCount: file.nodeCount,
+    }));
+  }
+
+  getNode(id: string): GraphNode | null { return this.getStore().getNodeById(id); }
+  getCallers(id: string): GraphNode[] { return getCallers(this.getStore(), id); }
+  getCallees(id: string): GraphNode[] { return getCallees(this.getStore(), id); }
+  getIncoming(id: string, kinds?: GraphEdge["kind"][]) { return getIncoming(this.getStore(), id, kinds); }
+  getOutgoing(id: string, kinds?: GraphEdge["kind"][]) { return getOutgoing(this.getStore(), id, kinds); }
+
+  close(): void {
+    if (this.db) this.db.close();
+    this.db = null;
+    this.store = null;
+  }
+}
+
+export function createGraphEngine(options: GraphEngineOptions): GraphEngine {
+  return new GraphEngineImpl(options);
+}
+
+async function stageCorpus(
+  root: string,
+  manifest = graphManifest(root),
+  sourceFileAccess: GraphSourceFileAccess = NODE_SOURCE_FILE_ACCESS,
+): Promise<StagedCorpus> {
+  const discovered = discoverSourceFiles(root, sourceFileAccess);
+  const compilerPaths = discovered.filter((file) => COMPILER_LANGUAGES.has(detectLanguage(file.relPath)))
+    .map((file) => file.relPath);
+  const compiler = buildTypeScriptExtraction(root, compilerPaths);
+  const compilerByPath = new Map(compiler.files.map((file) => [file.filePath, file]));
+  const treeLanguages = [...new Set(discovered.map((file) => detectLanguage(file.relPath))
+    .filter((language) => !COMPILER_LANGUAGES.has(language)))];
+  await loadGrammars(treeLanguages);
+
+  const files = discovered.map((file) => {
+    const compilerFile = compilerByPath.get(file.relPath);
+    return compilerFile ? stageCompilerFile(file, compilerFile) : stageTreeFile(file);
+  });
+  stageFrameworkAndFallbackResolution(root, files);
+  validateStagedCorpus(files);
+  const fingerprints = stageFingerprints(files);
+  return { files, compiler, fingerprints, ...manifest };
+}
+
+function stageFrameworkAndFallbackResolution(root: string, files: StagedFile[]): void {
+  const sourceByPath = new Map(files.map((file) => [file.record.path, file.discovered.source]));
+  const initialNodes = files.flatMap((file) => file.nodes);
+  const detectionContext = createStagedResolutionContext(initialNodes, root, sourceByPath);
+  const resolvers = FRAMEWORK_RESOLVERS.filter((resolver) => resolver.detect(detectionContext));
+  const fileNodeByPath = new Map(initialNodes
+    .filter((node) => node.kind === "file")
+    .map((node) => [node.filePath, node]));
+
+  for (const file of files) {
+    if (file.record.parseStatus !== "ok") continue;
+    const language = detectLanguage(file.record.path);
+    for (const resolver of resolvers) {
+      if (!resolver.extract || (resolver.languages && !resolver.languages.includes(language))) continue;
+      const extracted = resolver.extract(file.record.path, file.discovered.source);
+      for (const rawNode of extracted.nodes) {
+        const node: GraphNode = {
+          ...rawNode,
+          identityKey: rawNode.identityKey ?? canonicalNodeIdentity(
+            rawNode.filePath, rawNode.kind, rawNode.qualifiedName,
+            `framework:${resolver.name}`, rawNode.signature,
+          ),
+        };
+        file.nodes.push(node);
+        const fileNode = fileNodeByPath.get(file.record.path);
+        if (fileNode) file.edges.push({
+          source: fileNode.id,
+          target: node.id,
+          kind: "contains",
+          line: node.startLine,
+          confidence: 0.8,
+          provenance: "framework",
+          resolutionMethod: resolver.name,
+          evidence: [{ wiringSite: { filePath: file.record.path, line: node.startLine } }],
+        });
+      }
+      for (const ref of extracted.references) {
+        const wiringSite = {
+          filePath: ref.filePath,
+          line: ref.line === undefined ? undefined : ref.line + 1,
+          column: ref.column,
+        };
+        const explicitTargets = file.imports
+          .filter((binding) => binding.localName === ref.referenceName && binding.targetId)
+          .map((binding) => binding.targetId!)
+          .filter((id, index, values) => values.indexOf(id) === index);
+        const explicitTarget = ref.referenceKind === "function_ref" && explicitTargets.length === 1
+          ? explicitTargets[0]
+          : undefined;
+        const resolverName = resolver.name === "express" ? "express-route-handler" : resolver.name;
+        const stagedRef: UnresolvedRefRecord = {
+          ...ref,
+          line: wiringSite.line,
+          resolver: explicitTarget ? resolverName : resolver.name,
+          status: explicitTarget ? "resolved" : "pending",
+          targetId: explicitTarget,
+          confidence: 0.8,
+          candidates: explicitTarget ? [explicitTarget] : ref.candidates,
+          metadata: { wiringSite, ...(explicitTarget ? { importBinding: ref.referenceName } : {}) },
+        };
+        file.references.push(stagedRef);
+        if (explicitTarget) file.edges.push({
+          source: ref.fromNodeId,
+          target: explicitTarget,
+          kind: "references",
+          line: wiringSite.line,
+          column: wiringSite.column,
+          confidence: 0.8,
+          provenance: "framework",
+          resolutionMethod: resolverName,
+          evidence: [{ resolver: resolverName, wiringSite, importBinding: ref.referenceName }],
+        });
+      }
+    }
+    file.record.nodeCount = file.nodes.length;
+  }
+
+  const nodes = files.flatMap((file) => file.nodes);
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const context = createStagedResolutionContext(nodes, root, sourceByPath);
+  const refs = files.flatMap((file) => file.references).filter((ref) =>
+    ref.status !== "resolved"
+    && !ref.resolver?.startsWith("typescript-")
+    && ref.resolver !== "lexical-containment",
+  );
+  const resolvedEdges = resolveReferences(nodes, refs, { resolvers, context });
+  hydrateFallbackImportBindings(files, nodes, nodeById);
+  const fileByPath = new Map(files.map((file) => [file.record.path, file]));
+  for (const edge of resolvedEdges) {
+    const source = nodeById.get(edge.source);
+    const stagedFile = source ? fileByPath.get(source.filePath) : undefined;
+    if (stagedFile) stagedFile.edges.push(edge);
+  }
 }
 
 /**
- * body_hash = sha256 of the node's normalized body. Line-independent id means a
- * SAME-id node whose body_hash MOVED is a real edit → drift. Normalization
- * (collapse whitespace) keeps reindentation from reading as a change.
+ * Fallback resolvers prove module ownership while resolving import references.
+ * Persist that proof on each binding too: namespace imports target the file
+ * node, while a uniquely named imported declaration targets the declaration.
  */
+function hydrateFallbackImportBindings(
+  files: readonly StagedFile[],
+  nodes: readonly GraphNode[],
+  nodeById: ReadonlyMap<string, GraphNode>,
+): void {
+  const symbolsByFileAndName = new Map<string, GraphNode[]>();
+  for (const node of nodes) {
+    if (node.kind === "file") continue;
+    const key = `${node.filePath}\0${node.name}`;
+    const bucket = symbolsByFileAndName.get(key) ?? [];
+    bucket.push(node);
+    symbolsByFileAndName.set(key, bucket);
+  }
+  for (const file of files) {
+    for (const binding of file.imports) {
+      if (binding.resolvedFilePath || binding.targetId) continue;
+      const imported = file.references.find((reference) =>
+        reference.referenceKind === "imports"
+        && reference.referenceName === binding.moduleSpecifier
+        && fallbackBindings(reference).some((candidate) =>
+          candidate.localName === binding.localName && candidate.importedName === binding.importedName),
+      );
+      const targetFile = imported?.targetId ? nodeById.get(imported.targetId) : undefined;
+      if (!targetFile || targetFile.kind !== "file") continue;
+      binding.resolvedFilePath = targetFile.filePath;
+      if (binding.importedName === "*") {
+        binding.targetId = targetFile.id;
+        continue;
+      }
+      const candidates = symbolsByFileAndName.get(`${targetFile.filePath}\0${binding.importedName}`) ?? [];
+      if (candidates.length === 1) binding.targetId = candidates[0]!.id;
+    }
+  }
+}
+
+function validateStagedCorpus(files: readonly StagedFile[]): void {
+  const nodes = files.flatMap((file) => file.nodes);
+  const ids = new Set<string>();
+  const identities = new Set<string>();
+  for (const node of nodes) {
+    if (ids.has(node.id)) throw new Error(`Graph staging invariant failed: duplicate node id ${node.id}.`);
+    ids.add(node.id);
+    if (!node.identityKey) throw new Error(`Graph staging invariant failed: ${node.id} has no identity key.`);
+    if (identities.has(node.identityKey)) {
+      throw new Error(`Graph staging invariant failed: duplicate identity key for ${node.id}.`);
+    }
+    identities.add(node.identityKey);
+  }
+  for (const file of files) {
+    if (file.record.nodeCount !== file.nodes.length) {
+      throw new Error(`Graph staging invariant failed: ${file.record.path} emitted ${file.nodes.length} nodes but reported ${file.record.nodeCount}.`);
+    }
+    if (file.record.parseStatus === "failed" && file.nodes.length > 0) {
+      throw new Error(`Graph staging invariant failed: failed file ${file.record.path} emitted graph claims.`);
+    }
+    for (const node of file.nodes) {
+      if (node.containerId && !ids.has(node.containerId)) {
+        throw new Error(`Graph staging invariant failed: dangling container ${node.containerId}.`);
+      }
+    }
+    for (const edge of file.edges) {
+      if (!ids.has(edge.source) || !ids.has(edge.target)) {
+        throw new Error(`Graph staging invariant failed: dangling ${edge.kind} edge ${edge.source} -> ${edge.target}.`);
+      }
+    }
+    for (const ref of file.references) {
+      if (!ids.has(ref.fromNodeId)) {
+        throw new Error(`Graph staging invariant failed: dangling reference source ${ref.fromNodeId}.`);
+      }
+      if (ref.targetId && !ids.has(ref.targetId)) {
+        throw new Error(`Graph staging invariant failed: dangling reference target ${ref.targetId}.`);
+      }
+    }
+    for (const binding of file.imports) {
+      if (binding.targetId && !ids.has(binding.targetId)) {
+        throw new Error(`Graph staging invariant failed: dangling import target ${binding.targetId}.`);
+      }
+    }
+  }
+}
+
+function stageFingerprints(staged: readonly StagedFile[]): Array<{ nodeId: string; fingerprint: Fingerprint }> {
+  const fingerprintBuilder = createFingerprintBuilder();
+  const pending: Array<{ nodeId: string; fingerprint: Fingerprint }> = [];
+  const callersByTarget = new Map<string, Set<string>>();
+  const calleesBySource = new Map<string, Set<string>>();
+  for (const edge of staged.flatMap((file) => file.edges).filter((edge) => edge.kind === "calls")) {
+    const callers = callersByTarget.get(edge.target) ?? new Set<string>();
+    callers.add(edge.source);
+    callersByTarget.set(edge.target, callers);
+    const callees = calleesBySource.get(edge.source) ?? new Set<string>();
+    callees.add(edge.target);
+    calleesBySource.set(edge.source, callees);
+  }
+  for (const file of staged) {
+    const nodes = file.nodes.filter((node) => node.bodyHash);
+    if (nodes.length === 0) continue;
+    const nodeIds = new Set(nodes.map((node) => node.id));
+    const compilerNodes = file.compilerNodes?.filter((node) => nodeIds.has(node.id));
+    const tokens = compilerNodes && compilerNodes.length > 0
+      ? normalizedCompilerTokens(file.discovered.source, compilerNodes)
+      : normalizedAstTokens(file.record.path, file.discovered.source, nodes);
+    for (const node of nodes) {
+      pending.push({
+        nodeId: node.id,
+        fingerprint: fingerprintBuilder.create(
+          tokens.get(node.id) ?? [],
+          [...(callersByTarget.get(node.id) ?? [])],
+          [...(calleesBySource.get(node.id) ?? [])],
+        ),
+      });
+    }
+  }
+  return pending;
+}
+
+function stageCompilerFile(discovered: DiscoveredFile, extraction: CompilerFileExtraction): StagedFile {
+  const now = Date.now();
+  const lines = discovered.source.split("\n");
+  const nodes: GraphNode[] = extraction.nodes.map((node) => ({
+    id: node.id,
+    identityKey: node.identityKey,
+    containerId: node.containerId,
+    kind: node.kind,
+    name: node.name,
+    qualifiedName: node.qualifiedName,
+    filePath: node.filePath,
+    language: node.language,
+    startLine: node.startLine,
+    endLine: node.endLine,
+    startColumn: node.startColumn,
+    endColumn: node.endColumn,
+    docstring: node.docstring,
+    signature: node.signature,
+    visibility: node.visibility,
+    isExported: node.isExported,
+    isAsync: node.isAsync,
+    isStatic: node.isStatic,
+    isAbstract: node.isAbstract,
+    decorators: node.decorators,
+    typeParameters: node.typeParameters,
+    returnType: node.returnType,
+    bodyHash: BODY_KINDS.has(node.kind) ? bodyHash(lines, node.startLine, node.endLine) : undefined,
+    updatedAt: now,
+  }));
+  const edges: GraphEdge[] = [];
+  const references: UnresolvedRefRecord[] = [];
+  for (const ref of extraction.references) {
+    const reference: UnresolvedRefRecord = {
+      refKey: ref.id,
+      fromNodeId: ref.sourceId,
+      referenceName: ref.targetName,
+      referenceKind: ref.kind as ReferenceKind,
+      filePath: ref.filePath,
+      language: extraction.language,
+      line: ref.line + 1,
+      column: ref.column,
+      candidates: ref.candidates,
+      receiver: ref.receiver,
+      qualifier: ref.qualifier,
+      metadata: ref.evidence,
+      status: ref.status,
+      targetId: ref.targetId,
+      confidence: ref.confidence,
+      resolver: ref.resolutionMethod,
+    };
+    references.push(reference);
+    if (ref.status === "resolved" && ref.targetId) {
+      edges.push({
+        source: ref.sourceId,
+        target: ref.targetId,
+        kind: ref.kind,
+        metadata: { targetName: ref.targetName, targetQualifiedName: ref.targetQualifiedName },
+        line: ref.line + 1,
+        column: ref.column,
+        provenance: ref.provenance,
+        confidence: ref.confidence,
+        resolutionMethod: ref.resolutionMethod,
+        evidence: [ref.evidence],
+      });
+    }
+  }
+  const imports: ImportBindingRecord[] = extraction.importBindings.map((binding) => ({
+    bindingKey: binding.id,
+    filePath: binding.filePath,
+    localName: binding.localName,
+    importedName: binding.importedName,
+    moduleSpecifier: binding.moduleSpecifier,
+    resolvedFilePath: binding.resolvedFilePath,
+    targetId: binding.targetId,
+    isTypeOnly: binding.isTypeOnly,
+    metadata: {
+      isNamespace: binding.isNamespace, isDefault: binding.isDefault,
+      line: binding.line + 1, column: binding.column,
+      confidence: binding.confidence, resolutionMethod: binding.resolutionMethod,
+    },
+  }));
+  return {
+    discovered,
+    record: {
+      path: discovered.relPath,
+      contentHash: sha256(discovered.source),
+      language: extraction.language,
+      size: discovered.size,
+      modifiedAt: discovered.modifiedAt,
+      indexedAt: now,
+      nodeCount: nodes.length,
+      // File health describes whether structural graph claims are trustworthy.
+      // Semantic type errors are useful compiler observations, but treating them
+      // as parse/extraction loss makes healthy real-world repositories look
+      // corrupt (and would trigger unnecessary agent fallbacks).
+      errors: extraction.health.diagnostics
+        .slice(0, extraction.health.syntacticDiagnosticCount)
+        .map((diagnostic) => ({ ...diagnostic })),
+      parseStatus: extraction.health.status,
+      diagnosticCount: extraction.health.syntacticDiagnosticCount,
+      missingCount: 0,
+      errorCoverage: extraction.health.diagnosticByteCoverage,
+      extractorVersion: TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
+    },
+    nodes,
+    edges,
+    references,
+    imports,
+    compilerNodes: extraction.nodes,
+  };
+}
+
+function stageTreeFile(discovered: DiscoveredFile): StagedFile {
+  const now = Date.now();
+  const extraction = extractFile(discovered.relPath, discovered.source);
+  const language = extraction?.language ?? detectLanguage(discovered.relPath);
+  const health = extraction?.health ?? {
+    status: "failed" as const, diagnosticCount: 1, missingCount: 0, errorCoverage: 1,
+    diagnostics: [{ type: "PARSER_UNAVAILABLE", startLine: 1, endLine: 1 }],
+  };
+  const containsParents = new Map<string, string>();
+  for (const edge of extraction?.edges ?? []) {
+    if (edge.kind === "contains" && edge.target) containsParents.set(edge.target, edge.source);
+  }
+  const lines = discovered.source.split("\n");
+  const nodes: GraphNode[] = (extraction?.nodes ?? []).map((node) => ({
+    ...node,
+    containerId: containsParents.get(node.id),
+    identityKey: node.identityKey
+      ?? canonicalNodeIdentity(node.filePath, node.kind, node.qualifiedName, node.kind, node.signature),
+    bodyHash: BODY_KINDS.has(node.kind) ? bodyHash(lines, node.startLine, node.endLine) : undefined,
+    updatedAt: now,
+  }));
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const edges: GraphEdge[] = [];
+  const references: UnresolvedRefRecord[] = [];
+  for (const edge of extraction?.edges ?? []) {
+    if (edge.target) {
+      edges.push({
+        source: edge.source, target: edge.target, kind: edge.kind as GraphEdge["kind"],
+        line: edge.kind === "contains" ? byId.get(edge.target)?.startLine : edge.line === undefined ? undefined : edge.line + 1,
+        column: edge.column, metadata: edge.metadata, provenance: "tree-sitter",
+        confidence: 1, resolutionMethod: edge.kind === "contains" ? "lexical-containment" : "tree-sitter",
+      });
+    } else if (edge.targetName) {
+      const dot = edge.targetName.lastIndexOf(".");
+      references.push({
+        fromNodeId: edge.source,
+        referenceName: edge.targetName,
+        referenceKind: edge.kind,
+        filePath: discovered.relPath,
+        language,
+        line: edge.line === undefined ? undefined : edge.line + 1,
+        column: edge.column,
+        candidates: edge.candidates,
+        receiver: dot > 0 ? edge.targetName.slice(0, dot) : undefined,
+        qualifier: dot > 0 ? edge.targetName.slice(0, dot) : undefined,
+        metadata: edge.metadata,
+        status: "pending",
+        resolver: "tree-sitter",
+      });
+    }
+  }
+  const imports: ImportBindingRecord[] = references
+    .filter((reference) => reference.referenceKind === "imports")
+    .flatMap((reference) => fallbackBindings(reference).map((binding) => ({
+      bindingKey: `import:${sha256([
+        reference.filePath, binding.localName, binding.importedName, reference.referenceName,
+      ].join("\0")).slice(0, 32)}`,
+      filePath: reference.filePath,
+      localName: binding.localName,
+      importedName: binding.importedName,
+      moduleSpecifier: reference.referenceName,
+      isTypeOnly: false,
+      metadata: {
+        line: reference.line,
+        column: reference.column,
+        confidence: 1,
+        resolutionMethod: "explicit-import",
+      },
+    })));
+  return {
+    discovered,
+    record: {
+      path: discovered.relPath,
+      contentHash: sha256(discovered.source),
+      language,
+      size: discovered.size,
+      modifiedAt: discovered.modifiedAt,
+      indexedAt: now,
+      nodeCount: nodes.length,
+      errors: health.diagnostics.map((diagnostic) => ({ ...diagnostic })),
+      parseStatus: health.status,
+      diagnosticCount: health.diagnosticCount,
+      missingCount: health.missingCount,
+      errorCoverage: health.errorCoverage,
+      extractorVersion: TREE_SITTER_EXTRACTOR_VERSION,
+    },
+    nodes,
+    edges,
+    references,
+    imports,
+  };
+}
+
+function fallbackBindings(reference: UnresolvedRefRecord): Array<{ localName: string; importedName: string }> {
+  const bindings = reference.metadata?.bindings;
+  if (!Array.isArray(bindings)) return [];
+  return bindings.filter((binding): binding is { localName: string; importedName: string } => {
+    if (!binding || typeof binding !== "object") return false;
+    const candidate = binding as Record<string, unknown>;
+    return typeof candidate.localName === "string" && typeof candidate.importedName === "string";
+  });
+}
+
+function createCompatibilityAliases(
+  store: GraphStore,
+  oldNodes: GraphNode[],
+  oldAliases: NodeAliasRecord[],
+  oldFingerprints: ReadonlyMap<string, Fingerprint>,
+  freshFingerprints: FingerprintStore,
+): void {
+  const fresh = store.getAllNodes();
+  const freshIds = new Set(fresh.map((node) => node.id));
+  const freshById = new Map(fresh.map((node) => [node.id, node]));
+  const byQualified = groupUnique(fresh, (node) => `${node.filePath}\0${node.kind}\0${node.qualifiedName}`);
+  const bySignature = groupUnique(
+    fresh.filter((node) => normalizedSignature(node.signature).length > 0),
+    (node) => `${node.kind}\0${normalizedSignature(node.signature)}`,
+  );
+  const byBody = groupUnique(fresh.filter((node) => node.bodyHash), (node) => `${node.kind}\0${node.bodyHash}`);
+  const canonicalMap = new Map<string, string>();
+  for (const old of oldNodes) {
+    if (freshIds.has(old.id)) {
+      canonicalMap.set(old.id, old.id);
+      continue;
+    }
+    const qualified = byQualified.get(`${old.filePath}\0${old.kind}\0${old.qualifiedName}`);
+    const signatureKey = normalizedSignature(old.signature);
+    const signature = signatureKey ? bySignature.get(`${old.kind}\0${signatureKey}`) : undefined;
+    const body = old.bodyHash ? byBody.get(`${old.kind}\0${old.bodyHash}`) : undefined;
+    const match = qualified?.length === 1 ? { node: qualified[0]!, method: "qualified-name", confidence: 1 }
+      : signature?.length === 1 ? { node: signature[0]!, method: "signature", confidence: 0.98 }
+      : body?.length === 1 ? { node: body[0]!, method: "body-hash", confidence: 0.95 }
+      : fingerprintAliasMatch(old, oldFingerprints.get(old.id), freshFingerprints, freshById);
+    if (!match) continue;
+    store.insertAlias(old.id, match.node.id, match.method, match.confidence);
+    canonicalMap.set(old.id, match.node.id);
+  }
+  for (const alias of oldAliases) {
+    const canonical = canonicalMap.get(alias.canonicalNodeId);
+    if (canonical) store.insertAlias(alias.aliasId, canonical, alias.matchMethod, alias.confidence);
+  }
+}
+
+function normalizedSignature(signature: string | undefined): string {
+  return signature?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+function fingerprintAliasMatch(
+  old: GraphNode,
+  baseline: Fingerprint | undefined,
+  freshFingerprints: FingerprintStore,
+  freshById: ReadonlyMap<string, GraphNode>,
+): { node: GraphNode; method: string; confidence: number } | null {
+  if (!baseline || baseline.tokenCount < MIN_TOKENS) return null;
+  const scored = freshFingerprints.lookup(baseline)
+    .filter((candidate) => freshById.get(candidate.nodeId)?.kind === old.kind)
+    .map((candidate) => ({
+      ...candidate,
+      node: freshById.get(candidate.nodeId)!,
+      score: minhashJaccard(baseline.minhash, candidate.fingerprint.minhash),
+    }))
+    .sort((left, right) => right.score - left.score || left.nodeId.localeCompare(right.nodeId));
+  const best = scored[0];
+  if (!best || best.score < 0.95) return null;
+  const runnerUp = scored[1];
+  if (runnerUp && best.score - runnerUp.score < 0.08) return null;
+  return { node: best.node, method: "fingerprint", confidence: best.score };
+}
+
+function groupUnique<T>(values: T[], key: (value: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>();
+  for (const value of values) {
+    const bucket = grouped.get(key(value)) ?? [];
+    bucket.push(value);
+    grouped.set(key(value), bucket);
+  }
+  return grouped;
+}
+
+function inspectChangedSources(
+  root: string,
+  changedSources: readonly string[],
+  sourceFileAccess: GraphSourceFileAccess,
+): Set<string> {
+  const deleted = new Set<string>();
+  const failures: GraphSourceStagingFailure[] = [];
+  for (const relPath of changedSources) {
+    try {
+      sourceFileAccess.stat(resolve(root, relPath));
+    } catch (error) {
+      if (isMissingPathError(error)) deleted.add(relPath);
+      else failures.push(sourceStagingFailure(relPath, "stat", error));
+    }
+  }
+  if (failures.length > 0) throw new GraphSourceStagingError(failures);
+  return deleted;
+}
+
+function discoverSourceFiles(root: string, sourceFileAccess: GraphSourceFileAccess): DiscoveredFile[] {
+  const matches = globSync(SUPPORTED_SOURCE_GLOB, {
+    cwd: root, ignore: IGNORE_GLOBS, nodir: true, absolute: false, dot: false,
+  }).map(toPosix).sort();
+  const files: DiscoveredFile[] = [];
+  const failures: GraphSourceStagingFailure[] = [];
+  for (const relPath of matches) {
+    if (!isSupportedSourceFile(relPath)) continue;
+    let stat: { size: number; mtimeMs: number };
+    try {
+      stat = sourceFileAccess.stat(resolve(root, relPath));
+    } catch (error) {
+      failures.push(sourceStagingFailure(relPath, "stat", error));
+      continue;
+    }
+    try {
+      files.push({
+        relPath,
+        source: sourceFileAccess.read(resolve(root, relPath)),
+        size: stat.size,
+        modifiedAt: stat.mtimeMs,
+      });
+    } catch (error) {
+      failures.push(sourceStagingFailure(relPath, "read", error));
+    }
+  }
+  if (failures.length > 0) throw new GraphSourceStagingError(failures);
+  return files;
+}
+
+function sourceStagingFailure(
+  filePath: string,
+  operation: GraphSourceStagingFailure["operation"],
+  error: unknown,
+): GraphSourceStagingFailure {
+  const code = typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "") || undefined
+    : undefined;
+  return {
+    filePath,
+    operation,
+    ...(code ? { code } : {}),
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null || !("code" in error)) return false;
+  const code = String((error as { code?: unknown }).code ?? "");
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+export function graphManifest(root: string): GraphManifest {
+  const configPaths = [...new Set(globSync([
+    "package.json", "**/package.json", "tsconfig*.json", "**/tsconfig*.json",
+    "jsconfig*.json", "**/jsconfig*.json",
+  ], {
+    cwd: root, ignore: IGNORE_GLOBS, nodir: true,
+  }).map(toPosix))].sort();
+  const configs = configPaths.map((path) => {
+    try { return [path, sha256(readFileSync(resolve(root, path), "utf-8"))]; }
+    catch { return [path, "unreadable"]; }
+  });
+  const configHash = sha256(JSON.stringify(configs));
+  const grammarHash = grammarManifestHash();
+  const manifestHash = sha256(JSON.stringify({
+    db: DB_SCHEMA_VERSION,
+    compiler: TYPESCRIPT_COMPILER_VERSION,
+    extractor: CORPUS_EXTRACTOR_VERSION,
+    resolver: RESOLVER_VERSION,
+    grammarHash,
+    configHash,
+  }));
+  return { manifestHash, configHash, grammarHash };
+}
+
+function healthCounts(files: StagedFile[]): { ok: number; partial: number; failed: number } {
+  return {
+    ok: files.filter((file) => file.record.parseStatus === "ok").length,
+    partial: files.filter((file) => file.record.parseStatus === "partial").length,
+    failed: files.filter((file) => file.record.parseStatus === "failed").length,
+  };
+}
+
+function sha256(text: string | Buffer): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
 function bodyHash(sourceLines: string[], startLine: number, endLine: number): string {
-  const body = sourceLines.slice(startLine - 1, endLine).join("\n");
-  const normalized = body.replace(/\s+/g, " ").trim();
-  return sha256(normalized);
+  return sha256(sourceLines.slice(startLine - 1, endLine).join("\n").replace(/\s+/g, " ").trim());
 }

--- a/src/graph/engine.ts
+++ b/src/graph/engine.ts
@@ -17,7 +17,7 @@
 // Synchronous reads are what let the grounding checker match the existing
 // (synchronous) drift-checker signature exactly (`src/graph/grounding.ts`).
 
-import type { GraphNode, NodeKind, Language } from "./types.js";
+import type { EdgeKind, GraphEdge, GraphNode, NodeKind, Language } from "./types.js";
 import { NotImplementedError } from "./errors.js";
 
 // ----------------------------------------------------------------------------
@@ -30,6 +30,11 @@ export interface BuildResult {
   nodesCreated: number;
   edgesCreated: number;
   durationMs: number;
+  health?: {
+    ok: number;
+    partial: number;
+    failed: number;
+  };
 }
 
 /** Options for {@link GraphEngine.searchNodes}. */
@@ -40,6 +45,32 @@ export interface NodeSearchOptions {
   languages?: Language[];
   /** Cap the number of results. */
   limit?: number;
+}
+
+/** One typed graph edge and the node at its opposite endpoint. */
+export interface GraphNeighbor {
+  node: GraphNode;
+  edge: GraphEdge;
+}
+
+export interface IndexedFileInfo {
+  path: string;
+  contentHash: string;
+  parseStatus: "ok" | "partial" | "failed";
+  diagnosticCount: number;
+  errorCoverage: number;
+  nodeCount: number;
+}
+
+export interface SourceChunkMatch {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  contentHash: string;
+  rank: number;
+  matchedTerms?: string[];
+  /** Named structural declarations overlapping this source window, in deterministic relevance order. */
+  nodeIds?: string[];
 }
 
 // ----------------------------------------------------------------------------
@@ -88,6 +119,18 @@ export interface GraphEngine {
   /** Nodes with an outgoing `calls` edge from `id` (its callees). Synchronous. */
   getCallees(id: string): GraphNode[];
 
+  /** Incoming relationships of any requested kinds, preserving edge metadata. */
+  getIncoming(id: string, kinds?: EdgeKind[]): GraphNeighbor[];
+
+  /** Outgoing relationships of any requested kinds, preserving edge metadata. */
+  getOutgoing(id: string, kinds?: EdgeKind[]): GraphNeighbor[];
+
+  /** File-level lexical evidence used by one-call retrieval and parser fallback. */
+  searchSource?(query: string, limit?: number): SourceChunkMatch[];
+
+  /** Indexed file health and hashes. */
+  getIndexedFiles?(): IndexedFileInfo[];
+
   /** Release the underlying database handle. */
   close(): void;
 }
@@ -115,6 +158,18 @@ export const notImplementedGraphEngine: GraphEngine = {
   },
   getCallees(): GraphNode[] {
     throw new NotImplementedError("GraphEngine.getCallees");
+  },
+  getIncoming(): GraphNeighbor[] {
+    throw new NotImplementedError("GraphEngine.getIncoming");
+  },
+  getOutgoing(): GraphNeighbor[] {
+    throw new NotImplementedError("GraphEngine.getOutgoing");
+  },
+  searchSource(): SourceChunkMatch[] {
+    throw new NotImplementedError("GraphEngine.searchSource");
+  },
+  getIndexedFiles(): IndexedFileInfo[] {
+    throw new NotImplementedError("GraphEngine.getIndexedFiles");
   },
   close(): void {
     throw new NotImplementedError("GraphEngine.close");

--- a/src/graph/errors.ts
+++ b/src/graph/errors.ts
@@ -12,3 +12,14 @@ export class NotImplementedError extends Error {
     this.name = "NotImplementedError";
   }
 }
+
+/** A derived graph database exists, but was produced by an incompatible engine. */
+export class GraphRebuildRequiredError extends Error {
+  readonly code = "GRAPH_REBUILD_REQUIRED";
+  readonly recoveryCommand = "mex graph";
+
+  constructor(message = "The code graph was built with an incompatible schema or extractor.") {
+    super(`${message} Run \`mex graph\` to rebuild it.`);
+    this.name = "GraphRebuildRequiredError";
+  }
+}

--- a/src/graph/extraction/compiler.ts
+++ b/src/graph/extraction/compiler.ts
@@ -1,0 +1,1606 @@
+// Compiler-backed TypeScript/JavaScript graph extraction.
+//
+// This module deliberately sits beside the frozen tree-sitter extractor seam.
+// It stages a whole TS/JS corpus before persistence, which lets the engine use
+// the TypeScript checker for aliases, overloads, module resolution and calls
+// without changing the Python/Rust extraction path.
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import ts from "typescript";
+
+export const TYPESCRIPT_COMPILER_EXTRACTOR_VERSION = "typescript-5.9-v1";
+export const TYPESCRIPT_COMPILER_VERSION = ts.version;
+
+export type CompilerSourceLanguage =
+  | "typescript"
+  | "tsx"
+  | "javascript"
+  | "jsx";
+
+export type CompilerNodeKind =
+  | "file"
+  | "module"
+  | "class"
+  | "interface"
+  | "function"
+  | "method"
+  | "property"
+  | "variable"
+  | "constant"
+  | "enum"
+  | "enum_member"
+  | "type_alias"
+  | "namespace";
+
+export type CompilerReferenceKind =
+  | "contains"
+  | "calls"
+  | "imports"
+  | "exports"
+  | "extends"
+  | "implements"
+  | "references"
+  | "instantiates"
+  | "overrides";
+
+export type CompilerParseStatus = "ok" | "partial" | "failed";
+export type CompilerResolutionStatus =
+  | "resolved"
+  | "ambiguous"
+  | "unresolved";
+
+export interface CompilerDiagnosticSummary {
+  code: number;
+  category: "warning" | "error" | "suggestion" | "message";
+  message: string;
+  start?: number;
+  length?: number;
+}
+
+export interface CompilerSourceHealth {
+  status: CompilerParseStatus;
+  syntacticDiagnosticCount: number;
+  semanticDiagnosticCount: number;
+  /** Union of syntactic-error spans divided by the UTF-8 source byte length. */
+  diagnosticByteCoverage: number;
+  excludedDeclarationCount: number;
+  diagnostics: CompilerDiagnosticSummary[];
+}
+
+export interface CompilerExtractedNode {
+  id: string;
+  identityKey: string;
+  containerId?: string;
+  kind: CompilerNodeKind;
+  name: string;
+  qualifiedName: string;
+  declarationRole: string;
+  filePath: string;
+  language: CompilerSourceLanguage;
+  startLine: number;
+  endLine: number;
+  startColumn: number;
+  endColumn: number;
+  docstring?: string;
+  signature?: string;
+  visibility?: "public" | "private" | "protected" | "internal";
+  isExported: boolean;
+  isAsync?: boolean;
+  isStatic?: boolean;
+  isAbstract?: boolean;
+  decorators?: string[];
+  typeParameters?: string[];
+  returnType?: string;
+  /** All declarations represented by this node (overload sets are coalesced). */
+  declarationSpans: Array<{
+    startLine: number;
+    endLine: number;
+    startColumn: number;
+    endColumn: number;
+  }>;
+}
+
+export interface CompilerImportBinding {
+  id: string;
+  filePath: string;
+  localName: string;
+  importedName: string;
+  moduleSpecifier: string;
+  resolvedFilePath?: string;
+  targetId?: string;
+  isTypeOnly: boolean;
+  isNamespace: boolean;
+  isDefault: boolean;
+  line: number;
+  column: number;
+  confidence: 1;
+  resolutionMethod: "typescript-import";
+}
+
+export interface CompilerReference {
+  id: string;
+  sourceId: string;
+  targetId?: string;
+  kind: CompilerReferenceKind;
+  targetName: string;
+  targetQualifiedName?: string;
+  receiver?: string;
+  qualifier?: string;
+  candidates: string[];
+  status: CompilerResolutionStatus;
+  confidence: number;
+  resolutionMethod:
+    | "lexical-containment"
+    | "typescript-symbol"
+    | "typescript-signature"
+    | "typescript-import"
+    | "typescript-heritage"
+    | "typescript-callback-parameter";
+  provenance: "typescript-compiler" | "callback-synthesis";
+  filePath: string;
+  line: number;
+  column: number;
+  evidence: Record<string, unknown>;
+}
+
+export interface CompilerFileExtraction {
+  filePath: string;
+  language: CompilerSourceLanguage;
+  projectId: string;
+  health: CompilerSourceHealth;
+  nodes: CompilerExtractedNode[];
+  importBindings: CompilerImportBinding[];
+  references: CompilerReference[];
+}
+
+export interface DiscoveredTypeScriptProject {
+  id: string;
+  configPath: string | null;
+  projectReferences: string[];
+  configuredFilePaths: string[];
+  diagnostics: CompilerDiagnosticSummary[];
+}
+
+export interface CompilerExtractionResult {
+  compilerVersion: string;
+  extractorVersion: string;
+  projects: DiscoveredTypeScriptProject[];
+  files: CompilerFileExtraction[];
+}
+
+export interface CompilerExtractionOptions {
+  /** Additional options used only by the inferred program. */
+  inferredCompilerOptions?: ts.CompilerOptions;
+}
+
+interface ParsedProject {
+  id: string;
+  configPath: string;
+  parsed: ts.ParsedCommandLine;
+  diagnostics: ts.Diagnostic[];
+}
+
+interface RuntimeProject extends ParsedProject {
+  program: ts.Program;
+  checker: ts.TypeChecker;
+}
+
+interface ErrorRange {
+  start: number;
+  end: number;
+}
+
+interface DraftNode {
+  kind: CompilerNodeKind;
+  name: string;
+  qualifiedName: string;
+  declarationRole: string;
+  signature?: string;
+  declarations: ts.Node[];
+  symbol?: ts.Symbol;
+  container?: DraftNode;
+  filePath: string;
+  language: CompilerSourceLanguage;
+  docstring?: string;
+  visibility?: "public" | "private" | "protected" | "internal";
+  isExported: boolean;
+  isAsync?: boolean;
+  isStatic?: boolean;
+  isAbstract?: boolean;
+  decorators?: string[];
+  typeParameters?: string[];
+  returnType?: string;
+  identityBase?: string;
+  identityKey?: string;
+  id?: string;
+}
+
+interface FileContext {
+  filePath: string;
+  sourceFile: ts.SourceFile;
+  project: RuntimeProject;
+  language: CompilerSourceLanguage;
+  health: CompilerSourceHealth;
+  errorRanges: ErrorRange[];
+  excludedDeclarationRanges: ErrorRange[];
+  drafts: DraftNode[];
+  fileDraft?: DraftNode;
+  declarationDrafts: Map<ts.Node, DraftNode>;
+  symbolDrafts: Map<ts.Symbol, DraftNode>;
+  nodes: CompilerExtractedNode[];
+}
+
+interface PendingReference extends Omit<CompilerReference, "id"> {
+  position: number;
+  identityHint: string;
+}
+
+const SOURCE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".mex",
+  ".next",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+]);
+
+/**
+ * Find every tsconfig project below `rootDir`, including referenced projects.
+ * The returned paths and file lists are repository-relative and deterministic.
+ */
+export function discoverTypeScriptProjects(
+  rootDir: string,
+  candidateFiles?: readonly string[],
+): DiscoveredTypeScriptProject[] {
+  const root = resolve(rootDir);
+  const candidates = candidateFiles
+    ? new Set(candidateFiles.map((file) => absoluteCandidate(root, file)))
+    : undefined;
+  return parseProjects(root, candidates).map((project) => ({
+    id: project.id,
+    configPath: relativePath(root, project.configPath),
+    projectReferences: (project.parsed.projectReferences ?? [])
+      .map((reference) => relativePath(root, ts.resolveProjectReferencePath(reference)))
+      .sort(),
+    configuredFilePaths: project.parsed.fileNames
+      .map((file) => normalizedAbsolute(file))
+      .filter((file) => !candidates || candidates.has(file))
+      .filter((file) => withinRoot(root, file))
+      .map((file) => relativePath(root, file))
+      .sort(),
+    diagnostics: project.diagnostics.map(summarizeDiagnostic),
+  }));
+}
+
+/**
+ * Build compiler programs and extract a complete staged TS/JS graph corpus.
+ * Nothing is persisted here: callers can validate every invariant before a DB
+ * transaction publishes the result.
+ */
+export function buildTypeScriptExtraction(
+  rootDir: string,
+  candidateFiles?: readonly string[],
+  options: CompilerExtractionOptions = {},
+): CompilerExtractionResult {
+  const root = resolve(rootDir);
+  const candidates = collectCandidates(root, candidateFiles);
+  const parsedProjects = parseProjects(root, new Set(candidates));
+  const runtimeProjects: RuntimeProject[] = parsedProjects.map((project) => {
+    const program = ts.createProgram({
+      rootNames: project.parsed.fileNames,
+      options: project.parsed.options,
+      projectReferences: project.parsed.projectReferences,
+    });
+    return { ...project, program, checker: program.getTypeChecker() };
+  });
+
+  const ownership = new Map<string, RuntimeProject>();
+  for (const file of candidates) {
+    const owners = runtimeProjects
+      .filter((project) => project.program.getSourceFile(file) !== undefined)
+      .sort((left, right) => {
+        const specificity = dirname(right.configPath).length - dirname(left.configPath).length;
+        return specificity || left.configPath.localeCompare(right.configPath);
+      });
+    if (owners[0]) ownership.set(file, owners[0]);
+  }
+
+  const uncovered = candidates.filter((file) => !ownership.has(file));
+  let inferred: RuntimeProject | undefined;
+  if (uncovered.length > 0) {
+    const inferredOptions: ts.CompilerOptions = {
+      allowJs: true,
+      checkJs: false,
+      jsx: ts.JsxEmit.Preserve,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      noEmit: true,
+      skipLibCheck: true,
+      target: ts.ScriptTarget.ES2022,
+      ...options.inferredCompilerOptions,
+    };
+    const program = ts.createProgram({ rootNames: uncovered, options: inferredOptions });
+    inferred = {
+      id: "inferred",
+      configPath: "",
+      parsed: {
+        options: inferredOptions,
+        fileNames: uncovered,
+        errors: [],
+      },
+      diagnostics: [],
+      program,
+      checker: program.getTypeChecker(),
+    };
+    runtimeProjects.push(inferred);
+    for (const file of uncovered) ownership.set(file, inferred);
+  }
+
+  const contexts: FileContext[] = [];
+  for (const absoluteFile of candidates) {
+    const project = ownership.get(absoluteFile);
+    const sourceFile = project?.program.getSourceFile(absoluteFile);
+    if (!project || !sourceFile) continue;
+    const filePath = relativePath(root, absoluteFile);
+    const { health, ranges } = sourceHealth(project.program, sourceFile);
+    const context: FileContext = {
+      filePath,
+      sourceFile,
+      project,
+      language: languageForFile(filePath),
+      health,
+      errorRanges: ranges,
+      excludedDeclarationRanges: [],
+      drafts: [],
+      declarationDrafts: new Map(),
+      symbolDrafts: new Map(),
+      nodes: [],
+    };
+    if (health.status !== "failed") {
+      collectDrafts(context);
+      if (health.status === "partial" && context.drafts.length <= 1) {
+        health.status = "failed";
+        context.drafts = [];
+        context.fileDraft = undefined;
+        context.declarationDrafts.clear();
+        context.symbolDrafts.clear();
+      }
+    }
+    contexts.push(context);
+  }
+
+  assignCanonicalIdentities(contexts);
+
+  const locationIds = new Map<string, string>();
+  const nodeById = new Map<string, CompilerExtractedNode>();
+  for (const context of contexts) {
+    for (const draft of context.drafts) {
+      if (!draft.id) continue;
+      for (const declaration of draft.declarations) {
+        locationIds.set(declarationLocation(declaration), draft.id);
+      }
+    }
+    context.nodes = materializeNodes(context);
+    for (const node of context.nodes) nodeById.set(node.id, node);
+  }
+
+  const files = contexts.map((context) => {
+    const importBindings = extractImportBindings(root, context, locationIds);
+    const references = extractReferences(context, contexts, locationIds, nodeById, importBindings);
+    return {
+      filePath: context.filePath,
+      language: context.language,
+      projectId: context.project.id,
+      health: context.health,
+      nodes: context.nodes,
+      importBindings,
+      references,
+    } satisfies CompilerFileExtraction;
+  });
+
+  const projectSummaries: DiscoveredTypeScriptProject[] = runtimeProjects.map((project) => ({
+    id: project.id,
+    configPath: project.configPath ? relativePath(root, project.configPath) : null,
+    projectReferences: (project.parsed.projectReferences ?? [])
+      .map((reference) => relativePath(root, ts.resolveProjectReferencePath(reference)))
+      .sort(),
+    configuredFilePaths: files
+      .filter((file) => file.projectId === project.id)
+      .map((file) => file.filePath)
+      .sort(),
+    diagnostics: project.diagnostics.map(summarizeDiagnostic),
+  }));
+
+  return {
+    compilerVersion: ts.version,
+    extractorVersion: TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
+    projects: projectSummaries,
+    files,
+  };
+}
+
+/** Stable identity input shared with migration/invariant tests. */
+export function canonicalCompilerIdentity(input: {
+  filePath: string;
+  kind: CompilerNodeKind;
+  qualifiedName: string;
+  declarationRole: string;
+  signature?: string;
+  ordinal?: number;
+}): string {
+  const base = [
+    normalizeRelative(input.filePath),
+    input.kind,
+    normalizeQualifiedName(input.qualifiedName),
+    normalizeSignature(input.declarationRole),
+    normalizeSignature(input.signature ?? ""),
+  ].join("\u0000");
+  return input.ordinal === undefined ? base : `${base}\u0000ordinal:${input.ordinal}`;
+}
+
+export function generateCanonicalCompilerNodeId(
+  kind: CompilerNodeKind,
+  identityKey: string,
+): string {
+  return `${kind}:${sha256(identityKey).slice(0, 32)}`;
+}
+
+/**
+ * Produce spelling-independent compiler tokens for fingerprinting extracted
+ * nodes. Identifiers and literals are represented only by SyntaxKind, so a
+ * rename or constant edit does not erase structural similarity. Overload spans
+ * are scanned independently and joined with an explicit boundary token.
+ */
+export function normalizedCompilerTokens(
+  source: string,
+  nodes: readonly Pick<CompilerExtractedNode, "id" | "language" | "declarationSpans">[],
+): Map<string, string[]> {
+  const lineStarts = sourceLineStarts(source);
+  return new Map(nodes.map((node) => {
+    const tokens: string[] = [];
+    const variant = node.language === "tsx" || node.language === "jsx"
+      ? ts.LanguageVariant.JSX
+      : ts.LanguageVariant.Standard;
+    node.declarationSpans.forEach((span, index) => {
+      if (index > 0) tokens.push("OverloadBoundary");
+      const start = sourceOffset(lineStarts, span.startLine, span.startColumn, source.length);
+      const end = sourceOffset(lineStarts, span.endLine, span.endColumn, source.length);
+      const scanner = ts.createScanner(
+        ts.ScriptTarget.Latest,
+        true,
+        variant,
+        source.slice(start, Math.max(start, end)),
+      );
+      for (let token = scanner.scan(); token !== ts.SyntaxKind.EndOfFileToken; token = scanner.scan()) {
+        tokens.push(ts.SyntaxKind[token] ?? `SyntaxKind:${token}`);
+      }
+    });
+    return [node.id, tokens];
+  }));
+}
+
+function parseProjects(root: string, candidates?: ReadonlySet<string>): ParsedProject[] {
+  const queue = findConfigFiles(root);
+  const seen = new Set<string>();
+  const projects: ParsedProject[] = [];
+  while (queue.length > 0) {
+    const configPath = normalizedAbsolute(queue.shift()!);
+    if (seen.has(configPath)) continue;
+    seen.add(configPath);
+    const diagnostics: ts.Diagnostic[] = [];
+    const host: ts.ParseConfigFileHost = {
+      useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+      getCurrentDirectory: () => root,
+      fileExists: ts.sys.fileExists,
+      readDirectory: ts.sys.readDirectory,
+      readFile: ts.sys.readFile,
+      onUnRecoverableConfigFileDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    };
+    const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, host);
+    if (!parsed) continue;
+    diagnostics.push(...parsed.errors);
+    for (const reference of parsed.projectReferences ?? []) {
+      const referencePath = normalizedAbsolute(ts.resolveProjectReferencePath(reference));
+      if (withinRoot(root, referencePath) && !seen.has(referencePath)) queue.push(referencePath);
+    }
+    const includesCandidate = !candidates || parsed.fileNames.some((file) => candidates.has(normalizedAbsolute(file)));
+    const isReferenced = projects.some((project) =>
+      (project.parsed.projectReferences ?? []).some(
+        (reference) => normalizedAbsolute(ts.resolveProjectReferencePath(reference)) === configPath,
+      ),
+    );
+    if (includesCandidate || isReferenced || parsed.fileNames.length > 0) {
+      projects.push({
+        id: `config:${relativePath(root, configPath)}`,
+        configPath,
+        parsed,
+        diagnostics,
+      });
+    }
+  }
+  return projects.sort((left, right) => left.configPath.localeCompare(right.configPath));
+}
+
+function findConfigFiles(root: string): string[] {
+  const configs: string[] = [];
+  const visit = (directory: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRECTORIES.has(entry.name)) visit(resolve(directory, entry.name));
+        continue;
+      }
+      if (entry.isFile() && /^tsconfig(?:\.[^.]+)?\.json$/u.test(entry.name)) {
+        configs.push(resolve(directory, entry.name));
+      }
+    }
+  };
+  visit(root);
+  return configs.sort();
+}
+
+function collectCandidates(root: string, supplied?: readonly string[]): string[] {
+  if (supplied) {
+    return [...new Set(supplied
+      .map((file) => absoluteCandidate(root, file))
+      .filter(isCompilerSourceFile)
+      .filter((file) => existsSync(file) && statSync(file).isFile()))]
+      .sort();
+  }
+  const files: string[] = [];
+  const visit = (directory: string): void => {
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRECTORIES.has(entry.name)) visit(path);
+      } else if (entry.isFile() && isCompilerSourceFile(path)) {
+        files.push(normalizedAbsolute(path));
+      }
+    }
+  };
+  visit(root);
+  return files.sort();
+}
+
+function collectDrafts(context: FileContext): void {
+  const { sourceFile, project } = context;
+  const fileDraft: DraftNode = {
+    kind: "file",
+    name: sourceFile.fileName.split(/[\\/]/u).at(-1) ?? context.filePath,
+    qualifiedName: context.filePath,
+    declarationRole: "source-file",
+    declarations: [sourceFile],
+    filePath: context.filePath,
+    language: context.language,
+    isExported: false,
+  };
+  context.fileDraft = fileDraft;
+  context.drafts.push(fileDraft);
+  context.declarationDrafts.set(sourceFile, fileDraft);
+
+  const visit = (node: ts.Node): void => {
+    const descriptor = declarationDescriptor(node, context);
+    if (descriptor) addDraft(node, descriptor, context);
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  // Map every declaration in an overload set to the one coalesced node.
+  for (const draft of context.drafts) {
+    for (const declaration of draft.declarations) context.declarationDrafts.set(declaration, draft);
+    if (draft.symbol) context.symbolDrafts.set(canonicalSymbol(draft.symbol, project.checker), draft);
+  }
+}
+
+interface DeclarationDescriptor {
+  kind: CompilerNodeKind;
+  name: string;
+  role: string;
+  symbol?: ts.Symbol;
+}
+
+function declarationDescriptor(node: ts.Node, context: FileContext): DeclarationDescriptor | null {
+  const checker = context.project.checker;
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return { kind: "function", name: node.name.text, role: "function", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isClassDeclaration(node) && node.name) {
+    return { kind: "class", name: node.name.text, role: "class", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isInterfaceDeclaration(node)) {
+    return { kind: "interface", name: node.name.text, role: "interface", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isEnumDeclaration(node)) {
+    return { kind: "enum", name: node.name.text, role: "enum", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isEnumMember(node)) {
+    return { kind: "enum_member", name: propertyName(node.name), role: "enum-member", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isTypeAliasDeclaration(node)) {
+    return { kind: "type_alias", name: node.name.text, role: "type-alias", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isModuleDeclaration(node)) {
+    const name = node.name.text;
+    return { kind: "namespace", name, role: "namespace", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isMethodDeclaration(node) || ts.isMethodSignature(node)) {
+    return { kind: "method", name: propertyName(node.name), role: "method", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isConstructorDeclaration(node)) {
+    return { kind: "method", name: "constructor", role: "constructor" };
+  }
+  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) {
+    return { kind: "method", name: propertyName(node.name), role: "accessor", symbol: checker.getSymbolAtLocation(node.name) };
+  }
+  if (ts.isPropertyDeclaration(node) || ts.isPropertySignature(node)) {
+    const callable = ts.isPropertyDeclaration(node) && node.initializer && isFunctionLikeValue(node.initializer);
+    return {
+      kind: callable ? "method" : "property",
+      name: propertyName(node.name),
+      role: callable ? "callable-property" : "property",
+      symbol: checker.getSymbolAtLocation(node.name),
+    };
+  }
+  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+    const callable = node.initializer && isFunctionLikeValue(node.initializer);
+    if (!callable && !isModuleVariable(node)) return null;
+    return {
+      kind: callable ? "function" : variableKind(node),
+      name: node.name.text,
+      role: callable ? "function-variable" : "variable",
+      symbol: checker.getSymbolAtLocation(node.name),
+    };
+  }
+  if ((ts.isArrowFunction(node) || ts.isFunctionExpression(node)) && !isNamedFunctionValue(node)) {
+    const role = anonymousFunctionRole(node, context);
+    return { kind: "function", name: `<callback:${role.label}>`, role: role.identity };
+  }
+  return null;
+}
+
+function addDraft(
+  node: ts.Node,
+  descriptor: DeclarationDescriptor,
+  context: FileContext,
+): void {
+  const checker = context.project.checker;
+  const symbol = descriptor.symbol ? canonicalSymbol(descriptor.symbol, checker) : undefined;
+  if (symbol) {
+    const existing = context.symbolDrafts.get(symbol);
+    if (existing) {
+      context.declarationDrafts.set(node, existing);
+      return;
+    }
+  }
+  const declarations = symbol?.declarations
+    ?.filter((declaration) => declaration.getSourceFile() === context.sourceFile)
+    .filter((declaration) => compatibleDeclaration(descriptor.kind, declaration)) ?? [node];
+  const usableDeclarations = declarations.length > 0 ? declarations : [node];
+  if (usableDeclarations.some((declaration) => intersectsRanges(declaration, context.errorRanges))) {
+    context.health.excludedDeclarationCount++;
+    for (const declaration of usableDeclarations) {
+      context.excludedDeclarationRanges.push({
+        start: declaration.getStart(context.sourceFile, false),
+        end: declaration.getEnd(),
+      });
+    }
+    return;
+  }
+  const container = closestDraft(node.parent, context) ?? context.fileDraft;
+  const qualifiedName = [
+    ...(container && container.kind !== "file" ? [container.qualifiedName] : []),
+    descriptor.name,
+  ].join("::");
+  const signature = declarationSignature(symbol, usableDeclarations, checker);
+  const representative = implementationDeclaration(usableDeclarations);
+  const draft: DraftNode = {
+    kind: descriptor.kind,
+    name: descriptor.name,
+    qualifiedName,
+    declarationRole: descriptor.role,
+    signature,
+    declarations: usableDeclarations,
+    symbol,
+    container,
+    filePath: context.filePath,
+    language: context.language,
+    docstring: symbol ? ts.displayPartsToString(symbol.getDocumentationComment(checker)) || undefined : jsDocForNode(representative),
+    visibility: visibilityOf(representative),
+    isExported: isExported(representative, symbol, checker),
+    isAsync: hasModifier(representative, ts.SyntaxKind.AsyncKeyword) || undefined,
+    isStatic: hasModifier(representative, ts.SyntaxKind.StaticKeyword) || undefined,
+    isAbstract: hasModifier(representative, ts.SyntaxKind.AbstractKeyword) || undefined,
+    decorators: decoratorsOf(representative),
+    typeParameters: typeParametersOf(representative),
+    returnType: returnTypeOf(symbol, representative, checker),
+  };
+  context.drafts.push(draft);
+  context.declarationDrafts.set(node, draft);
+  for (const declaration of usableDeclarations) context.declarationDrafts.set(declaration, draft);
+  if (symbol) context.symbolDrafts.set(symbol, draft);
+}
+
+function assignCanonicalIdentities(contexts: readonly FileContext[]): void {
+  for (const context of contexts) {
+    const groups = new Map<string, DraftNode[]>();
+    for (const draft of context.drafts) {
+      const base = canonicalCompilerIdentity({
+        filePath: draft.filePath,
+        kind: draft.kind,
+        qualifiedName: draft.qualifiedName,
+        declarationRole: draft.declarationRole,
+        signature: draft.signature,
+      });
+      draft.identityBase = base;
+      const entries = groups.get(base) ?? [];
+      entries.push(draft);
+      groups.set(base, entries);
+    }
+    for (const [base, entries] of groups) {
+      entries.sort((left, right) => declarationStart(left) - declarationStart(right));
+      entries.forEach((draft, index) => {
+        draft.identityKey = entries.length === 1 ? base : `${base}\u0000ordinal:${index}`;
+        draft.id = generateCanonicalCompilerNodeId(draft.kind, draft.identityKey);
+      });
+    }
+  }
+}
+
+function materializeNodes(context: FileContext): CompilerExtractedNode[] {
+  return context.drafts
+    .filter((draft): draft is DraftNode & { id: string; identityKey: string } => Boolean(draft.id && draft.identityKey))
+    .sort((left, right) => declarationStart(left) - declarationStart(right) || left.id.localeCompare(right.id))
+    .map((draft) => {
+      const declarations = draft.declarations.slice().sort((a, b) => a.getStart() - b.getStart());
+      const first = declarations[0];
+      const last = declarations.at(-1)!;
+      const start = context.sourceFile.getLineAndCharacterOfPosition(first.getStart(context.sourceFile));
+      const end = context.sourceFile.getLineAndCharacterOfPosition(last.getEnd());
+      return {
+        id: draft.id,
+        identityKey: draft.identityKey,
+        containerId: draft.container?.id,
+        kind: draft.kind,
+        name: draft.name,
+        qualifiedName: draft.qualifiedName,
+        declarationRole: draft.declarationRole,
+        filePath: draft.filePath,
+        language: draft.language,
+        startLine: start.line + 1,
+        endLine: end.line + 1,
+        startColumn: start.character,
+        endColumn: end.character,
+        docstring: draft.docstring,
+        signature: draft.signature,
+        visibility: draft.visibility,
+        isExported: draft.isExported,
+        isAsync: draft.isAsync,
+        isStatic: draft.isStatic,
+        isAbstract: draft.isAbstract,
+        decorators: draft.decorators,
+        typeParameters: draft.typeParameters,
+        returnType: draft.returnType,
+        declarationSpans: declarations.map((declaration) => {
+          const declarationStartPosition = context.sourceFile.getLineAndCharacterOfPosition(declaration.getStart(context.sourceFile));
+          const declarationEndPosition = context.sourceFile.getLineAndCharacterOfPosition(declaration.getEnd());
+          return {
+            startLine: declarationStartPosition.line + 1,
+            endLine: declarationEndPosition.line + 1,
+            startColumn: declarationStartPosition.character,
+            endColumn: declarationEndPosition.character,
+          };
+        }),
+      };
+    });
+}
+
+function extractImportBindings(
+  root: string,
+  context: FileContext,
+  locationIds: ReadonlyMap<string, string>,
+): CompilerImportBinding[] {
+  const bindings: CompilerImportBinding[] = [];
+  const checker = context.project.checker;
+  const options = context.project.program.getCompilerOptions();
+  for (const statement of context.sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteralLike(statement.moduleSpecifier)) continue;
+    if (!referenceSyntaxIsTrusted(statement, context)) continue;
+    const moduleSpecifier = statement.moduleSpecifier.text;
+    const resolution = ts.resolveModuleName(moduleSpecifier, context.sourceFile.fileName, options, ts.sys).resolvedModule;
+    const resolvedFilePath = resolution && withinRoot(root, resolution.resolvedFileName)
+      ? relativePath(root, resolution.resolvedFileName)
+      : undefined;
+    const add = (
+      local: ts.Identifier,
+      importedName: string,
+      flags: { isDefault?: boolean; isNamespace?: boolean; isTypeOnly?: boolean } = {},
+    ): void => {
+      const symbol = checker.getSymbolAtLocation(local);
+      const targetId = symbol ? idForSymbol(symbol, checker, locationIds) : undefined;
+      const position = context.sourceFile.getLineAndCharacterOfPosition(local.getStart(context.sourceFile));
+      const identity = [context.filePath, local.text, moduleSpecifier, importedName].join("\u0000");
+      bindings.push({
+        id: `import:${sha256(identity).slice(0, 32)}`,
+        filePath: context.filePath,
+        localName: local.text,
+        importedName,
+        moduleSpecifier,
+        resolvedFilePath,
+        targetId,
+        isTypeOnly: Boolean(statement.importClause?.isTypeOnly || flags.isTypeOnly),
+        isNamespace: Boolean(flags.isNamespace),
+        isDefault: Boolean(flags.isDefault),
+        line: position.line,
+        column: position.character,
+        confidence: 1,
+        resolutionMethod: "typescript-import",
+      });
+    };
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name) add(clause.name, "default", { isDefault: true });
+    if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) {
+      add(clause.namedBindings.name, "*", { isNamespace: true });
+    } else if (clause.namedBindings) {
+      for (const element of clause.namedBindings.elements) {
+        add(element.name, element.propertyName?.text ?? element.name.text, { isTypeOnly: element.isTypeOnly });
+      }
+    }
+  }
+  return bindings.sort((left, right) => left.line - right.line || left.column - right.column || left.id.localeCompare(right.id));
+}
+
+function extractReferences(
+  context: FileContext,
+  contexts: readonly FileContext[],
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  importBindings: readonly CompilerImportBinding[],
+): CompilerReference[] {
+  if (!context.fileDraft?.id) return [];
+  const pending: PendingReference[] = [];
+  const checker = context.project.checker;
+
+  const push = (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string): void => {
+    pending.push({ ...reference, position, identityHint });
+  };
+
+  // Structural containment is compiler-proven and never inferred by name.
+  for (const draft of context.drafts) {
+    if (!draft.id || !draft.container?.id) continue;
+    const position = declarationStart(draft);
+    push({
+      sourceId: draft.container.id,
+      targetId: draft.id,
+      kind: "contains",
+      targetName: draft.name,
+      targetQualifiedName: draft.qualifiedName,
+      candidates: [draft.id],
+      status: "resolved",
+      confidence: 1,
+      resolutionMethod: "lexical-containment",
+      provenance: "typescript-compiler",
+      filePath: context.filePath,
+      line: lineColumn(context.sourceFile, position).line,
+      column: lineColumn(context.sourceFile, position).column,
+      evidence: { declarationRole: draft.declarationRole },
+    }, position, `contains:${draft.identityKey}`);
+  }
+
+  for (const binding of importBindings) {
+    const resolvedFilePath = binding.resolvedFilePath;
+    const targetFileId = resolvedFilePath
+      ? contexts.find((entry) => entry.filePath === normalizeRelative(resolvedFilePath))?.fileDraft?.id
+      : undefined;
+    const targetId = targetFileId ?? binding.targetId;
+    push({
+      sourceId: context.fileDraft.id,
+      targetId,
+      kind: "imports",
+      targetName: binding.moduleSpecifier,
+      targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+      candidates: targetId ? [targetId] : [],
+      status: targetId ? "resolved" : "unresolved",
+      confidence: targetId ? 1 : 0,
+      resolutionMethod: "typescript-import",
+      provenance: "typescript-compiler",
+      filePath: context.filePath,
+      line: binding.line,
+      column: binding.column,
+      evidence: { importBindingId: binding.id, resolvedFilePath: binding.resolvedFilePath },
+    }, context.sourceFile.getPositionOfLineAndCharacter(binding.line, binding.column), `import:${binding.id}`);
+  }
+
+  const visit = (node: ts.Node): void => {
+    const trusted = referenceSyntaxIsTrusted(node, context);
+    if (trusted && (ts.isCallExpression(node) || ts.isNewExpression(node))) {
+      emitCallReference(node, context, locationIds, nodeById, push);
+      if (ts.isCallExpression(node)) {
+        emitCallbackReferences(node, context, locationIds, nodeById, push);
+      }
+    } else if (trusted && ts.isHeritageClause(node)) {
+      emitHeritageReferences(node, context, locationIds, nodeById, push);
+    } else if (trusted && ts.isIdentifier(node) && shouldEmitIdentifierReference(node)) {
+      emitIdentifierReference(node, context, locationIds, nodeById, push);
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(context.sourceFile, visit);
+
+  pending.sort((left, right) => left.position - right.position || left.kind.localeCompare(right.kind) || left.identityHint.localeCompare(right.identityHint));
+  const occurrence = new Map<string, number>();
+  return pending.map(({ position: _position, identityHint, ...reference }) => {
+    const base = [reference.sourceId, reference.kind, normalizeSignature(identityHint)].join("\u0000");
+    const ordinal = occurrence.get(base) ?? 0;
+    occurrence.set(base, ordinal + 1);
+    return {
+      ...reference,
+      id: `ref:${sha256(`${base}\u0000ordinal:${ordinal}`).slice(0, 32)}`,
+    };
+  });
+}
+
+function emitCallReference(
+  node: ts.CallExpression | ts.NewExpression,
+  context: FileContext,
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+): void {
+  const checker = context.project.checker;
+  const expression = node.expression;
+  const sourceId = enclosingSourceId(node, context);
+  if (!sourceId) return;
+  const resolvedSignature = checker.getResolvedSignature(node);
+  const signatureSymbol = resolvedSignature?.declaration
+    ? symbolForDeclaration(resolvedSignature.declaration, checker)
+    : undefined;
+  const expressionSymbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(expression) ? expression.name : expression);
+  const signatureTargets = idsForSymbol(signatureSymbol, checker, locationIds);
+  const expressionTargets = idsForSymbol(expressionSymbol, checker, locationIds);
+  const callSignatures = checker.getTypeAtLocation(expression).getCallSignatures();
+  const candidates = [...new Set(callSignatures
+    .map((signature) => signature.declaration ? symbolForDeclaration(signature.declaration, checker) : undefined)
+    .flatMap((symbol) => idsForSymbol(symbol, checker, locationIds))
+    .concat(signatureTargets, expressionTargets))].sort();
+  const polymorphic = ts.isPropertyAccessExpression(expression)
+    && expression.expression.kind !== ts.SyntaxKind.ThisKeyword
+    && expression.expression.kind !== ts.SyntaxKind.SuperKeyword
+    && isPolymorphicReceiver(checker.getTypeAtLocation(expression.expression));
+  const uniqueCandidate = !polymorphic && candidates.length === 1 ? candidates[0] : undefined;
+  const receiver = ts.isPropertyAccessExpression(expression) ? expression.expression.getText(context.sourceFile) : undefined;
+  const targetName = ts.isPropertyAccessExpression(expression)
+    ? expression.name.text
+    : expression.getText(context.sourceFile);
+  // A chained call expression starts where its entire receiver chain starts;
+  // use the actual callee token so semantic callsite uniqueness is real.
+  const position = ts.isPropertyAccessExpression(expression)
+    ? expression.name.getStart(context.sourceFile)
+    : expression.getStart(context.sourceFile);
+  const point = lineColumn(context.sourceFile, position);
+  const ambiguous = !uniqueCandidate && (candidates.length > 0 || polymorphic);
+  push({
+    sourceId,
+    targetId: uniqueCandidate,
+    kind: ts.isNewExpression(node) ? "instantiates" : "calls",
+    targetName,
+    targetQualifiedName: uniqueCandidate ? nodeById.get(uniqueCandidate)?.qualifiedName : undefined,
+    receiver,
+    qualifier: receiver,
+    candidates,
+    status: uniqueCandidate ? "resolved" : ambiguous ? "ambiguous" : "unresolved",
+    confidence: uniqueCandidate ? 1 : ambiguous ? 0.75 : 0,
+    resolutionMethod: "typescript-signature",
+    provenance: "typescript-compiler",
+    filePath: context.filePath,
+    line: point.line,
+    column: point.column,
+    evidence: {
+      expression: expression.getText(context.sourceFile),
+      signature: resolvedSignature ? normalizeSignature(checker.signatureToString(resolvedSignature, node)) : undefined,
+      polymorphic,
+    },
+  }, position, `${targetName}:${receiver ?? ""}`);
+}
+
+function emitHeritageReferences(
+  clause: ts.HeritageClause,
+  context: FileContext,
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+): void {
+  const sourceId = enclosingSourceId(clause.parent, context);
+  if (!sourceId) return;
+  const checker = context.project.checker;
+  for (const type of clause.types) {
+    const symbol = checker.getSymbolAtLocation(type.expression);
+    const targetId = idForSymbol(symbol, checker, locationIds);
+    const targetName = type.expression.getText(context.sourceFile);
+    const position = type.getStart(context.sourceFile);
+    const point = lineColumn(context.sourceFile, position);
+    push({
+      sourceId,
+      targetId,
+      kind: clause.token === ts.SyntaxKind.ImplementsKeyword ? "implements" : "extends",
+      targetName,
+      targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+      candidates: targetId ? [targetId] : [],
+      status: targetId ? "resolved" : "unresolved",
+      confidence: targetId ? 1 : 0,
+      resolutionMethod: "typescript-heritage",
+      provenance: "typescript-compiler",
+      filePath: context.filePath,
+      line: point.line,
+      column: point.column,
+      evidence: { heritage: clause.token === ts.SyntaxKind.ImplementsKeyword ? "implements" : "extends" },
+    }, position, targetName);
+  }
+}
+
+function emitIdentifierReference(
+  identifier: ts.Identifier,
+  context: FileContext,
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+): void {
+  const checker = context.project.checker;
+  const symbol = checker.getSymbolAtLocation(identifier);
+  const targetIds = idsForSymbol(symbol, checker, locationIds);
+  const targetId = targetIds.length === 1 ? targetIds[0] : undefined;
+  const sourceId = enclosingSourceId(identifier, context);
+  if (!sourceId || targetId === sourceId || targetIds.length === 0) return;
+  const position = identifier.getStart(context.sourceFile);
+  const point = lineColumn(context.sourceFile, position);
+  const parent = identifier.parent;
+  const receiver = ts.isPropertyAccessExpression(parent) && parent.name === identifier
+    ? parent.expression.getText(context.sourceFile)
+    : undefined;
+  push({
+    sourceId,
+    targetId,
+    kind: "references",
+    targetName: identifier.text,
+    targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+    receiver,
+    qualifier: receiver,
+    candidates: targetIds,
+    status: targetId ? "resolved" : "ambiguous",
+    confidence: targetId ? 1 : 0.75,
+    resolutionMethod: "typescript-symbol",
+    provenance: "typescript-compiler",
+    filePath: context.filePath,
+    line: point.line,
+    column: point.column,
+    evidence: { expression: identifier.text },
+  }, position, `${identifier.text}:${receiver ?? ""}`);
+}
+
+function emitCallbackReferences(
+  call: ts.CallExpression,
+  context: FileContext,
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+): void {
+  const checker = context.project.checker;
+  const signature = checker.getResolvedSignature(call);
+  const declaration = signature?.getDeclaration();
+  if (!declaration || !ts.isFunctionLike(declaration)) return;
+  const calleeSymbol = symbolForDeclaration(declaration, checker);
+  const calleeId = idForSymbol(calleeSymbol, checker, locationIds);
+  if (!calleeId) return;
+  const parameters = declaration.parameters;
+  call.arguments.forEach((argument, index) => {
+    const mapping = callbackParameterForArgument(parameters, index);
+    if (!mapping || !parameterIsInvoked(
+      mapping.parameter,
+      declaration,
+      checker,
+      mapping.restArgumentIndex,
+    )) return;
+    const { parameter } = mapping;
+    let callbackId: string | undefined;
+    if (ts.isArrowFunction(argument) || ts.isFunctionExpression(argument)) {
+      callbackId = context.declarationDrafts.get(argument)?.id;
+    } else {
+      const callbackIds = idsForSymbol(checker.getSymbolAtLocation(argument), checker, locationIds);
+      callbackId = callbackIds.length === 1 ? callbackIds[0] : undefined;
+    }
+    if (!callbackId) return;
+    const position = argument.getStart(context.sourceFile);
+    const point = lineColumn(context.sourceFile, position);
+    const parameterName = parameter.name.getText(declaration.getSourceFile());
+    push({
+      sourceId: calleeId,
+      targetId: callbackId,
+      kind: "calls",
+      targetName: nodeById.get(callbackId)?.name ?? argument.getText(context.sourceFile),
+      targetQualifiedName: nodeById.get(callbackId)?.qualifiedName,
+      candidates: [callbackId],
+      status: "resolved",
+      confidence: 0.85,
+      resolutionMethod: "typescript-callback-parameter",
+      provenance: "callback-synthesis",
+      filePath: context.filePath,
+      line: point.line,
+      column: point.column,
+      evidence: {
+        parameterName,
+        argumentIndex: index,
+        wiringSite: call.getText(context.sourceFile),
+        callee: nodeById.get(calleeId)?.qualifiedName,
+      },
+    }, position, `callback:${calleeId}:${parameterName}:${index}:${callbackId}`);
+  });
+}
+
+/**
+ * Match an actual argument to its formal parameter without treating an
+ * ordinary final parameter as variadic. For a real rest parameter, retain the
+ * element offset so callback synthesis can require evidence for that specific
+ * argument instead of claiming that every rest value is invoked.
+ */
+function callbackParameterForArgument(
+  parameters: ts.NodeArray<ts.ParameterDeclaration>,
+  argumentIndex: number,
+): { parameter: ts.ParameterDeclaration; restArgumentIndex?: number } | undefined {
+  const restIndex = parameters.length - 1;
+  const finalParameter = parameters[restIndex];
+  if (finalParameter?.dotDotDotToken && argumentIndex >= restIndex) {
+    return {
+      parameter: finalParameter,
+      restArgumentIndex: argumentIndex - restIndex,
+    };
+  }
+  const parameter = parameters[argumentIndex];
+  return parameter ? { parameter } : undefined;
+}
+
+function parameterIsInvoked(
+  parameter: ts.ParameterDeclaration,
+  declaration: ts.SignatureDeclaration,
+  checker: ts.TypeChecker,
+  restArgumentIndex?: number,
+): boolean {
+  const body = "body" in declaration ? declaration.body : undefined;
+  if (!body || !ts.isIdentifier(parameter.name)) return false;
+  const parameterSymbol = checker.getSymbolAtLocation(parameter.name);
+  if (!parameterSymbol) return false;
+  let invoked = false;
+  const visit = (node: ts.Node): void => {
+    if (invoked) return;
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression;
+      const candidate = ts.isPropertyAccessExpression(expression)
+        && (expression.name.text === "call" || expression.name.text === "apply")
+        ? expression.expression
+        : expression;
+      if (restArgumentIndex === undefined) {
+        if (ts.isIdentifier(candidate) && checker.getSymbolAtLocation(candidate) === parameterSymbol) {
+          invoked = true;
+          return;
+        }
+      } else if (ts.isElementAccessExpression(candidate)) {
+        const element = candidate.argumentExpression;
+        const index = element && ts.isNumericLiteral(element) ? Number(element.text) : Number.NaN;
+        if (
+          Number.isSafeInteger(index)
+          && index === restArgumentIndex
+          && ts.isIdentifier(candidate.expression)
+          && checker.getSymbolAtLocation(candidate.expression) === parameterSymbol
+        ) {
+          invoked = true;
+          return;
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(body, visit);
+  return invoked;
+}
+
+function sourceHealth(program: ts.Program, sourceFile: ts.SourceFile): { health: CompilerSourceHealth; ranges: ErrorRange[] } {
+  const syntactic = program.getSyntacticDiagnostics(sourceFile);
+  const semantic = program.getSemanticDiagnostics(sourceFile);
+  const ranges = diagnosticRanges(sourceFile.text, syntactic);
+  const coveredBytes = ranges.reduce((total, range) => total + Buffer.byteLength(sourceFile.text.slice(range.start, range.end), "utf8"), 0);
+  const totalBytes = Math.max(1, Buffer.byteLength(sourceFile.text, "utf8"));
+  const coverage = Math.min(1, coveredBytes / totalBytes);
+  return {
+    health: {
+      status: syntactic.length === 0 ? "ok" : coverage <= 0.25 ? "partial" : "failed",
+      syntacticDiagnosticCount: syntactic.length,
+      semanticDiagnosticCount: semantic.length,
+      diagnosticByteCoverage: coverage,
+      excludedDeclarationCount: 0,
+      diagnostics: [...syntactic, ...semantic].slice(0, 100).map(summarizeDiagnostic),
+    },
+    ranges,
+  };
+}
+
+function diagnosticRanges(source: string, diagnostics: readonly ts.Diagnostic[]): ErrorRange[] {
+  const ranges = diagnostics
+    .filter((diagnostic): diagnostic is ts.Diagnostic & { start: number } => diagnostic.start !== undefined)
+    .map((diagnostic) => ({
+      start: Math.max(0, Math.min(source.length, diagnostic.start)),
+      end: Math.max(0, Math.min(source.length, diagnostic.start + Math.max(1, diagnostic.length ?? 1))),
+    }))
+    .sort((left, right) => left.start - right.start || left.end - right.end);
+  const merged: ErrorRange[] = [];
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (previous && range.start <= previous.end) previous.end = Math.max(previous.end, range.end);
+    else merged.push({ ...range });
+  }
+  return merged;
+}
+
+function intersectsRanges(node: ts.Node, ranges: readonly ErrorRange[]): boolean {
+  const start = node.getStart(node.getSourceFile(), false);
+  const end = node.getEnd();
+  return ranges.some((range) => range.start < end && range.end > start);
+}
+
+function referenceSyntaxIsTrusted(node: ts.Node, context: FileContext): boolean {
+  if (intersectsRanges(node, context.errorRanges)) return false;
+  const start = node.getStart(context.sourceFile, false);
+  const end = node.getEnd();
+  return !context.excludedDeclarationRanges.some((range) => range.start <= start && range.end >= end);
+}
+
+function declarationSignature(
+  symbol: ts.Symbol | undefined,
+  declarations: readonly ts.Node[],
+  checker: ts.TypeChecker,
+): string | undefined {
+  if (symbol) {
+    const location = declarations[0];
+    const type = checker.getTypeOfSymbolAtLocation(symbol, location);
+    const signatures = [
+      ...checker.getSignaturesOfType(type, ts.SignatureKind.Call),
+      ...checker.getSignaturesOfType(type, ts.SignatureKind.Construct),
+    ];
+    const rendered = [...new Set(signatures.map((signature) => normalizeSignature(checker.signatureToString(signature, location))))].sort();
+    if (rendered.length > 0) return rendered.join(" | ");
+    const typeText = normalizeSignature(checker.typeToString(type, location, ts.TypeFormatFlags.NoTruncation));
+    if (typeText && typeText !== "any") return typeText;
+  }
+  const headers = [...new Set(declarations.map(declarationHeader).filter(Boolean))].sort();
+  return headers.length > 0 ? headers.join(" | ") : undefined;
+}
+
+function declarationHeader(node: ts.Node): string {
+  const source = node.getSourceFile();
+  let end = node.getEnd();
+  if (isFunctionLikeWithBody(node)) end = node.body.getStart(source);
+  else if (ts.isClassDeclaration(node) || ts.isInterfaceDeclaration(node) || ts.isEnumDeclaration(node)) {
+    end = node.members.pos;
+  } else if (ts.isVariableDeclaration(node) && node.initializer) {
+    end = node.initializer.getStart(source);
+  } else if (ts.isPropertyDeclaration(node) && node.initializer) {
+    end = node.initializer.getStart(source);
+  }
+  return normalizeSignature(source.text.slice(node.getStart(source), end).replace(/[={:]\s*$/u, ""));
+}
+
+function closestDraft(node: ts.Node | undefined, context: FileContext): DraftNode | undefined {
+  for (let current = node; current && !ts.isSourceFile(current); current = current.parent) {
+    const draft = context.declarationDrafts.get(current);
+    if (draft) return draft;
+  }
+  return context.fileDraft;
+}
+
+function enclosingSourceId(node: ts.Node, context: FileContext): string | undefined {
+  return closestDraft(node, context)?.id ?? context.fileDraft?.id;
+}
+
+function idForSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  locations: ReadonlyMap<string, string>,
+): string | undefined {
+  return idsForSymbol(symbol, checker, locations)[0];
+}
+
+function idsForSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+  locations: ReadonlyMap<string, string>,
+): string[] {
+  if (!symbol) return [];
+  const resolved = canonicalSymbol(symbol, checker);
+  const ids = new Set<string>();
+  for (const declaration of resolved.declarations ?? []) {
+    const id = locations.get(declarationLocation(declaration));
+    if (id) ids.add(id);
+  }
+  return [...ids].sort();
+}
+
+function isPolymorphicReceiver(type: ts.Type): boolean {
+  if (type.isUnionOrIntersection() || (type.flags & ts.TypeFlags.TypeParameter) !== 0) return true;
+  const symbol = type.getSymbol();
+  return Boolean(symbol && (symbol.flags & ts.SymbolFlags.Interface) !== 0);
+}
+
+function canonicalSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
+  if (!(symbol.flags & ts.SymbolFlags.Alias)) return symbol;
+  try {
+    return checker.getAliasedSymbol(symbol);
+  } catch {
+    return symbol;
+  }
+}
+
+function symbolForDeclaration(declaration: ts.Declaration, checker: ts.TypeChecker): ts.Symbol | undefined {
+  const named = declaration as ts.NamedDeclaration;
+  const symbol = named.name ? checker.getSymbolAtLocation(named.name) : checker.getSymbolAtLocation(declaration);
+  if (symbol) return canonicalSymbol(symbol, checker);
+  const parent = declaration.parent;
+  if (ts.isClassLike(parent) && parent.name) return checker.getSymbolAtLocation(parent.name);
+  return undefined;
+}
+
+function declarationLocation(node: ts.Node): string {
+  return `${normalizedAbsolute(node.getSourceFile().fileName)}:${node.getStart(node.getSourceFile(), false)}:${node.kind}`;
+}
+
+function compatibleDeclaration(kind: CompilerNodeKind, declaration: ts.Declaration): boolean {
+  if (kind === "function") return ts.isFunctionDeclaration(declaration) || ts.isVariableDeclaration(declaration) || ts.isFunctionExpression(declaration) || ts.isArrowFunction(declaration);
+  if (kind === "method") return ts.isMethodDeclaration(declaration) || ts.isMethodSignature(declaration) || ts.isGetAccessorDeclaration(declaration) || ts.isSetAccessorDeclaration(declaration) || ts.isPropertyDeclaration(declaration);
+  if (kind === "property") return ts.isPropertyDeclaration(declaration) || ts.isPropertySignature(declaration);
+  return true;
+}
+
+function implementationDeclaration(declarations: readonly ts.Node[]): ts.Node {
+  return declarations.find(isFunctionLikeWithBody)
+    ?? declarations.find((declaration) => ts.isClassLike(declaration) && Boolean(declaration.members))
+    ?? declarations.at(-1)!;
+}
+
+function isFunctionLikeWithBody(node: ts.Node): node is ts.FunctionLikeDeclaration & { body: ts.ConciseBody } {
+  return ts.isFunctionLike(node) && "body" in node && Boolean(node.body);
+}
+
+function anonymousFunctionRole(node: ts.ArrowFunction | ts.FunctionExpression, context: FileContext): { label: string; identity: string } {
+  const parent = node.parent;
+  if (ts.isCallExpression(parent)) {
+    const index = parent.arguments.indexOf(node);
+    const callee = normalizeSignature(parent.expression.getText(context.sourceFile)).slice(0, 80);
+    return { label: `${callee}[${index}]`, identity: `callback-argument:${callee}:${index}` };
+  }
+  if (ts.isNewExpression(parent)) {
+    const index = parent.arguments?.indexOf(node) ?? -1;
+    const callee = normalizeSignature(parent.expression.getText(context.sourceFile)).slice(0, 80);
+    return { label: `${callee}[${index}]`, identity: `constructor-callback:${callee}:${index}` };
+  }
+  const syntaxRole = ts.SyntaxKind[parent.kind] ?? "expression";
+  return { label: syntaxRole, identity: `anonymous-callback:${syntaxRole}` };
+}
+
+function isNamedFunctionValue(node: ts.ArrowFunction | ts.FunctionExpression): boolean {
+  const parent = node.parent;
+  return ts.isVariableDeclaration(parent)
+    || ts.isPropertyDeclaration(parent)
+    || ts.isPropertyAssignment(parent)
+    || (ts.isFunctionExpression(node) && Boolean(node.name));
+}
+
+function isFunctionLikeValue(node: ts.Expression): boolean {
+  return ts.isArrowFunction(node) || ts.isFunctionExpression(node);
+}
+
+function isModuleVariable(node: ts.VariableDeclaration): boolean {
+  const statement = node.parent.parent;
+  return ts.isVariableStatement(statement)
+    && (ts.isSourceFile(statement.parent) || ts.isModuleBlock(statement.parent));
+}
+
+function variableKind(node: ts.VariableDeclaration): "constant" | "variable" {
+  const declarationList = node.parent;
+  return ts.isVariableDeclarationList(declarationList) && (declarationList.flags & ts.NodeFlags.Const) !== 0
+    ? "constant"
+    : "variable";
+}
+
+function propertyName(name: ts.PropertyName): string {
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name) || ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) return name.text;
+  return name.getText(name.getSourceFile());
+}
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return Boolean(ts.canHaveModifiers(node) && ts.getModifiers(node)?.some((modifier) => modifier.kind === kind));
+}
+
+function visibilityOf(node: ts.Node): "public" | "private" | "protected" | "internal" | undefined {
+  if (hasModifier(node, ts.SyntaxKind.PrivateKeyword)) return "private";
+  if (hasModifier(node, ts.SyntaxKind.ProtectedKeyword)) return "protected";
+  if (hasModifier(node, ts.SyntaxKind.PublicKeyword)) return "public";
+  return undefined;
+}
+
+function isExported(node: ts.Node, symbol: ts.Symbol | undefined, checker: ts.TypeChecker): boolean {
+  if (hasModifier(node, ts.SyntaxKind.ExportKeyword) || hasModifier(node, ts.SyntaxKind.DefaultKeyword)) return true;
+  const sourceFile = node.getSourceFile();
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  return Boolean(symbol && moduleSymbol && checker.getExportsOfModule(moduleSymbol).some((entry) => canonicalSymbol(entry, checker) === symbol));
+}
+
+function decoratorsOf(node: ts.Node): string[] | undefined {
+  if (!ts.canHaveDecorators(node)) return undefined;
+  const decorators = ts.getDecorators(node)?.map((decorator) => decorator.expression.getText(node.getSourceFile()));
+  return decorators && decorators.length > 0 ? decorators : undefined;
+}
+
+function typeParametersOf(node: ts.Node): string[] | undefined {
+  if (!("typeParameters" in node)) return undefined;
+  const parameters = (node as ts.Node & { typeParameters?: ts.NodeArray<ts.TypeParameterDeclaration> }).typeParameters;
+  const result = parameters?.map((parameter) => parameter.name.text);
+  return result && result.length > 0 ? result : undefined;
+}
+
+function returnTypeOf(symbol: ts.Symbol | undefined, node: ts.Node, checker: ts.TypeChecker): string | undefined {
+  if (!symbol || !ts.isFunctionLike(node)) return undefined;
+  const type = checker.getTypeOfSymbolAtLocation(symbol, node);
+  const signature = checker.getSignaturesOfType(type, ts.SignatureKind.Call)[0];
+  return signature ? normalizeSignature(checker.typeToString(signature.getReturnType(), node, ts.TypeFormatFlags.NoTruncation)) : undefined;
+}
+
+function jsDocForNode(node: ts.Node): string | undefined {
+  const comments = ts.getJSDocCommentsAndTags(node)
+    .filter(ts.isJSDoc)
+    .map((doc) => typeof doc.comment === "string" ? doc.comment : "")
+    .filter(Boolean);
+  return comments.length > 0 ? comments.join("\n") : undefined;
+}
+
+function shouldEmitIdentifierReference(node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (
+    ("name" in parent && (parent as ts.NamedDeclaration).name === node)
+    || ts.isImportClause(parent)
+    || ts.isImportSpecifier(parent)
+    || ts.isNamespaceImport(parent)
+    || ts.isExportSpecifier(parent)
+    || ts.isPropertyAssignment(parent) && parent.name === node
+    || ts.isPropertyAccessExpression(parent) && parent.name === node && (ts.isCallExpression(parent.parent) || ts.isNewExpression(parent.parent))
+    || (ts.isCallExpression(parent) || ts.isNewExpression(parent)) && parent.expression === node
+    || ts.isTypeReferenceNode(parent)
+    || ts.isExpressionWithTypeArguments(parent)
+  ) return false;
+  for (let current: ts.Node | undefined = parent; current && !ts.isStatement(current); current = current.parent) {
+    if (ts.isTypeNode(current)) return false;
+  }
+  return true;
+}
+
+function sourceDiagnosticCategory(category: ts.DiagnosticCategory): CompilerDiagnosticSummary["category"] {
+  if (category === ts.DiagnosticCategory.Error) return "error";
+  if (category === ts.DiagnosticCategory.Warning) return "warning";
+  if (category === ts.DiagnosticCategory.Suggestion) return "suggestion";
+  return "message";
+}
+
+function summarizeDiagnostic(diagnostic: ts.Diagnostic): CompilerDiagnosticSummary {
+  return {
+    code: diagnostic.code,
+    category: sourceDiagnosticCategory(diagnostic.category),
+    message: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+    start: diagnostic.start,
+    length: diagnostic.length,
+  };
+}
+
+function lineColumn(sourceFile: ts.SourceFile, position: number): { line: number; column: number } {
+  const point = sourceFile.getLineAndCharacterOfPosition(position);
+  return { line: point.line, column: point.character };
+}
+
+function sourceLineStarts(source: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < source.length; index++) {
+    if (source.charCodeAt(index) === 10) starts.push(index + 1);
+  }
+  return starts;
+}
+
+function sourceOffset(
+  lineStarts: readonly number[],
+  oneBasedLine: number,
+  column: number,
+  sourceLength: number,
+): number {
+  const lineStart = lineStarts[Math.max(0, oneBasedLine - 1)] ?? sourceLength;
+  return Math.max(0, Math.min(sourceLength, lineStart + Math.max(0, column)));
+}
+
+function declarationStart(draft: DraftNode): number {
+  return Math.min(...draft.declarations.map((declaration) => declaration.getStart(declaration.getSourceFile(), false)));
+}
+
+function languageForFile(filePath: string): CompilerSourceLanguage {
+  const extension = extname(filePath).toLowerCase();
+  if (extension === ".tsx") return "tsx";
+  if (extension === ".jsx") return "jsx";
+  if (extension === ".js" || extension === ".mjs" || extension === ".cjs") return "javascript";
+  return "typescript";
+}
+
+function isCompilerSourceFile(filePath: string): boolean {
+  return SOURCE_EXTENSIONS.has(extname(filePath).toLowerCase());
+}
+
+function normalizeSignature(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function normalizeQualifiedName(value: string): string {
+  return value.split("::").map((part) => normalizeSignature(part)).join("::");
+}
+
+function normalizeRelative(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^\.\//u, "");
+}
+
+function normalizedAbsolute(value: string): string {
+  return resolve(value).split(sep).join("/");
+}
+
+function absoluteCandidate(root: string, file: string): string {
+  return normalizedAbsolute(isAbsolute(file) ? file : resolve(root, file));
+}
+
+function relativePath(root: string, file: string): string {
+  return normalizeRelative(relative(root, file));
+}
+
+function withinRoot(root: string, file: string): boolean {
+  const rel = relative(root, file);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== "..");
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/graph/extraction/grammars.ts
+++ b/src/graph/extraction/grammars.ts
@@ -11,6 +11,8 @@
 // Grammars are loaded on demand — only languages actually present in the project
 // are compiled — keeping WASM heap pressure low on large repos.
 
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { Parser, Language as WasmLanguage } from "web-tree-sitter";
 import type { Language } from "../types.js";
 import type { TSTree } from "./types.js";
@@ -29,6 +31,25 @@ const WASM_GRAMMAR_FILES: Partial<Record<Language, string>> = {
   python: "tree-sitter-python.wasm",
   rust: "tree-sitter-rust.wasm",
 };
+let grammarHashCache: string | null = null;
+
+/**
+ * Content hash of the exact grammar assets this build can use. Persisting the
+ * asset bytes (rather than package versions) makes copied/bundled installs and
+ * local development obey the same rebuild contract.
+ */
+export function grammarManifestHash(): string {
+  if (grammarHashCache) return grammarHashCache;
+  const hash = createHash("sha256");
+  for (const wasmFile of [...new Set(Object.values(WASM_GRAMMAR_FILES))].sort()) {
+    hash.update(wasmFile);
+    hash.update("\0");
+    hash.update(readFileSync(grammarWasmPath(wasmFile)));
+    hash.update("\0");
+  }
+  grammarHashCache = hash.digest("hex");
+  return grammarHashCache;
+}
 
 /** File extension → language. The single source of truth for "index this file?". */
 const EXTENSION_MAP: Record<string, Language> = {

--- a/src/graph/extraction/index.ts
+++ b/src/graph/extraction/index.ts
@@ -18,16 +18,49 @@ export {
   loadGrammars,
   supportedLanguages,
   disposeParsers,
+  grammarManifestHash,
   SUPPORTED_SOURCE_GLOB,
 } from "./grammars.js";
 export { getExtractor, EXTRACTORS } from "./languages/index.js";
-export { generateNodeId } from "./node-id.js";
+export { canonicalNodeIdentity, generateNodeId } from "./node-id.js";
+export {
+  buildTypeScriptExtraction,
+  canonicalCompilerIdentity,
+  discoverTypeScriptProjects,
+  generateCanonicalCompilerNodeId,
+  normalizedCompilerTokens,
+  TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
+  TYPESCRIPT_COMPILER_VERSION,
+} from "./compiler.js";
+export type {
+  CompilerDiagnosticSummary,
+  CompilerExtractedNode,
+  CompilerExtractionOptions,
+  CompilerExtractionResult,
+  CompilerFileExtraction,
+  CompilerImportBinding,
+  CompilerNodeKind,
+  CompilerParseStatus,
+  CompilerReference,
+  CompilerReferenceKind,
+  CompilerResolutionStatus,
+  CompilerSourceHealth,
+  CompilerSourceLanguage,
+  DiscoveredTypeScriptProject,
+} from "./compiler.js";
 
 /** What one file's extraction yields, before the engine resolves/persists it. */
 export interface FileExtraction {
   language: Language;
   nodes: ExtractedNode[];
   edges: ExtractedEdge[];
+  health: {
+    status: "ok" | "partial" | "failed";
+    diagnosticCount: number;
+    missingCount: number;
+    errorCoverage: number;
+    diagnostics: Array<{ type: string; startLine: number; endLine: number }>;
+  };
 }
 
 /**
@@ -44,8 +77,57 @@ export function extractFile(
   if (!extractor) return null;
   const tree = parse(source, language);
   if (!tree) return null;
-  const { nodes, edges } = extractor.extract(tree, filePath, source);
-  return { language, nodes, edges };
+  const health = treeHealth(tree.rootNode, source);
+  if (health.status === "failed") return { language, nodes: [], edges: [], health };
+  const extracted = extractor.extract(tree, filePath, source);
+  if (health.status === "partial" && extracted.nodes.every((node) => node.kind === "file")) {
+    return { language, nodes: [], edges: [], health: { ...health, status: "failed" } };
+  }
+  const excluded = new Set(extracted.nodes.filter((node) => node.kind !== "file" && health.diagnostics.some((diagnostic) =>
+    diagnostic.startLine <= node.endLine && diagnostic.endLine >= node.startLine,
+  )).map((node) => node.id));
+  const nodes = extracted.nodes.filter((node) => !excluded.has(node.id));
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges = extracted.edges.filter((edge) => nodeIds.has(edge.source) && (!edge.target || nodeIds.has(edge.target)));
+  return { language, nodes, edges, health };
+}
+
+function treeHealth(root: TSNode, source: string): FileExtraction["health"] {
+  const errors: TSNode[] = [];
+  const missing: TSNode[] = [];
+  let missingCount = 0;
+  const visit = (node: TSNode): void => {
+    if (node.type === "ERROR" || node.isError) errors.push(node);
+    if (node.isMissing) {
+      missingCount++;
+      missing.push(node);
+    }
+    for (const child of node.children) visit(child);
+  };
+  visit(root);
+  const issueNodes = [...errors, ...missing];
+  const ranges = issueNodes.map((node) => ({ start: node.startIndex, end: Math.max(node.startIndex + 1, node.endIndex) }))
+    .sort((left, right) => left.start - right.start || left.end - right.end);
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const range of ranges) {
+    const prior = merged.at(-1);
+    if (prior && range.start <= prior.end) prior.end = Math.max(prior.end, range.end);
+    else merged.push({ ...range });
+  }
+  const covered = merged.reduce((sum, range) => sum + Math.max(0, range.end - range.start), 0);
+  const coverage = Math.min(1, covered / Math.max(1, Buffer.byteLength(source, "utf8")));
+  const failed = root.type === "ERROR" || Boolean(root.isError) || coverage > 0.25;
+  return {
+    status: failed ? "failed" : errors.length > 0 || missingCount > 0 ? "partial" : "ok",
+    diagnosticCount: errors.length,
+    missingCount,
+    errorCoverage: coverage,
+    diagnostics: issueNodes.slice(0, 100).map((node) => ({
+      type: node.isMissing ? `MISSING:${node.type}` : node.type,
+      startLine: node.startPosition.row + 1,
+      endLine: node.endPosition.row + 1,
+    })),
+  };
 }
 
 /**

--- a/src/graph/extraction/languages/python.ts
+++ b/src/graph/extraction/languages/python.ts
@@ -6,7 +6,7 @@ import type {
   TSNode,
   TSTree,
 } from "../types.js";
-import { generateNodeId, getChildByField, getNodeText } from "../node-id.js";
+import { canonicalNodeIdentity, generateNodeId, getChildByField, getNodeText } from "../node-id.js";
 
 const FUNCTION_TYPES = new Set(["function_definition"]);
 const CLASS_TYPES = new Set(["class_definition"]);
@@ -18,6 +18,7 @@ class PythonWalker {
   private readonly nodes: ExtractedNode[] = [];
   private readonly edges: ExtractedEdge[] = [];
   private readonly scopeStack: string[] = [];
+  private readonly identityOccurrences = new Map<string, number>();
 
   constructor(
     private readonly filePath: string,
@@ -26,11 +27,13 @@ class PythonWalker {
   ) {}
 
   run(root: TSNode): { nodes: ExtractedNode[]; edges: ExtractedEdge[] } {
-    const fileId = `file:${this.filePath}`;
+    const fileName = baseName(this.filePath);
+    const fileId = generateNodeId(this.filePath, "file", fileName, this.filePath, "source-file");
     this.nodes.push({
       id: fileId,
+      identityKey: canonicalNodeIdentity(this.filePath, "file", this.filePath, "source-file"),
       kind: "file",
-      name: baseName(this.filePath),
+      name: fileName,
       qualifiedName: this.filePath,
       filePath: this.filePath,
       language: this.language,
@@ -80,12 +83,19 @@ class PythonWalker {
     extra?: Partial<ExtractedNode>,
   ): string | null {
     if (!name) return null;
-    const id = generateNodeId(this.filePath, kind, name);
+    const qualifiedName = this.qualify(name);
+    const baseIdentity = canonicalNodeIdentity(this.filePath, kind, qualifiedName, kind, extra?.signature);
+    const ordinal = this.identityOccurrences.get(baseIdentity) ?? 0;
+    this.identityOccurrences.set(baseIdentity, ordinal + 1);
+    const declarationRole = ordinal === 0 ? kind : `${kind}:ordinal:${ordinal}`;
+    const identityKey = canonicalNodeIdentity(this.filePath, kind, qualifiedName, declarationRole, extra?.signature);
+    const id = generateNodeId(this.filePath, kind, name, qualifiedName, declarationRole, extra?.signature);
     this.nodes.push({
       id,
+      identityKey,
       kind,
       name,
-      qualifiedName: this.qualify(name),
+      qualifiedName,
       filePath: this.filePath,
       language: this.language,
       startLine: node.startPosition.row + 1,
@@ -195,33 +205,16 @@ class PythonWalker {
   }
 
   private extractImport(node: TSNode): void {
-    if (node.type === "import_statement") {
-      for (const child of node.namedChildren) {
-        if (child.type === "dotted_name" || child.type === "aliased_import") {
-          const specifier = importName(child, this.source);
-          this.addRef(`file:${this.filePath}`, specifier, "imports", node);
-        }
-      }
-    } else if (node.type === "import_from_statement") {
-      const moduleNameNode = getChildByField(node, "module_name") ?? node.namedChild(0);
-      if (!moduleNameNode) return;
-
-      const moduleName = getNodeText(moduleNameNode, this.source);
-      this.addRef(`file:${this.filePath}`, moduleName, "imports", node);
-
-      // `from . import models` names the package as the module field and the
-      // actual sibling module separately. Preserve `.models` as another
-      // candidate so the resolver can bind it to `models.py`.
-      if (/^\.+$/.test(moduleName)) {
-        for (const child of node.namedChildren) {
-          if (child === moduleNameNode) continue;
-          if (child.type !== "dotted_name" && child.type !== "aliased_import") continue;
-          const importedName = importName(child, this.source);
-          if (importedName) {
-            this.addRef(`file:${this.filePath}`, `${moduleName}${importedName}`, "imports", child);
-          }
-        }
-      }
+    const fileId = this.scopeStack[0];
+    if (!fileId) return;
+    const grouped = new Map<string, Array<{ localName: string; importedName: string }>>();
+    for (const binding of pythonImportBindings(getNodeText(node, this.source))) {
+      const entries = grouped.get(binding.moduleSpecifier) ?? [];
+      entries.push({ localName: binding.localName, importedName: binding.importedName });
+      grouped.set(binding.moduleSpecifier, entries);
+    }
+    for (const [moduleSpecifier, bindings] of grouped) {
+      this.addRef(fileId, moduleSpecifier, "imports", node, { bindings });
     }
   }
 
@@ -276,6 +269,7 @@ class PythonWalker {
     targetName: string,
     kind: ExtractedEdge["kind"],
     node: TSNode,
+    metadata?: Record<string, unknown>,
   ): void {
     if (!targetName) return;
     this.edges.push({
@@ -284,6 +278,7 @@ class PythonWalker {
       kind,
       line: node.startPosition.row,
       column: node.startPosition.column,
+      metadata,
     });
   }
 }
@@ -297,11 +292,38 @@ function nameOf(node: TSNode, source: string): string {
   return nameNode ? getNodeText(nameNode, source) : "";
 }
 
-function importName(node: TSNode, source: string): string {
-  const imported = node.type === "aliased_import"
-    ? getChildByField(node, "name") ?? node.namedChild(0)
-    : node;
-  return imported ? getNodeText(imported, source) : "";
+function pythonImportBindings(statement: string): Array<{
+  moduleSpecifier: string; importedName: string; localName: string;
+}> {
+  const normalized = statement.replace(/[()]/g, " ").replace(/\\\s*\n/g, " ").trim();
+  const direct = normalized.match(/^import\s+(.+)$/s);
+  if (direct) {
+    return direct[1]!.split(",").map((entry) => entry.trim()).filter(Boolean).map((entry) => {
+      const [moduleSpecifier, alias] = entry.split(/\s+as\s+/);
+      return {
+        moduleSpecifier: moduleSpecifier!.trim(),
+        importedName: "*",
+        localName: alias?.trim() || moduleSpecifier!.trim().split(".")[0]!,
+      };
+    });
+  }
+  const from = normalized.match(/^from\s+([^\s]+)\s+import\s+(.+)$/s);
+  if (!from) return [];
+  const moduleName = from[1]!;
+  return from[2]!.split(",").map((entry) => entry.trim()).filter(Boolean).flatMap((entry) => {
+    const [importedName, alias] = entry.split(/\s+as\s+/);
+    const imported = importedName!.trim();
+    const importsSiblingModule = /^\.+$/.test(moduleName);
+    const localName = alias?.trim() || imported;
+    if (!importsSiblingModule) return [{ moduleSpecifier: moduleName, importedName: imported, localName }];
+    // `from . import name` can mean a symbol from __init__.py or a sibling
+    // module. Preserve both explicit candidates; later binding resolves only
+    // the one(s) backed by indexed files/symbols.
+    return [
+      { moduleSpecifier: moduleName, importedName: imported, localName },
+      { moduleSpecifier: `${moduleName}${imported}`, importedName: "*", localName },
+    ];
+  });
 }
 
 function isConstructorName(name: string): boolean {

--- a/src/graph/extraction/languages/rust.ts
+++ b/src/graph/extraction/languages/rust.ts
@@ -7,6 +7,7 @@ import type {
   TSTree,
 } from "../types.js";
 import {
+  canonicalNodeIdentity,
   generateNodeId,
   getChildByField,
   getNodeText,
@@ -39,6 +40,7 @@ class RustWalker {
   private readonly edges: ExtractedEdge[] = [];
   private scopeStack: string[] = [];
   private readonly deferredImpls: { node: TSNode; stack: string[] }[] = [];
+  private readonly identityOccurrences = new Map<string, number>();
 
   constructor(
     private readonly filePath: string,
@@ -47,11 +49,13 @@ class RustWalker {
   ) {}
 
   run(root: TSNode): { nodes: ExtractedNode[]; edges: ExtractedEdge[] } {
-    const fileId = `file:${this.filePath}`;
+    const fileName = baseName(this.filePath);
+    const fileId = generateNodeId(this.filePath, "file", fileName, this.filePath, "source-file");
     this.nodes.push({
       id: fileId,
+      identityKey: canonicalNodeIdentity(this.filePath, "file", this.filePath, "source-file"),
       kind: "file",
-      name: baseName(this.filePath),
+      name: fileName,
       qualifiedName: this.filePath,
       filePath: this.filePath,
       language: this.language,
@@ -112,12 +116,19 @@ class RustWalker {
     extra?: Partial<ExtractedNode>,
   ): string | null {
     if (!name) return null;
-    const id = generateNodeId(this.filePath, kind, name);
+    const qualifiedName = this.qualify(name);
+    const baseIdentity = canonicalNodeIdentity(this.filePath, kind, qualifiedName, kind, extra?.signature);
+    const ordinal = this.identityOccurrences.get(baseIdentity) ?? 0;
+    this.identityOccurrences.set(baseIdentity, ordinal + 1);
+    const declarationRole = ordinal === 0 ? kind : `${kind}:ordinal:${ordinal}`;
+    const identityKey = canonicalNodeIdentity(this.filePath, kind, qualifiedName, declarationRole, extra?.signature);
+    const id = generateNodeId(this.filePath, kind, name, qualifiedName, declarationRole, extra?.signature);
     this.nodes.push({
       id,
+      identityKey,
       kind,
       name,
-      qualifiedName: this.qualify(name),
+      qualifiedName,
       filePath: this.filePath,
       language: this.language,
       startLine: node.startPosition.row + 1,
@@ -311,8 +322,13 @@ class RustWalker {
     const arg = node.namedChild(0);
     if (!arg) return;
     const path = getNodeText(arg, this.source);
-    if (path) {
-      this.addRef(`file:${this.filePath}`, path, "imports", node);
+    const fileId = this.scopeStack[0];
+    if (path && fileId) {
+      for (const binding of rustUseBindings(path)) {
+        this.addRef(fileId, binding.moduleSpecifier, "imports", node, {
+          bindings: [{ localName: binding.localName, importedName: binding.importedName }],
+        });
+      }
     }
   }
 
@@ -378,6 +394,7 @@ class RustWalker {
     targetName: string,
     kind: ExtractedEdge["kind"],
     node: TSNode,
+    metadata?: Record<string, unknown>,
   ): void {
     if (!targetName) return;
     this.edges.push({
@@ -386,8 +403,30 @@ class RustWalker {
       kind,
       line: node.startPosition.row,
       column: node.startPosition.column,
+      metadata,
     });
   }
+}
+
+function rustUseBindings(path: string): Array<{
+  moduleSpecifier: string; importedName: string; localName: string;
+}> {
+  const normalized = path.trim();
+  const open = normalized.indexOf("{");
+  if (open >= 0) {
+    const prefix = normalized.slice(0, open).replace(/::$/, "");
+    const close = normalized.lastIndexOf("}");
+    const inner = normalized.slice(open + 1, close >= 0 ? close : undefined);
+    return inner.split(",").map((entry) => entry.trim()).filter(Boolean).map((entry) => {
+      const [memberPath, alias] = entry.split(/\s+as\s+/);
+      const full = [prefix, memberPath!.trim()].filter(Boolean).join("::");
+      const importedName = memberPath!.trim().split("::").at(-1)!;
+      return { moduleSpecifier: full, importedName, localName: alias?.trim() || importedName };
+    });
+  }
+  const [memberPath, alias] = normalized.split(/\s+as\s+/);
+  const importedName = memberPath!.trim().split("::").at(-1)!;
+  return [{ moduleSpecifier: memberPath!.trim(), importedName, localName: alias?.trim() || importedName }];
 }
 
 function nameOf(node: TSNode, source: string): string {

--- a/src/graph/extraction/languages/typescript.ts
+++ b/src/graph/extraction/languages/typescript.ts
@@ -133,12 +133,13 @@ class TsFamilyWalker {
     extra?: Partial<ExtractedNode>,
   ): string | null {
     if (!name) return null;
-    const id = generateNodeId(this.filePath, kind, name);
+    const qualifiedName = this.qualify(name);
+    const id = generateNodeId(this.filePath, kind, name, qualifiedName, kind, extra?.signature);
     this.nodes.push({
       id,
       kind,
       name,
-      qualifiedName: this.qualify(name),
+      qualifiedName,
       filePath: this.filePath,
       language: this.language,
       startLine: node.startPosition.row + 1,

--- a/src/graph/extraction/node-id.ts
+++ b/src/graph/extraction/node-id.ts
@@ -31,12 +31,30 @@ export function generateNodeId(
   filePath: string,
   kind: NodeKind,
   name: string,
+  qualifiedName = name,
+  declarationRole: string = kind,
+  signature = "",
 ): string {
+  const identity = canonicalNodeIdentity(filePath, kind, qualifiedName, declarationRole, signature);
   const hash = createHash("sha256")
-    .update(`${filePath}:${kind}:${name}`)
+    .update(identity)
     .digest("hex")
     .substring(0, 32);
   return `${kind}:${hash}`;
+}
+
+export function canonicalNodeIdentity(
+  filePath: string,
+  kind: NodeKind,
+  qualifiedName: string,
+  declarationRole: string = kind,
+  signature = "",
+): string {
+  return [
+    filePath.replaceAll("\\", "/"), kind,
+    qualifiedName.replace(/\s+/g, " ").trim(), declarationRole,
+    signature.replace(/\s+/g, " ").trim(),
+  ].join("\0");
 }
 
 /** Source text spanned by a syntax node (its byte range into `source`). */

--- a/src/graph/extraction/types.ts
+++ b/src/graph/extraction/types.ts
@@ -68,6 +68,9 @@ export interface TSNode {
   readonly namedChildren: TSNode[];
   readonly previousNamedSibling: TSNode | null;
   readonly nextNamedSibling: TSNode | null;
+  readonly isError?: boolean;
+  readonly isMissing?: boolean;
+  readonly hasError?: boolean;
   child(index: number): TSNode | null;
   namedChild(index: number): TSNode | null;
   childForFieldName(fieldName: string): TSNode | null;

--- a/src/graph/fingerprint-store.ts
+++ b/src/graph/fingerprint-store.ts
@@ -23,32 +23,80 @@ export class FingerprintStore {
   constructor(private readonly db: SqliteDatabase) {}
 
   upsert(nodeId: string, fingerprint: Fingerprint): void {
-    const buckets = bandHashes(fingerprint);
-    this.db.exec("SAVEPOINT mex_fingerprint_upsert");
+    this.upsertMany([{ nodeId, fingerprint }]);
+  }
+
+  /**
+   * Persist a corpus of fingerprints with one savepoint and one set of
+   * prepared statements. Each node still replaces exactly the same fingerprint
+   * and LSH rows as {@link upsert}; batching only removes statement preparation,
+   * savepoint, and per-band insert overhead from full graph builds.
+   */
+  upsertMany(entries: Iterable<{ nodeId: string; fingerprint: Fingerprint }>): void {
+    const latestByNode = new Map<string, { nodeId: string; fingerprint: Fingerprint }>();
+    for (const entry of entries) latestByNode.set(entry.nodeId, entry);
+    const ordered = [...latestByNode.values()].sort((left, right) => left.nodeId.localeCompare(right.nodeId));
+    if (ordered.length === 0) return;
+
+    const upsertFingerprint = this.db.prepare(
+      `INSERT INTO node_fingerprints (node_id, minhash, neighbors, token_count)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(node_id) DO UPDATE SET minhash=excluded.minhash,
+         neighbors=excluded.neighbors, token_count=excluded.token_count`,
+    );
+    const bucketCount = bandHashes(ordered[0]!.fingerprint).length;
+    const insertBuckets = this.db.prepare(
+      `INSERT INTO lsh_buckets (band, band_hash, node_id) VALUES ${
+        Array.from({ length: bucketCount }, () => "(?, ?, ?)").join(", ")
+      }`,
+    );
+
+    this.db.exec("SAVEPOINT mex_fingerprint_upsert_many");
     try {
-      this.db.prepare("DELETE FROM lsh_buckets WHERE node_id = ?").run(nodeId);
-      this.db.prepare(
-        `INSERT INTO node_fingerprints (node_id, minhash, neighbors, token_count)
-         VALUES (?, ?, ?, ?)
-         ON CONFLICT(node_id) DO UPDATE SET minhash=excluded.minhash,
-           neighbors=excluded.neighbors, token_count=excluded.token_count`,
-      ).run(nodeId, JSON.stringify(fingerprint.minhash), JSON.stringify(fingerprint.neighbors), fingerprint.tokenCount);
-      const insert = this.db.prepare(
-        "INSERT INTO lsh_buckets (band, band_hash, node_id) VALUES (?, ?, ?)",
-      );
-      buckets.forEach((bandHash, band) => insert.run(band, bandHash, nodeId));
-      this.db.exec("RELEASE mex_fingerprint_upsert");
+      // Delete prior buckets before inserting any replacements. Without a
+      // node_id-oriented LSH index, deleting once per node degenerates into a
+      // full-table scan for every fingerprint as this table grows. Chunked IN
+      // deletes scan the old table only a bounded number of times and produce
+      // the identical final rows (the last entry for a duplicate node wins).
+      const deleteChunkSize = 500;
+      for (let offset = 0; offset < ordered.length; offset += deleteChunkSize) {
+        const nodeIds = ordered.slice(offset, offset + deleteChunkSize).map((entry) => entry.nodeId);
+        this.db.prepare(
+          `DELETE FROM lsh_buckets WHERE node_id IN (${nodeIds.map(() => "?").join(",")})`,
+        ).run(...nodeIds);
+      }
+      for (const { nodeId, fingerprint } of ordered) {
+        const buckets = bandHashes(fingerprint);
+        if (buckets.length !== bucketCount) {
+          throw new Error(`Inconsistent fingerprint band count for ${nodeId}.`);
+        }
+        upsertFingerprint.run(
+          nodeId,
+          JSON.stringify(fingerprint.minhash),
+          JSON.stringify(fingerprint.neighbors),
+          fingerprint.tokenCount,
+        );
+        insertBuckets.run(...buckets.flatMap((bandHash, band) => [band, bandHash, nodeId]));
+      }
+      this.db.exec("RELEASE mex_fingerprint_upsert_many");
     } catch (error) {
-      this.db.exec("ROLLBACK TO mex_fingerprint_upsert");
-      this.db.exec("RELEASE mex_fingerprint_upsert");
+      this.db.exec("ROLLBACK TO mex_fingerprint_upsert_many");
+      this.db.exec("RELEASE mex_fingerprint_upsert_many");
       throw error;
     }
   }
 
   get(nodeId: string): Fingerprint | null {
     const row = this.db.prepare(
-      "SELECT node_id, minhash, neighbors, token_count FROM node_fingerprints WHERE node_id = ?",
-    ).get(nodeId) as FingerprintRow | undefined;
+      `SELECT node_id, minhash, neighbors, token_count
+       FROM node_fingerprints WHERE node_id = ?
+       UNION ALL
+       SELECT fingerprints.node_id, fingerprints.minhash, fingerprints.neighbors, fingerprints.token_count
+       FROM node_aliases aliases
+       JOIN node_fingerprints fingerprints ON fingerprints.node_id = aliases.canonical_node_id
+       WHERE aliases.alias_id = ?
+       LIMIT 1`,
+    ).get(nodeId, nodeId) as FingerprintRow | undefined;
     return row ? decodeRow(row) : null;
   }
 
@@ -71,8 +119,14 @@ export class FingerprintStore {
   getGroundedSource(scaffoldFile: string, nodeId: string): GroundedSource | null {
     const row = this.db.prepare(
       `SELECT scaffold_file, node_id, source, body_hash, fingerprint
-       FROM _mex_grounded_source WHERE scaffold_file = ? AND node_id = ?`,
-    ).get(scaffoldFile, nodeId) as {
+       FROM _mex_grounded_source WHERE scaffold_file = ? AND node_id = ?
+       UNION ALL
+       SELECT grounded.scaffold_file, grounded.node_id, grounded.source, grounded.body_hash, grounded.fingerprint
+       FROM node_aliases aliases
+       JOIN _mex_grounded_source grounded ON grounded.node_id = aliases.alias_id
+       WHERE grounded.scaffold_file = ? AND aliases.canonical_node_id = ?
+       LIMIT 1`,
+    ).get(scaffoldFile, nodeId, scaffoldFile, nodeId) as {
       scaffold_file: string;
       node_id: string;
       source: string;

--- a/src/graph/fingerprint.ts
+++ b/src/graph/fingerprint.ts
@@ -13,27 +13,66 @@ function hash32(value: string, seed: number): number {
   return digest.readUInt32BE(0);
 }
 
+export interface FingerprintBuilder {
+  create(
+    normalizedTokens: readonly string[],
+    callers?: readonly string[],
+    callees?: readonly string[],
+  ): Fingerprint;
+}
+
+/**
+ * Create a corpus-scoped builder that memoizes the 64 seed hashes for each
+ * normalized syntax trigram. Extractor tokens intentionally discard identifier
+ * and literal spellings, so the same small trigram vocabulary recurs throughout
+ * a repository; sharing those hashes avoids repeating identical SHA-256 work
+ * without changing a single MinHash value.
+ */
+export function createFingerprintBuilder(): FingerprintBuilder {
+  const trigramHashes = new Map<string, Uint32Array>();
+  return {
+    create(normalizedTokens, callers = [], callees = []) {
+      return createFingerprintInternal(normalizedTokens, callers, callees, trigramHashes);
+    },
+  };
+}
+
 /** Build a Tier-2 fingerprint from an extractor-provided normalized AST token stream. */
 export function createFingerprint(
   normalizedTokens: readonly string[],
   callers: readonly string[] = [],
   callees: readonly string[] = [],
 ): Fingerprint {
+  return createFingerprintInternal(normalizedTokens, callers, callees);
+}
+
+function createFingerprintInternal(
+  normalizedTokens: readonly string[],
+  callers: readonly string[],
+  callees: readonly string[],
+  trigramHashes?: Map<string, Uint32Array>,
+): Fingerprint {
   const trigrams = new Set<string>();
   for (let index = 0; index <= normalizedTokens.length - 3; index += 1) {
     trigrams.add(normalizedTokens.slice(index, index + 3).join("\0"));
   }
 
-  const minhash = Array.from({ length: K }, (_, seed) => {
-    let minimum = UINT32_MAX;
-    for (const trigram of trigrams) {
-      minimum = Math.min(minimum, hash32(trigram, seed));
+  const minima = new Uint32Array(K);
+  minima.fill(UINT32_MAX);
+  for (const trigram of trigrams) {
+    let hashes = trigramHashes?.get(trigram);
+    if (!hashes) {
+      hashes = new Uint32Array(K);
+      for (let seed = 0; seed < K; seed += 1) hashes[seed] = hash32(trigram, seed);
+      trigramHashes?.set(trigram, hashes);
     }
-    return minimum;
-  });
+    for (let seed = 0; seed < K; seed += 1) {
+      if (hashes[seed]! < minima[seed]!) minima[seed] = hashes[seed]!;
+    }
+  }
 
   return {
-    minhash,
+    minhash: Array.from(minima),
     neighbors: [...new Set([...callers, ...callees])].sort(),
     tokenCount: normalizedTokens.length,
   };

--- a/src/graph/resolution/context.ts
+++ b/src/graph/resolution/context.ts
@@ -42,3 +42,43 @@ export function createResolutionContext(store: GraphStore, projectRoot: string):
     getAllFiles: () => [...new Set(allNodes().map((node) => node.filePath))].sort(),
   };
 }
+
+/**
+ * Read-only resolver view over a staged corpus. This is used before the publish
+ * transaction so framework detection and cross-file resolution cannot hold the
+ * WAL writer lock while reading/parsing project files.
+ */
+export function createStagedResolutionContext(
+  stagedNodes: readonly GraphNode[],
+  projectRoot: string,
+  stagedSources: ReadonlyMap<string, string> = new Map(),
+): ResolutionContext {
+  const nodes = [...stagedNodes];
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const index = (key: (node: GraphNode) => string): Map<string, GraphNode[]> => {
+    const map = new Map<string, GraphNode[]>();
+    for (const node of nodes) {
+      const value = key(node);
+      const bucket = map.get(value) ?? [];
+      bucket.push(node);
+      map.set(value, bucket);
+    }
+    return map;
+  };
+  const byFile = index((node) => node.filePath);
+  const byName = index((node) => node.name);
+  const byQualifiedName = index((node) => node.qualifiedName);
+  const byKind = index((node) => node.kind);
+  return {
+    getNodesInFile: (path) => byFile.get(path) ?? [],
+    getNodesByName: (name) => byName.get(name) ?? [],
+    getNodesByQualifiedName: (name) => byQualifiedName.get(name) ?? [],
+    getNodesByKind: (kind) => byKind.get(kind) ?? [],
+    getNodeById: (id) => byId.get(id) ?? null,
+    fileExists: (path) => stagedSources.has(path) || existsSync(resolve(projectRoot, path)),
+    readFile: (path) => stagedSources.get(path)
+      ?? (() => { try { return readFileSync(resolve(projectRoot, path), "utf-8"); } catch { return null; } })(),
+    getProjectRoot: () => projectRoot,
+    getAllFiles: () => [...new Set([...stagedSources.keys(), ...nodes.map((node) => node.filePath)])].sort(),
+  };
+}

--- a/src/graph/resolution/frameworks/express.ts
+++ b/src/graph/resolution/frameworks/express.ts
@@ -1,5 +1,5 @@
 // Express FrameworkResolver — reference implementation for contributors.
-import { generateNodeId } from "../../extraction/node-id.js";
+import { canonicalNodeIdentity, generateNodeId } from "../../extraction/node-id.js";
 import type { GraphNode, Language } from "../../types.js";
 import type { FrameworkExtractionResult, FrameworkResolver, ResolvedRef, UnresolvedRef } from "../types.js";
 
@@ -22,14 +22,20 @@ export const expressResolver: FrameworkResolver = {
     const references: UnresolvedRef[] = [];
     const language = languageFor(filePath);
     if (!language) return { nodes, references };
+    const occurrences = new Map<string, number>();
     for (const match of content.matchAll(ROUTE)) {
       const name = `${match[1]!.toUpperCase()} ${match[3]!}`;
       const handler = match[4]!;
       const line = content.slice(0, match.index).split("\n").length;
-      const id = generateNodeId(filePath, "route", name);
-      nodes.push({ id, kind: "route", name, qualifiedName: name, filePath, language,
+      const ordinal = occurrences.get(name) ?? 0;
+      occurrences.set(name, ordinal + 1);
+      const role = `express-route:${ordinal}`;
+      const signature = `${name} -> ${handler}`;
+      const id = generateNodeId(filePath, "route", name, name, role, signature);
+      nodes.push({ id, identityKey: canonicalNodeIdentity(filePath, "route", name, role, signature),
+        kind: "route", name, qualifiedName: name, filePath, language,
         startLine: line, endLine: line, startColumn: 0, endColumn: match[0].length,
-        isExported: false, updatedAt: 0 });
+        signature, isExported: false, updatedAt: 0 });
       references.push({ fromNodeId: id, referenceName: handler, referenceKind: "function_ref",
         filePath, language, line: line - 1, column: 0 });
     }
@@ -40,8 +46,13 @@ export const expressResolver: FrameworkResolver = {
     const candidates = context.getNodesByName(ref.referenceName)
       .filter((node) => node.kind === "function" || node.kind === "method");
     const sameFile = candidates.filter((node) => node.filePath === ref.filePath);
-    const target = sameFile.length === 1 ? sameFile[0] : candidates.length === 1 ? candidates[0] : null;
-    return target ? { original: ref, targetNodeId: target.id, confidence: 1, resolvedBy: "framework" } : null;
+    // The route syntax proves the handler name, not a repository-global target.
+    // Imported handlers need an explicit compiler import binding; abstain here
+    // rather than connecting to a coincidentally unique same-named declaration.
+    const target = sameFile.length === 1 ? sameFile[0] : null;
+    return target
+      ? { original: ref, targetNodeId: target.id, confidence: 0.8, resolvedBy: "express-route-handler" }
+      : null;
   },
 };
 

--- a/src/graph/resolution/resolver.ts
+++ b/src/graph/resolution/resolver.ts
@@ -7,11 +7,11 @@
 // project is indexed, this pass binds each reference to a concrete node and
 // produces the persisted reference edges (calls / imports / extends / …).
 //
-// This is the 0.7.0 BASE resolver: name-based, with import-awareness for
-// disambiguation. It deliberately ships NO framework resolvers — the frozen
-// `FrameworkResolver` seam (`./types.ts`) is where the 0.7.x community adds
-// framework-specific edges. Kept pure (nodes + refs in → edges out) so it is
-// trivially unit-testable and reused unchanged by both `build` and `sync`.
+// Fallback-language bindings are intentionally conservative: lexical scope and
+// explicit import/use evidence only. Framework resolvers may add relationships
+// through their frozen seam, but repository-global name uniqueness is never
+// treated as proof. Kept pure (nodes + refs in → edges out) so build and sync
+// share the exact same deterministic resolution pass.
 
 import type { EdgeKind, GraphEdge, GraphNode, Language, NodeKind } from "../types.js";
 import type { UnresolvedRefRecord } from "../db/store.js";
@@ -64,19 +64,29 @@ export function resolveReferences(
   }
 
   const edges: GraphEdge[] = [];
-  const seen = new Set<string>(); // dedup (source|target|kind)
+  const seen = new Set<string>(); // dedup one semantic callsite
   const importsByFile = new Map<string, Set<string>>(); // file → imported file paths
+  const bindingsByFile = new Map<string, Map<string, Array<{
+    importedName: string; targetPath: string;
+  }>>>();
 
   const push = (
     source: string,
     target: string,
     kind: EdgeKind,
     ref: UnresolvedRefRecord,
-    provenance: GraphEdge["provenance"] = "tree-sitter",
+    provenance: GraphEdge["provenance"] = "lexical",
+    confidence = 1,
+    resolutionMethod = "lexical",
+    evidence?: Record<string, unknown>,
   ) => {
-    const key = `${source}|${target}|${kind}`;
+    const key = `${source}|${target}|${kind}|${ref.line ?? -1}|${ref.column ?? -1}`;
     if (seen.has(key)) return;
     seen.add(key);
+    ref.status = "resolved";
+    ref.targetId = target;
+    ref.confidence = confidence;
+    ref.resolver = resolutionMethod;
     edges.push({
       source,
       target,
@@ -84,6 +94,9 @@ export function resolveReferences(
       line: ref.line,
       column: ref.column,
       provenance,
+      confidence,
+      resolutionMethod,
+      evidence: evidence ? [evidence] : undefined,
     });
   };
 
@@ -103,10 +116,19 @@ export function resolveReferences(
     if (!targetPath) continue;
     const targetFileId = fileNodeByPath.get(targetPath);
     if (!targetFileId) continue;
-    push(ref.fromNodeId, targetFileId, "imports", ref);
+    push(ref.fromNodeId, targetFileId, "imports", ref, "lexical", 1, "explicit-import", {
+      moduleSpecifier: ref.referenceName,
+    });
     let set = importsByFile.get(fromNode.filePath);
     if (!set) importsByFile.set(fromNode.filePath, (set = new Set()));
     set.add(targetPath);
+    for (const binding of importBindings(ref)) {
+      let byLocal = bindingsByFile.get(fromNode.filePath);
+      if (!byLocal) bindingsByFile.set(fromNode.filePath, (byLocal = new Map()));
+      const entries = byLocal.get(binding.localName) ?? [];
+      entries.push({ importedName: binding.importedName, targetPath });
+      byLocal.set(binding.localName, entries);
+    }
   }
 
   // Pass 2: symbol references (calls, extends, implements, instantiates, …).
@@ -123,12 +145,34 @@ export function resolveReferences(
       const kind = ref.referenceKind === "function_ref"
         ? "references"
         : ref.referenceKind as EdgeKind;
-      push(ref.fromNodeId, frameworkResolution.targetNodeId, kind, ref, "heuristic");
+      push(
+        ref.fromNodeId,
+        frameworkResolution.targetNodeId,
+        kind,
+        ref,
+        "framework",
+        frameworkResolution.confidence,
+        frameworkResolution.resolvedBy,
+        {
+          resolver: frameworkResolution.resolvedBy,
+          wiringSite: { filePath: ref.filePath, line: ref.line, column: ref.column },
+        },
+      );
       continue;
     }
 
     // A `recv.method` callee resolves on its method name (last segment).
-    const simpleName = lastSegment(ref.referenceName);
+    const referencedName = lastSegment(ref.referenceName);
+    const qualifier = firstQualifier(ref.referenceName);
+    const directBindings = bindingsByFile.get(fromNode.filePath)?.get(referencedName) ?? [];
+    const qualifierBindings = qualifier
+      ? bindingsByFile.get(fromNode.filePath)?.get(qualifier) ?? []
+      : [];
+    const symbolBindings = directBindings.filter((binding) => binding.importedName !== "*");
+    const uniqueDirect = symbolBindings.length === 1
+      ? symbolBindings[0]
+      : undefined;
+    const simpleName = uniqueDirect?.importedName ?? referencedName;
     const candidates = byName.get(simpleName);
     if (!candidates || candidates.length === 0) continue;
 
@@ -139,14 +183,37 @@ export function resolveReferences(
         : candidates.filter((n) => allowedKinds.includes(n.kind) && n.id !== ref.fromNodeId);
     if (filtered.length === 0) continue;
 
-    const target = pickBest(filtered, fromNode.filePath, importsByFile.get(fromNode.filePath));
+    const provenFiles = new Set([
+      ...directBindings.map((binding) => binding.targetPath),
+      ...qualifierBindings.map((binding) => binding.targetPath),
+    ]);
+    const target = pickBest(
+      filtered,
+      fromNode,
+      ref,
+      provenFiles.size > 0 ? provenFiles : importsByFile.get(fromNode.filePath),
+    );
     if (!target) continue;
 
     const edgeKind: EdgeKind =
       ref.referenceKind === "function_ref" ? "references" : (ref.referenceKind as EdgeKind);
-    push(ref.fromNodeId, target.id, edgeKind, ref);
+    push(
+      ref.fromNodeId,
+      target.id,
+      edgeKind,
+      ref,
+      "lexical",
+      1,
+      target.filePath === fromNode.filePath ? "lexical-scope" : "explicit-import",
+    );
   }
 
+  for (const ref of refs) {
+    if (ref.status === "pending" || ref.status === undefined) {
+      ref.status = (ref.candidates?.length ?? 0) > 1 ? "ambiguous" : "unresolved";
+      ref.confidence = ref.status === "ambiguous" ? 0.75 : 0;
+    }
+  }
   return edges;
 }
 
@@ -154,36 +221,59 @@ export function resolveReferences(
  * Choose the best target among same-named candidates:
  *   1. one defined in the SAME file as the reference,
  *   2. one in a file the reference's file IMPORTS,
- *   3. the sole candidate, or a unique exported candidate,
  *   otherwise null (ambiguous — better no edge than a wrong one).
  */
 function pickBest(
   candidates: GraphNode[],
-  fromFile: string,
+  fromNode: GraphNode,
+  ref: UnresolvedRefRecord,
   importedFiles: Set<string> | undefined,
 ): GraphNode | null {
-  const sameFile = candidates.find((n) => n.filePath === fromFile);
-  if (sameFile) return sameFile;
+  const sameFile = candidates.filter((n) => n.filePath === fromNode.filePath);
+  if (sameFile.length > 0) {
+    // `this`/`super` and unqualified names may bind only inside the lexical
+    // container. Never pick the first same-named method in the file.
+    const receiver = ref.receiver ?? ref.referenceName.split(".").slice(0, -1).join(".");
+    const lexical = sameFile.filter((node) =>
+      node.containerId === fromNode.containerId
+      || node.containerId === fromNode.id
+      || (receiver === "this" && node.containerId === fromNode.containerId),
+    );
+    if (lexical.length === 1) return lexical[0]!;
+    if (lexical.length > 1) return null;
+    const moduleLevel = sameFile.filter((node) => !node.containerId);
+    if (!receiver && moduleLevel.length === 1) return moduleLevel[0]!;
+    return null;
+  }
 
   if (importedFiles) {
     const imported = candidates.filter((n) => importedFiles.has(n.filePath));
     if (imported.length === 1) return imported[0]!;
-    if (imported.length > 1) {
-      const exported = imported.filter((n) => n.isExported);
-      if (exported.length === 1) return exported[0]!;
-    }
   }
-
-  if (candidates.length === 1) return candidates[0]!;
-  const exported = candidates.filter((n) => n.isExported);
-  if (exported.length === 1) return exported[0]!;
   return null;
 }
 
 /** The segment after the last `.` (`obj.method` → `method`; `free` → `free`). */
 function lastSegment(name: string): string {
   const dot = name.lastIndexOf(".");
-  return dot < 0 ? name : name.slice(dot + 1);
+  const rust = name.lastIndexOf("::");
+  const index = Math.max(dot, rust);
+  return index < 0 ? name : name.slice(index + (index === rust ? 2 : 1));
+}
+
+function firstQualifier(name: string): string | undefined {
+  const match = name.match(/^([A-Za-z_$][\w$]*)(?:(?:::)|\.)/);
+  return match?.[1];
+}
+
+function importBindings(ref: UnresolvedRefRecord): Array<{ localName: string; importedName: string }> {
+  const raw = ref.metadata?.bindings;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((entry): entry is { localName: string; importedName: string } => {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as Record<string, unknown>;
+    return typeof candidate.localName === "string" && typeof candidate.importedName === "string";
+  });
 }
 
 /**
@@ -200,6 +290,9 @@ function resolveModulePath(
   if (language === "python") {
     return resolvePythonModulePath(fromFile, specifier, fileNodeByPath);
   }
+  if (language === "rust") {
+    return resolveRustModulePath(fromFile, specifier, fileNodeByPath);
+  }
   if (!specifier.startsWith(".")) return null; // external package
   const base = posixJoin(posixDirname(fromFile), specifier);
   const candidates = [
@@ -211,6 +304,55 @@ function resolveModulePath(
     if (fileNodeByPath.has(candidate)) return candidate;
   }
   return null;
+}
+
+/** Resolve a local Rust `use` path to the module file which owns its symbols. */
+function resolveRustModulePath(
+  fromFile: string,
+  specifier: string,
+  fileNodeByPath: Map<string, string>,
+): string | null {
+  const normalized = specifier.replace(/^\s*pub\s+/, "").replace(/\s+as\s+[^:,{]+$/, "").trim();
+  const bracePrefix = normalized.includes("{") ? normalized.slice(0, normalized.indexOf("{")).replace(/::$/, "") : normalized;
+  const parts = bracePrefix.split("::").map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const fromDir = posixDirname(fromFile);
+  const sourceRoot = fromFile.includes("/") ? fromFile.split("/", 1)[0]! : "";
+  let base = fromDir;
+  if (parts[0] === "crate") {
+    parts.shift();
+    base = sourceRoot;
+  } else if (parts[0] === "self") {
+    parts.shift();
+    base = rustModuleDirectory(fromFile);
+  } else {
+    while (parts[0] === "super") {
+      parts.shift();
+      base = posixDirname(base);
+    }
+  }
+
+  const bases = [...new Set([base, sourceRoot].filter((entry) => entry !== undefined))];
+  // A use path may end in either a module or a symbol. Try longest module path
+  // first, then peel symbol segments until an indexed local module is proven.
+  for (let length = parts.length; length > 0; length -= 1) {
+    const moduleParts = parts.slice(0, length);
+    for (const candidateBase of bases) {
+      const moduleBase = posixJoin(candidateBase, ...moduleParts);
+      for (const candidate of [`${moduleBase}.rs`, posixJoin(moduleBase, "mod.rs")]) {
+        if (fileNodeByPath.has(candidate)) return candidate;
+      }
+    }
+  }
+  return null;
+}
+
+function rustModuleDirectory(fromFile: string): string {
+  const dir = posixDirname(fromFile);
+  const file = fromFile.slice(fromFile.lastIndexOf("/") + 1);
+  if (file === "mod.rs" || file === "lib.rs" || file === "main.rs") return dir;
+  return posixJoin(dir, file.replace(/\.rs$/, ""));
 }
 
 /** Resolve Python's dotted absolute and package-relative module syntax. */

--- a/src/graph/resolution/types.ts
+++ b/src/graph/resolution/types.ts
@@ -53,8 +53,8 @@ export interface ResolvedRef {
   targetNodeId: string;
   /** Confidence in the resolution, 0–1. */
   confidence: number;
-  /** How it was resolved — `"framework"` for a `FrameworkResolver` hit. */
-  resolvedBy: "framework" | "import" | "exact-match" | "qualified-name" | "fuzzy";
+  /** Stable resolver name (for example `express-route-handler`). */
+  resolvedBy: string;
 }
 
 /**

--- a/src/graph/retrieval/query.ts
+++ b/src/graph/retrieval/query.ts
@@ -1,0 +1,183 @@
+/** Query planning shared by graph search and scope assembly. */
+
+export interface PlannedTerm {
+  /** Lowercase search token. */
+  term: string;
+  /** Token exactly as the user typed it. */
+  raw: string;
+  /** Distinctive identifiers are safe to treat as explicit symbol names. */
+  identifierLike: boolean;
+  /** Stems broaden recall but carry less evidence than literal query terms. */
+  stem: boolean;
+  /** Relative contribution to coverage and lexical scoring. */
+  weight: number;
+}
+
+export interface GraphQueryPlan {
+  raw: string;
+  terms: PlannedTerm[];
+  explicitIdentifiers: string[];
+  asksForTests: boolean;
+}
+
+/** English and code-question boilerplate that carries no repository signal. */
+export const GRAPH_STOP_WORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "been", "but", "by",
+  "can", "could", "did", "do", "does", "each", "every", "for", "from",
+  "give", "had", "has", "have", "how", "i", "if", "in", "into", "is",
+  "it", "its", "just", "may", "me", "might", "more", "my", "need", "no",
+  "not", "of", "on", "only", "or", "our", "out", "should", "show", "so",
+  "some", "such", "tell", "than", "that", "the", "their", "them", "then",
+  "there", "these", "they", "this", "those", "to", "up", "us", "used",
+  "using", "want", "was", "we", "what", "when", "where", "which", "who",
+  "why", "will", "with", "work", "works", "would", "you", "your",
+]);
+
+/** Generic code vocabulary is useful, but much less discriminative than domain words. */
+const LOW_SIGNAL_WORDS = new Set([
+  "agent", "called", "class", "code", "declaration", "declarations", "file",
+  "files", "function", "graph", "method", "node", "nodes", "object", "search",
+  "source", "symbol", "symbols", "task",
+]);
+
+/** Whether a token looks deliberately identifier-shaped as the user typed it. */
+export function isDistinctiveIdentifier(token: string): boolean {
+  // A hyphen by itself is ordinary English punctuation as often as it is code:
+  // `command-line`, `watch-mode`, and `source-file` must remain NL concepts.
+  // Paths, extensions, private names, and qualified names are unambiguous
+  // enough to pin. A hyphenated token carrying one of the other code-shape
+  // signals below (snake/camel case, digits, qualification) still qualifies.
+  if (/[/\\]/.test(token)) return true;
+  if (/^#[A-Za-z_$]/.test(token)) return true;
+  if (/[A-Za-z0-9_$](?:\.|::|#)[A-Za-z0-9_$]/.test(token)) return true;
+  if (/[_$0-9]/.test(token)) return true;
+  if (/^[A-Z][A-Za-z0-9]*$/.test(token)) return true;
+  return /[A-Z]/.test(token.slice(1));
+}
+
+/**
+ * Preserve a compound identifier and expose its camelCase/snake_case components.
+ * `BudgetLedger` becomes `budgetledger`, `budget`, `ledger`.
+ */
+export function identifierComponents(raw: string): string[] {
+  const fragments = raw.split(/[/\\.:#-]+/).filter(Boolean);
+  if (fragments.length > 1 || /[/\\.:#-]/.test(raw)) {
+    return [...new Set(fragments.flatMap(identifierFragmentComponents))];
+  }
+  return identifierFragmentComponents(raw);
+}
+
+function identifierFragmentComponents(raw: string): string[] {
+  const cleaned = raw.replace(/[^A-Za-z0-9_$]/g, "").replace(/^[$_]+|[$_]+$/g, "");
+  if (!cleaned) return [];
+  const whole = cleaned.toLowerCase();
+  const split = cleaned
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/[_$]+/g, " ")
+    .split(/\s+/)
+    .map((entry) => entry.toLowerCase())
+    .filter((entry) => entry.length >= 2);
+  return [...new Set([whole, ...split])];
+}
+
+/** Conservative suffix stemming for identifier-oriented prefix search. */
+export function stemVariants(term: string): string[] {
+  const out = new Set<string>();
+  const add = (value: string): void => {
+    if (value.length >= 3 && value !== term) out.add(value);
+  };
+  if (term.endsWith("ing") && term.length > 5) {
+    const base = term.slice(0, -3);
+    add(base);
+    add(`${base}e`);
+    if (base.at(-1) === base.at(-2)) add(base.slice(0, -1));
+  }
+  if ((term.endsWith("tion") || term.endsWith("sion")) && term.length >= 9) {
+    // Derivational nouns often describe code whose identifier uses a related
+    // stem: configuration -> config, compilation -> compiler, resolution ->
+    // resolver. A five-character prefix is deliberately conservative: it is
+    // long enough for identifier prefix matching, while avoiding a synonym
+    // table or aggressive linguistic guessing. The planner weights it below
+    // ordinary inflectional stems.
+    add(term.slice(0, 5));
+  }
+  if (term.endsWith("ment") && term.length > 6) add(term.slice(0, -4));
+  if (term.endsWith("ies") && term.length > 4) add(`${term.slice(0, -3)}y`);
+  else if (/(?:sses|xes|zes|ches|shes|oes)$/.test(term) && term.length > 4) add(term.slice(0, -2));
+  else if (term.endsWith("s") && !term.endsWith("ss") && term.length > 4) add(term.slice(0, -1));
+  if (term.endsWith("ed") && term.length > 4) {
+    add(term.slice(0, -1));
+    add(term.slice(0, -2));
+  }
+  return [...out];
+}
+
+/** Turn a natural-language task into bounded, weighted index terms. */
+export function planGraphQuery(raw: string): GraphQueryPlan {
+  const sourceTokens = raw.match(/[#A-Za-z_$][#A-Za-z0-9_$.:/\\-]*/g) ?? [];
+  const terms = new Map<string, PlannedTerm>();
+  const explicitIdentifiers: string[] = [];
+
+  const add = (entry: PlannedTerm): void => {
+    if (entry.term.length < 2 || GRAPH_STOP_WORDS.has(entry.term)) return;
+    const current = terms.get(entry.term);
+    if (!current || entry.weight > current.weight) terms.set(entry.term, entry);
+  };
+
+  for (const rawToken of sourceTokens.slice(0, 40)) {
+    const distinctive = isDistinctiveIdentifier(rawToken);
+    const stronglyCodeShaped = /[/\\.:#_$0-9]/.test(rawToken)
+      || (!/^[A-Z]+$/.test(rawToken) && /[A-Z]/.test(rawToken.slice(1)));
+    const components = identifierComponents(rawToken);
+    if (components.length === 0) continue;
+    if (distinctive && components.some((component) => !GRAPH_STOP_WORDS.has(component))) {
+      explicitIdentifiers.push(rawToken);
+    }
+    for (const [index, term] of components.entries()) {
+      const lowSignal = LOW_SIGNAL_WORDS.has(term);
+      add({
+        term,
+        raw: rawToken,
+        identifierLike: distinctive && index === 0,
+        stem: false,
+        weight: distinctive && index === 0 ? (stronglyCodeShaped ? 2 : 1.15) : lowSignal ? 0.35 : 1,
+      });
+      if (index > 0 || components.length === 1) {
+        for (const stem of stemVariants(term)) {
+          const derivationalPrefix = /(?:tion|sion)$/.test(term)
+            && term.length >= 9 && stem === term.slice(0, 5);
+          add({
+            term: stem,
+            raw: rawToken,
+            identifierLike: false,
+            stem: true,
+            weight: derivationalPrefix ? (lowSignal ? 0.08 : 0.2) : lowSignal ? 0.15 : 0.55,
+          });
+        }
+      }
+    }
+  }
+
+  // A stopword-only query should produce a legitimate empty result, not match everything.
+  return {
+    raw,
+    terms: [...terms.values()].slice(0, 32),
+    explicitIdentifiers: [...new Set(explicitIdentifiers)].slice(0, 16),
+    asksForTests: /\b(test|tests|testing|spec|specs|verify|verification)\b/i.test(raw),
+  };
+}
+
+/** Test, fixture, example, benchmark, generated, and other non-production paths. */
+export function isLowValueGraphPath(filePath: string): boolean {
+  const path = filePath.toLowerCase();
+  return (
+    /(^|\/)(__tests?__|tests?|specs?|fixtures?|examples?|samples?|benchmarks?|demos?|mocks?|testdata|integration)(\/|$)/.test(path)
+    || /\.(test|spec)\.[^/]+$/.test(path)
+    || /(^|\/)test_[^/]+\.[^/]+$/.test(path)
+    || /_test\.[^/]+$/.test(path)
+    || /(^|\/)evaluate\//.test(path)
+    || /(^|\/)(generated|vendor)\//.test(path)
+    || /(?:^|\/).*(?:\.generated|\.gen|\.pb)\.[^/]+$/.test(path)
+  );
+}

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -47,7 +47,9 @@ export async function loadGroundingRuntime(config: MexConfig): Promise<Grounding
     const fingerprints = new FingerprintStore(db);
     const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
     const changed = findChangedSourceFiles(config.projectRoot, db);
-    if (changed.length > 0) await graph.sync(changed);
+    // sync also checks the persisted compiler/config/grammar manifest, so it
+    // must run even when source mtimes are unchanged.
+    await graph.sync(changed);
     const reconciler = new MinHashReconciler(fingerprints);
     const checkerReconciler: Reconciler & GroundingReconcilerCapabilities = {
       reconcile: (nodeId, baseline) => reconciler.reconcile(nodeId, baseline),
@@ -126,7 +128,19 @@ export function persistMovedGroundings(
     const scaffoldFile = relative(config.projectRoot, filePath).replaceAll("\\", "/");
     let dirty = false;
     for (const grounding of groundings) {
-      if (runtime.graph.getNode(grounding.node)) continue;
+      const aliasedNode = runtime.graph.getNode(grounding.node);
+      if (aliasedNode) {
+        if (aliasedNode.id === grounding.node) continue;
+        const oldId = grounding.node;
+        grounding.node = aliasedNode.id;
+        const fingerprint = runtime.reconciler.getFingerprint(aliasedNode.id);
+        if (fingerprint) grounding.fingerprint = serializeFingerprint(fingerprint);
+        saveCurrentBaseline(config, scaffoldFile, grounding.node, grounding.fingerprint, runtime);
+        runtime.fingerprints.deleteGroundedSource(scaffoldFile, oldId);
+        dirty = true;
+        moved += 1;
+        continue;
+      }
       const baselineSource = runtime.reconciler.getGroundedSource(scaffoldFile, grounding.node);
       const baseline = deserializeFingerprint(grounding.fingerprint)
         ?? (baselineSource ? deserializeFingerprint(baselineSource.fingerprint) : null);
@@ -146,7 +160,13 @@ export function persistMovedGroundings(
     let anchoredContent = groundedContent;
     const anchors = findMexAnchors(anchoredContent);
     for (const anchor of [...anchors].reverse()) {
-      if (runtime.graph.getNode(anchor.nodeId)) continue;
+      const aliasedNode = runtime.graph.getNode(anchor.nodeId);
+      if (aliasedNode) {
+        if (aliasedNode.id === anchor.nodeId) continue;
+        anchoredContent = rewriteMexAnchor(anchoredContent, anchor, aliasedNode.id);
+        moved += 1;
+        continue;
+      }
       const baselineSource = runtime.reconciler.getGroundedSource(scaffoldFile, anchor.nodeId);
       const baseline = runtime.anchorFingerprints.get(anchor.nodeId)
         ?? (baselineSource ? deserializeFingerprint(baselineSource.fingerprint) : null);

--- a/src/graph/schema.sql
+++ b/src/graph/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS schema_versions (
 );
 
 INSERT OR IGNORE INTO schema_versions (version, applied_at, description)
-VALUES (1, strftime('%s', 'now') * 1000, 'Initial mex code-graph schema (CG base + node.body_hash + fingerprints + grounded source)');
+VALUES (2, strftime('%s', 'now') * 1000, 'Trustworthy graph identity, health, references, aliases, and source chunks');
 
 -- =============================================================================
 -- Core tables (ported from CodeGraph — kept as-is except node.body_hash)
@@ -59,6 +59,8 @@ CREATE TABLE IF NOT EXISTS nodes (
     kind TEXT NOT NULL,
     name TEXT NOT NULL,
     qualified_name TEXT NOT NULL,
+    container_id TEXT,
+    identity_key TEXT NOT NULL,
     file_path TEXT NOT NULL,
     language TEXT NOT NULL,
     start_line INTEGER NOT NULL,
@@ -95,6 +97,9 @@ CREATE TABLE IF NOT EXISTS edges (
     line INTEGER,
     col INTEGER,
     provenance TEXT DEFAULT NULL,
+    confidence REAL NOT NULL DEFAULT 1.0,
+    resolution_method TEXT,
+    evidence TEXT,
     FOREIGN KEY (source) REFERENCES nodes(id) ON DELETE CASCADE,
     FOREIGN KEY (target) REFERENCES nodes(id) ON DELETE CASCADE
 );
@@ -109,13 +114,19 @@ CREATE TABLE IF NOT EXISTS files (
     modified_at INTEGER NOT NULL,
     indexed_at INTEGER NOT NULL,
     node_count INTEGER DEFAULT 0,
-    errors TEXT               -- JSON array
+    errors TEXT,              -- JSON array
+    parse_status TEXT NOT NULL DEFAULT 'ok' CHECK(parse_status IN ('ok','partial','failed')),
+    diagnostic_count INTEGER NOT NULL DEFAULT 0,
+    missing_count INTEGER NOT NULL DEFAULT 0,
+    error_coverage REAL NOT NULL DEFAULT 0,
+    extractor_version TEXT NOT NULL DEFAULT 'unknown'
 );
 
 -- Unresolved references: parked during single-file extraction, resolved after a
 -- full index pass (two-phase extract -> resolve). Kept so cross-file edges work.
 CREATE TABLE IF NOT EXISTS unresolved_refs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ref_key TEXT NOT NULL UNIQUE,
     from_node_id TEXT NOT NULL,
     reference_name TEXT NOT NULL,
     reference_kind TEXT NOT NULL,
@@ -124,7 +135,65 @@ CREATE TABLE IF NOT EXISTS unresolved_refs (
     candidates TEXT,          -- JSON array
     file_path TEXT NOT NULL DEFAULT '',
     language TEXT NOT NULL DEFAULT 'unknown',
+    receiver TEXT,
+    qualifier TEXT,
+    import_source TEXT,
+    metadata TEXT,
+    status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','resolved','ambiguous','unresolved')),
+    target_id TEXT,
+    confidence REAL,
+    resolver TEXT,
     FOREIGN KEY (from_node_id) REFERENCES nodes(id) ON DELETE CASCADE
+);
+
+-- Compiler/fallback import binding evidence. This is deliberately separate
+-- from graph edges: an import may be valid even when its target is outside the
+-- indexed corpus.
+CREATE TABLE IF NOT EXISTS import_bindings (
+    binding_key TEXT PRIMARY KEY,
+    file_path TEXT NOT NULL,
+    local_name TEXT NOT NULL,
+    imported_name TEXT NOT NULL,
+    module_specifier TEXT NOT NULL,
+    resolved_file_path TEXT,
+    target_id TEXT,
+    is_type_only INTEGER NOT NULL DEFAULT 0,
+    metadata TEXT,
+    FOREIGN KEY (target_id) REFERENCES nodes(id) ON DELETE SET NULL
+);
+
+-- Compatibility aliases survive rebuilds. Readers accept alias ids, while all
+-- discovery APIs emit only the canonical node id.
+CREATE TABLE IF NOT EXISTS node_aliases (
+    alias_id TEXT PRIMARY KEY,
+    canonical_node_id TEXT NOT NULL,
+    match_method TEXT NOT NULL,
+    confidence REAL NOT NULL,
+    created_at INTEGER NOT NULL,
+    FOREIGN KEY (canonical_node_id) REFERENCES nodes(id) ON DELETE CASCADE
+);
+
+-- Source retrieval is indexed in overlapping windows. The FTS table is
+-- contentless: response source is always re-read from disk.
+CREATE TABLE IF NOT EXISTS source_chunks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    path_terms TEXT NOT NULL,
+    identifier_terms TEXT NOT NULL,
+    comment_terms TEXT NOT NULL,
+    UNIQUE(file_path, start_line, end_line)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS source_chunks_fts USING fts5(
+    path_terms,
+    identifier_terms,
+    comment_terms,
+    source_text,
+    content='',
+    contentless_delete=1
 );
 
 -- =============================================================================
@@ -167,6 +236,8 @@ CREATE INDEX IF NOT EXISTS idx_nodes_file_path ON nodes(file_path);
 CREATE INDEX IF NOT EXISTS idx_nodes_language ON nodes(language);
 CREATE INDEX IF NOT EXISTS idx_nodes_file_line ON nodes(file_path, start_line);
 CREATE INDEX IF NOT EXISTS idx_nodes_lower_name ON nodes(lower(name));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_identity_key ON nodes(identity_key);
+CREATE INDEX IF NOT EXISTS idx_nodes_container_id ON nodes(container_id);
 
 -- Edge indexes. Narrow source-only / target-only indexes are intentionally
 -- omitted; the (source, kind) / (target, kind) composites cover them via
@@ -175,6 +246,9 @@ CREATE INDEX IF NOT EXISTS idx_edges_kind ON edges(kind);
 CREATE INDEX IF NOT EXISTS idx_edges_source_kind ON edges(source, kind);
 CREATE INDEX IF NOT EXISTS idx_edges_target_kind ON edges(target, kind);
 CREATE INDEX IF NOT EXISTS idx_edges_provenance ON edges(provenance);
+CREATE INDEX IF NOT EXISTS idx_edges_confidence ON edges(confidence);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_edges_semantic_callsite
+ON edges(source, target, kind, IFNULL(line, -1), IFNULL(col, -1));
 
 CREATE INDEX IF NOT EXISTS idx_files_language ON files(language);
 CREATE INDEX IF NOT EXISTS idx_files_modified_at ON files(modified_at);
@@ -183,6 +257,11 @@ CREATE INDEX IF NOT EXISTS idx_unresolved_from_node ON unresolved_refs(from_node
 CREATE INDEX IF NOT EXISTS idx_unresolved_name ON unresolved_refs(reference_name);
 CREATE INDEX IF NOT EXISTS idx_unresolved_file_path ON unresolved_refs(file_path);
 CREATE INDEX IF NOT EXISTS idx_unresolved_from_name ON unresolved_refs(from_node_id, reference_name);
+CREATE INDEX IF NOT EXISTS idx_unresolved_status ON unresolved_refs(status);
+CREATE INDEX IF NOT EXISTS idx_import_bindings_file ON import_bindings(file_path);
+CREATE INDEX IF NOT EXISTS idx_import_bindings_local ON import_bindings(file_path, local_name);
+CREATE INDEX IF NOT EXISTS idx_aliases_canonical ON node_aliases(canonical_node_id);
+CREATE INDEX IF NOT EXISTS idx_source_chunks_file ON source_chunks(file_path, start_line);
 
 -- =============================================================================
 -- Project metadata (ported from CG — small key/value store for build metadata,

--- a/src/graph/scope.ts
+++ b/src/graph/scope.ts
@@ -293,7 +293,9 @@ export function selectScope(
         && (nodeMatchesConceptInIdentity(target, pair.left)
           || nodeMatchesConceptInIdentity(target, pair.right))
         && (plan.asksForTests || !isLowValueGraphPath(target.filePath)))
-      .map(({ node: target, edge }) => ({ source, target, edge, sourceRank, phraseIndex: pair.index }))));
+      .map(({ node: target, edge }) => ({
+        source, target, edge, sourceRank, phraseIndex: pair.index, left: pair.left, right: pair.right,
+      }))));
   const semanticPhraseBridges: SemanticPhraseBridge[] = [];
   const semanticPhraseTargetPaths = new Set<string>();
   for (const bridge of phraseBridgeCandidates.sort((left, right) => left.sourceRank - right.sourceRank
@@ -314,7 +316,7 @@ export function selectScope(
     target.reasons.add(`graph:${bridge.edge.kind}`);
     target.reasons.add("query-phrase-flow");
     target.reliable = true;
-    for (const concept of [adjacentConceptPairs[bridge.phraseIndex]!.left, adjacentConceptPairs[bridge.phraseIndex]!.right]) {
+    for (const concept of [bridge.left, bridge.right]) {
       addConceptEvidence(source, concept);
       addConceptEvidence(target, concept);
     }

--- a/src/graph/scope.ts
+++ b/src/graph/scope.ts
@@ -1,15 +1,12 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import type { GraphEngine } from "./engine.js";
-import type { GraphNode, NodeKind } from "./types.js";
+import type { GraphEngine, GraphNeighbor, IndexedFileInfo, SourceChunkMatch } from "./engine.js";
+import { identifierComponents, isLowValueGraphPath, planGraphQuery } from "./retrieval/query.js";
+import type { EdgeKind, GraphEdge, GraphNode, NodeKind } from "./types.js";
 
 export type DetailLevel = "minimal" | "standard" | "source";
 
-/**
- * Ephemeral, agent-facing fact for one graph node — structure and relationship
- * counts, never the source body. Source is a separate, opt-in {@link SourceRange}
- * record. Never persisted.
- */
 export interface CompactFact {
   id: string;
   kind: NodeKind;
@@ -23,20 +20,14 @@ export interface CompactFact {
   calleeCount: number;
   detail: DetailLevel;
   sourceIncluded: boolean;
-  /** Short content hash (node body sha256) for cache-aware source expansion. */
   bodyHash?: string;
-  /** Full serialized minhash fingerprint. Opt-in (--fingerprint); used by grounding. */
   fingerprint?: string;
-  /** Relevance score in [0,1]. Present on `scope` facts only. */
   score?: number;
-  /** Why this node was selected (e.g. "exact-name-match"). Scope facts only. */
   selectionReasons?: string[];
 }
 
-/** Quota bucket for scope selection diversity. */
 export type SelectionCategory = "direct" | "neighbor" | "test";
 
-/** A ranked scope candidate with its reasons and quota bucket. */
 export interface ScopedCandidate {
   id: string;
   score: number;
@@ -44,165 +35,2639 @@ export interface ScopedCandidate {
   category: SelectionCategory;
 }
 
-/** One node's source body, read on demand and line-capped. */
+export interface RankedScopeFile {
+  filePath: string;
+  score: number;
+  reasons: string[];
+  nodeIds: string[];
+  textHits: SourceChunkMatch[];
+  textOnly: boolean;
+  parseStatus: "ok" | "partial" | "failed";
+}
+
+export interface ScopeFlow { steps: GraphEdge[]; }
+
+export interface ScopeSelection {
+  candidates: ScopedCandidate[];
+  files: RankedScopeFile[];
+  flows: ScopeFlow[];
+  matchedCount: number;
+  coveredTerms: string[];
+  evidenceStrength: "strong" | "moderate" | "weak" | "none";
+}
+
 export interface SourceRange {
   startLine: number;
   endLine: number;
   nodeIds: string[];
   content: string;
   truncated: boolean;
+  reason?: "whole-file" | "complete-symbol" | "query-hit" | "callsite" | "signature" | "text-only";
 }
 
-/** FTS top-ten seeds expanded by one hop in both call directions. Deduped. */
-export function scopeSelect(graph: GraphEngine, task: string): string[] {
-  const ids = new Set<string>();
-  for (const seed of graph.searchNodes(task, { limit: 10 })) {
-    ids.add(seed.id);
-    for (const caller of graph.getCallers(seed.id)) ids.add(caller.id);
-    for (const callee of graph.getCallees(seed.id)) ids.add(callee.id);
-  }
-  return [...ids];
-}
+const RRF_K = 60;
+const SOURCE_FILE_RRF_WEIGHT = 30;
+const RELEVANCE_EDGE_KINDS: EdgeKind[] = [
+  "calls", "instantiates", "references", "imports", "exports", "extends",
+  "implements", "overrides", "type_of", "returns", "contains",
+];
+const FLOW_EDGE_KINDS: EdgeKind[] = ["calls", "instantiates", "references"];
+const FLOW_TRAVERSAL_EDGE_KINDS: EdgeKind[] = [...FLOW_EDGE_KINDS, "contains"];
+const STRONG_FLOW_RELEVANCE = 2;
+const SOURCE_NEAR_CUTOFF_RATIO = 0.85;
+/** Fixed request limits: callers in a high-fan-in graph must not multiply flow work. */
+const MAX_FLOW_SEEDS = 32;
+const FLOW_TRAVERSAL_WORK_BUDGET = 256;
+const FLOW_BRANCH_LIMIT = 8;
+/** One proven whole-query call pair may complete through a direct callback. */
+const CALL_PAIR_CALLBACKS_LIMIT = 2;
+const CALL_PAIR_CALLBACK_EDGES_LIMIT = 4;
+const MIN_CALL_PAIR_CALLBACK_TERMINAL_NAME_RELEVANCE = 1;
+/** Bounded adjacent-concept searches used only to prove cross-file semantic destinations. */
+const MAX_SEMANTIC_PHRASE_SEARCHES = 8;
+const MAX_SEMANTIC_PHRASE_CANDIDATES = 8;
+const MAX_SEMANTIC_PHRASE_OUTGOING_PER_SOURCE = 16;
+const MAX_SEMANTIC_PHRASE_BRIDGES = 2;
+const MIN_SEMANTIC_PHRASE_CONCEPT_WEIGHT = 1;
+/** Whole-query call-pair seeds stay inside the already fetched, bounded BM25 pool. */
+const MAX_FULL_QUERY_CALL_PAIR_RANK = 64;
+const MAX_FULL_QUERY_CALL_PAIR_SEEDS = 2;
+/** A compound request may reserve at most two independently strong responsibilities. */
+const MAX_STRONG_INTENT_FACET_DECLARATIONS = 2;
 
-const QUOTA: Record<SelectionCategory, number> = { direct: 5, neighbor: 4, test: 2 };
-const HOP_CAP = 3;
-
-interface Candidate {
+interface NodeEvidence {
   node: GraphNode;
-  score: number;
+  rrf: number;
+  /** Best zero-based rank in the independent whole-task node BM25 channel. */
+  fullQueryRank: number;
+  /** Query evidence from an FTS region that overlaps this declaration. */
+  region: number;
+  /** Direct (non-propagated) portion of source-region evidence. */
+  directRegion: number;
+  regionHits: SourceChunkMatch[];
+  /** Best zero-based rank of a source chunk aligned to this declaration. */
+  bestRegionRank: number;
+  /** Declaration order supplied by the source-chunk bridge at that rank. */
+  bestRegionOverlapRank: number;
+  /** Trusted semantic callsites whose source locations fall inside matched regions. */
+  regionCallsites: Set<string>;
+  /** Trusted structural entries into one anonymous callback within a matched region. */
+  regionCallbackCallsites: Set<string>;
+  /** Best source-chunk rank of a trusted callsite that reached this node. */
+  bestCallsiteRank: number;
+  exact: boolean;
+  exactIdentifiers: Set<string>;
+  graph: number;
+  terms: Set<string>;
+  nameTerms: Set<string>;
   reasons: Set<string>;
-  category: SelectionCategory;
+  reliable: boolean;
 }
 
-function isTestNode(node: GraphNode): boolean {
-  return /(^|\/)(__tests__|tests?)\//.test(node.filePath) || /\.(test|spec)\./.test(node.filePath);
+interface FileEvidence {
+  filePath: string;
+  score: number;
+  /** Strongest declaration-aligned source-region signal in this file. */
+  region: number;
+  /** Strongest trusted callsite expansion entering this file. */
+  callsiteRegion: number;
+  /** Query-concept weight at the source region proving that callsite. */
+  callsiteQueryWeight: number;
+  /** Best source-chunk rank backing that callsite expansion. */
+  bestCallsiteRank: number;
+  terms: Set<string>;
+  reasons: Set<string>;
+  nodeIds: Set<string>;
+  textHits: SourceChunkMatch[];
+  /** Best zero-based position in the independent source-chunk channel. */
+  bestTextRank: number;
+  exact: boolean;
+  exactIdentifiers: Set<string>;
+  reliableGraph: boolean;
 }
 
-/** Identifier-like tokens in a task string (drops trivial 1-char fragments). */
-function taskTokens(task: string): string[] {
-  return [...new Set(task.split(/[^A-Za-z0-9_$]+/).filter((t) => t.length >= 2))];
+interface QueryConcept {
+  key: string;
+  raw: string;
+  weight: number;
+  terms: Array<{ term: string; stem: boolean }>;
 }
 
-/**
- * Scored, quota-limited scope selection. Combines whole-task semantic search,
- * exact identifier matches (which are boosted so explicitly named symbols survive
- * trimming), and a capped one-hop neighborhood, then applies per-category quotas
- * under `maxNodes`. Deterministic: ties break by node id.
- *
- * Returns the picked candidates plus `matchedCount`, the size of the candidate
- * pool before the cap (so callers can report truncation).
- */
+interface ScopeRequestAccess {
+  rememberNode(node: GraphNode): void;
+  getNode(id: string): GraphNode | null;
+  getIncoming(id: string, kinds: EdgeKind[]): GraphNeighbor[];
+  getOutgoing(id: string, kinds: EdgeKind[]): GraphNeighbor[];
+}
+
+interface DerivedFlowSeed {
+  node: GraphNode;
+  relevance: number;
+  callsiteRank: number;
+  confidence: number;
+}
+
+interface SemanticPhraseBridge {
+  source: NodeEvidence;
+  target: NodeEvidence;
+  edge: GraphEdge;
+  phraseIndex: number;
+  sourceRank: number;
+}
+
+interface FullQueryCallPair {
+  source: NodeEvidence;
+  target: NodeEvidence;
+  edge: GraphEdge;
+}
+
+export function scopeSelect(graph: GraphEngine, task: string): string[] {
+  return selectScope(graph, task, 24, 6).candidates.map((candidate) => candidate.id);
+}
+
+/** File-first hybrid retrieval with independent RRF channels and gated graph expansion. */
 export function selectScope(
   graph: GraphEngine,
   task: string,
   maxNodes: number,
-): { candidates: ScopedCandidate[]; matchedCount: number } {
-  const pool = new Map<string, Candidate>();
-  const add = (node: GraphNode, score: number, reason: string, bucket: SelectionCategory): void => {
-    const category = isTestNode(node) ? "test" : bucket;
-    const existing = pool.get(node.id);
-    if (existing) {
-      existing.score = Math.max(existing.score, score);
-      existing.reasons.add(reason);
-      if (category === "direct") existing.category = "direct";
-    } else {
-      pool.set(node.id, { node, score, reasons: new Set([reason]), category });
-    }
+  maxFiles = 6,
+): ScopeSelection {
+  if (maxNodes <= 0 || maxFiles <= 0) return emptySelection();
+  const plan = planGraphQuery(task);
+  if (plan.terms.length === 0 && plan.explicitIdentifiers.length === 0) return emptySelection();
+
+  const access = createScopeRequestAccess(graph);
+  const nodes = new Map<string, NodeEvidence>();
+  const fileEvidence = new Map<string, FileEvidence>();
+  const queryTerms = weightedTerms(plan);
+  const concepts = queryConcepts(plan);
+  const adjacentConceptPairs = concepts.slice(0, -1).map((left, index) => ({
+    left,
+    right: concepts[index + 1]!,
+    query: `${left.raw} ${concepts[index + 1]!.raw}`,
+    index,
+  })).filter(({ left, right }) => left.weight >= MIN_SEMANTIC_PHRASE_CONCEPT_WEIGHT
+    || right.weight >= MIN_SEMANTIC_PHRASE_CONCEPT_WEIGHT)
+    .slice(0, MAX_SEMANTIC_PHRASE_SEARCHES);
+  const requestedSearches = [
+    { query: task, limit: 80 },
+    ...plan.explicitIdentifiers.map((query) => ({ query, limit: 60 })),
+    ...concepts.slice(0, 16).map((concept) => ({ query: concept.raw, limit: 30 })),
+    ...adjacentConceptPairs.map((pair) => ({ query: pair.query, limit: 24 })),
+  ];
+  const searchRequests = new Map<string, { query: string; limit: number }>();
+  for (const request of requestedSearches) {
+    const key = normalizeNodeSearch(request.query);
+    const prior = searchRequests.get(key);
+    if (!prior || request.limit > prior.limit) searchRequests.set(key, { query: prior?.query ?? request.query, limit: request.limit });
+  }
+  const nodeSearchCache = new Map<string, GraphNode[]>();
+  for (const [key, request] of searchRequests) {
+    const results = graph.searchNodes(request.query, { limit: request.limit });
+    for (const node of results) access.rememberNode(node);
+    nodeSearchCache.set(key, results);
+  }
+  const searchNodes = (query: string, limit: number): GraphNode[] =>
+    (nodeSearchCache.get(normalizeNodeSearch(query)) ?? []).slice(0, limit);
+  const addNodeChannel = (
+    ranked: GraphNode[],
+    reason: string | ((node: GraphNode) => string),
+    exactIdentifier?: string,
+    fullQuery = false,
+  ): void => {
+    ranked.forEach((node, index) => {
+      const evidence = ensureNode(nodes, node);
+      evidence.rrf += 1 / (RRF_K + index + 1);
+      if (fullQuery) evidence.fullQueryRank = Math.min(evidence.fullQueryRank, index);
+      evidence.exact ||= exactIdentifier !== undefined;
+      if (exactIdentifier) evidence.exactIdentifiers.add(exactIdentifier);
+      evidence.reasons.add(typeof reason === "string" ? reason : reason(node));
+      for (const term of queryTerms) if (nodeContains(node, term.term, term.stem)) evidence.terms.add(term.term);
+      const nameComponents = new Set(searchComponents(node.name));
+      for (const term of queryTerms) {
+        if (componentMatches(nameComponents, term.term, term.stem)) evidence.nameTerms.add(term.term);
+      }
+    });
   };
 
-  graph.searchNodes(task, { limit: 10 }).forEach((node, i) => add(node, 0.6 - i * 0.03, "semantic-match", "direct"));
-  for (const token of taskTokens(task)) {
-    for (const match of graph.searchNodes(token, { limit: 20 })) {
-      if (match.name === token || match.qualifiedName === token || match.qualifiedName.endsWith(`::${token}`)) {
-        add(match, 1, "exact-name-match", "direct");
+  addNodeChannel(searchNodes(task, 80), "bm25-node", undefined, true);
+  for (const identifier of plan.explicitIdentifiers) {
+    const candidates = searchNodes(identifier, 60);
+    const strict = candidates.filter((node) => exactIdentifierMatch(node, identifier));
+    const exact = strict.length > 0 || !/^[A-Z][a-z]+$/.test(identifier)
+      ? strict
+      : candidates.filter((node) => caseFoldedIdentifierMatch(node, identifier));
+    addNodeChannel(exact, `exact:${identifier}`, identifier);
+  }
+  for (const concept of concepts.slice(0, 16)) {
+    const matchedTerm = new Map<string, string>();
+    const candidates = searchNodes(concept.raw, 30).filter((node) => {
+      const match = concept.terms.find((term) => nodeContains(node, term.term, term.stem));
+      if (match) matchedTerm.set(node.id, match.term);
+      return Boolean(match);
+    });
+    addNodeChannel(candidates, (node) => `term:${matchedTerm.get(node.id) ?? concept.key}`);
+  }
+
+  // A broad multi-responsibility query can rank a literal namesake above the
+  // actual entry point. Preserve a destination only when an adjacent query
+  // phrase independently matches both endpoints of a real, cross-file,
+  // compiler-trusted semantic edge. Same-file helpers, one-sided lexical
+  // matches, and ambiguous edges cannot consume this two-file reserve.
+  const phraseBridgeCandidates = adjacentConceptPairs.flatMap((pair) => searchNodes(pair.query, 24)
+    .map((source, sourceRank) => ({ source, sourceRank }))
+    .filter(({ source }) => nodeMatchesConcept(source, pair.left)
+      && nodeMatchesConcept(source, pair.right)
+      && (nodeMatchesConceptInIdentity(source, pair.left)
+        || nodeMatchesConceptInIdentity(source, pair.right))
+      && (plan.asksForTests || !isLowValueGraphPath(source.filePath)))
+    .slice(0, MAX_SEMANTIC_PHRASE_CANDIDATES)
+    .flatMap(({ source, sourceRank }) => [...access.getOutgoing(source.id, FLOW_EDGE_KINDS)]
+      .sort(compareSemanticPhraseNeighbor)
+      .slice(0, MAX_SEMANTIC_PHRASE_OUTGOING_PER_SOURCE)
+      .filter(({ node: target, edge }) => (edge.confidence ?? 1) >= 0.8
+        && source.filePath !== target.filePath
+        && isSourceAnchorKind(target)
+        && nodeMatchesConcept(target, pair.left)
+        && nodeMatchesConcept(target, pair.right)
+        && (nodeMatchesConceptInIdentity(target, pair.left)
+          || nodeMatchesConceptInIdentity(target, pair.right))
+        && (plan.asksForTests || !isLowValueGraphPath(target.filePath)))
+      .map(({ node: target, edge }) => ({ source, target, edge, sourceRank, phraseIndex: pair.index }))));
+  const semanticPhraseBridges: SemanticPhraseBridge[] = [];
+  const semanticPhraseTargetPaths = new Set<string>();
+  for (const bridge of phraseBridgeCandidates.sort((left, right) => left.sourceRank - right.sourceRank
+    || left.phraseIndex - right.phraseIndex
+    || (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+    || compareEdgeCallsite(left.edge, right.edge)
+    || left.source.filePath.localeCompare(right.source.filePath)
+    || left.source.id.localeCompare(right.source.id)
+    || left.target.filePath.localeCompare(right.target.filePath)
+    || left.target.id.localeCompare(right.target.id))) {
+    if (semanticPhraseTargetPaths.has(bridge.target.filePath)) continue;
+    const source = ensureNode(nodes, bridge.source);
+    const target = ensureNode(nodes, bridge.target);
+    source.rrf += 1 / (RRF_K + bridge.sourceRank + 1);
+    source.reasons.add("query-phrase-flow");
+    source.reliable = true;
+    target.graph = Math.max(target.graph, 0.16 * (bridge.edge.confidence ?? 1));
+    target.reasons.add(`graph:${bridge.edge.kind}`);
+    target.reasons.add("query-phrase-flow");
+    target.reliable = true;
+    for (const concept of [adjacentConceptPairs[bridge.phraseIndex]!.left, adjacentConceptPairs[bridge.phraseIndex]!.right]) {
+      addConceptEvidence(source, concept);
+      addConceptEvidence(target, concept);
+    }
+    const file = ensureFile(fileEvidence, target.node.filePath);
+    file.nodeIds.add(target.node.id);
+    file.reliableGraph = true;
+    file.reasons.add("query-phrase-flow");
+    semanticPhraseBridges.push({ source, target, edge: bridge.edge, phraseIndex: bridge.phraseIndex, sourceRank: bridge.sourceRank });
+    semanticPhraseTargetPaths.add(target.node.filePath);
+    if (semanticPhraseBridges.length >= MAX_SEMANTIC_PHRASE_BRIDGES) break;
+  }
+
+  const indexedFiles = safeIndexedFiles(graph);
+  const fileInfo = new Map(indexedFiles.map((file) => [file.path, file]));
+  const textHits = safeSourceSearch(graph, task, 100);
+  const queryRegionCallsiteRanks = new Map<string, number>();
+  const queryRegionCallsiteWeights = new Map<string, number>();
+  textHits.forEach((hit, index) => {
+    const evidence = ensureFile(fileEvidence, hit.filePath);
+    evidence.reasons.add("source-fts");
+    evidence.textHits.push(hit);
+    evidence.bestTextRank = Math.min(evidence.bestTextRank, index);
+
+    // Source FTS is a declaration-retrieval channel, not merely a file vote.
+    // The store supplies a bounded list of named declarations overlapping the
+    // recovered region. This bridges natural-language body/comment matches to
+    // symbols without inventing synonyms or graph relationships.
+    const hitTerms = new Set(hit.matchedTerms ?? []);
+    const localConceptCount = concepts.filter((concept) => conceptMatchesTerms(concept, hitTerms)).length;
+    const localConceptWeight = concepts.filter((concept) => conceptMatchesTerms(concept, hitTerms))
+      .reduce((sum, concept) => sum + concept.weight, 0);
+    for (const [overlapIndex, id] of (hit.nodeIds ?? []).entries()) {
+      const node = access.getNode(id);
+      if (!node || node.filePath !== hit.filePath || !isSourceAnchorKind(node)) continue;
+      const entry = ensureNode(nodes, node);
+      if (index < entry.bestRegionRank) {
+        entry.bestRegionRank = index;
+        entry.bestRegionOverlapRank = overlapIndex;
+      } else if (index === entry.bestRegionRank) {
+        entry.bestRegionOverlapRank = Math.min(entry.bestRegionOverlapRank, overlapIndex);
+      }
+      for (const term of hitTerms) entry.terms.add(term);
+      const nameComponents = new Set(searchComponents(node.name));
+      for (const term of queryTerms) {
+        if (componentMatches(nameComponents, term.term, term.stem)) entry.nameTerms.add(term.term);
+      }
+      const nameConceptCount = concepts.filter((concept) => conceptMatchesComponents(concept, nameComponents)).length;
+      const startsInside = node.startLine >= hit.startLine && node.startLine <= hit.endLine;
+      const enclosesRegion = node.startLine <= hit.startLine && node.endLine >= hit.endLine;
+      const alignment = Math.min(1.2,
+        Math.max(0, localConceptCount - 1) * 0.18
+        + nameConceptCount * 0.32
+        + (startsInside ? 0.08 : enclosesRegion ? 0.04 : 0)
+        + Math.min(0.1, Math.abs(hit.rank) * 2)
+        + 20 / (RRF_K + index + overlapIndex + 1));
+      entry.region = Math.max(entry.region, alignment);
+      entry.directRegion = Math.max(entry.directRegion, alignment);
+      if (!entry.regionHits.some((candidate) => candidate.filePath === hit.filePath
+        && candidate.startLine === hit.startLine && candidate.endLine === hit.endLine)) {
+        entry.regionHits.push(hit);
+      }
+      // Inspect semantic callsites only for the strongest global source
+      // regions. Looking up every declaration in all 100 windows is both noisy
+      // and needlessly expensive on compiler-sized repositories.
+      if (index < 24 || (index < 64 && overlapIndex === 0 && localConceptCount >= 2)) {
+        const outgoing = access.getOutgoing(node.id, FLOW_TRAVERSAL_EDGE_KINDS).filter((neighbor) => (
+          (neighbor.edge.confidence ?? 1) >= 0.8
+          && (neighbor.edge.kind !== "contains" || isUnnamedFlowNode(neighbor.node))
+        ));
+        for (const neighbor of outgoing) {
+          if (neighbor.edge.line === undefined || neighbor.edge.line < hit.startLine || neighbor.edge.line > hit.endLine) continue;
+          const key = edgeKey(neighbor.edge);
+          entry.regionCallsites.add(key);
+          queryRegionCallsiteRanks.set(key, Math.min(queryRegionCallsiteRanks.get(key) ?? index, index));
+          queryRegionCallsiteWeights.set(key, Math.max(queryRegionCallsiteWeights.get(key) ?? 0, localConceptWeight));
+          if (neighbor.edge.kind === "contains" && isUnnamedFlowNode(neighbor.node)) {
+            entry.regionCallbackCallsites.add(key);
+          }
+        }
+      }
+      entry.rrf += 1 / (RRF_K + index + overlapIndex + 1);
+      entry.reasons.add("source-region");
+      evidence.region = Math.max(evidence.region, alignment);
+      evidence.nodeIds.add(node.id);
+    }
+  });
+  for (const entry of nodes.values()) {
+    const file = ensureFile(fileEvidence, entry.node.filePath);
+    file.region = Math.max(file.region, regionStrength(entry));
+  }
+
+  // Per-term channels deliberately stay narrow, so a long natural-language
+  // request can place its real public entry point below every individual
+  // generic-term cutoff. Recover only a bounded declaration that is already
+  // in the whole-query pool, is public/exported, and calls another whole-query
+  // declaration that adds an independent intent concept. This compiler-proven
+  // pair rejects broad source/evaluation helpers that merely describe the
+  // retrieval machinery. Graph traversal, rather than further lexical
+  // widening, decides which later implementation helpers belong to the entry.
+  const fullQueryCallPairs = bestFullQueryCallPairs(
+    [...nodes.values()], concepts, access, MAX_FULL_QUERY_CALL_PAIR_SEEDS,
+  );
+  const fullQueryCallPairSeeds = fullQueryCallPairs.flatMap((pair) => [pair.source, pair.target]);
+  const fullQueryCallPairSeedIds = new Set(fullQueryCallPairSeeds.map((entry) => entry.node.id));
+  for (const entry of fullQueryCallPairSeeds) {
+    entry.reliable = true;
+    entry.reasons.add("bm25-call-pair");
+    for (const concept of concepts) {
+      if (nodeMatchesConcept(entry.node, concept)) addConceptEvidence(entry, concept);
+    }
+    const file = ensureFile(fileEvidence, entry.node.filePath);
+    file.nodeIds.add(entry.node.id);
+    file.reliableGraph = true;
+    file.reasons.add("bm25-call-pair");
+  }
+
+  const pathTerms = literalTerms(plan).filter((term) => term.length >= 3);
+  const adjacentPairs = pathTerms.slice(0, -1).map((term, index) => [term, pathTerms[index + 1]!] as const);
+  const pathMatches = indexedFiles.map((file) => {
+    const components = new Set(searchComponents(file.path));
+    const basename = new Set(searchComponents(file.path.split("/").at(-1) ?? file.path));
+    const matched = concepts.filter((concept) => conceptMatchesComponents(concept, components));
+    const basenameMatched = matched.filter((concept) => conceptMatchesComponents(concept, basename));
+    return { file, components, matched, basenameMatched };
+  }).filter((entry) => entry.matched.length > 0)
+    .sort((left, right) => right.matched.length - left.matched.length
+      || right.basenameMatched.length - left.basenameMatched.length
+      || left.file.path.localeCompare(right.file.path));
+  pathMatches.forEach(({ file, components, matched }, index) => {
+      const evidence = ensureFile(fileEvidence, file.path);
+      evidence.score += 1 / (RRF_K + index + 1);
+      evidence.reasons.add("path-match");
+      for (const concept of matched) {
+        for (const term of concept.terms) {
+          if (componentMatches(components, term.term, term.stem)) {
+            evidence.terms.add(term.term);
+          }
+        }
+      }
+    });
+
+  for (const evidence of nodes.values()) {
+    const file = ensureFile(fileEvidence, evidence.node.filePath);
+    file.nodeIds.add(evidence.node.id);
+    file.exact ||= evidence.exact;
+    for (const identifier of evidence.exactIdentifiers) file.exactIdentifiers.add(identifier);
+    for (const term of evidence.terms) file.terms.add(term);
+    for (const reason of evidence.reasons) file.reasons.add(reason);
+  }
+  for (const evidence of fileEvidence.values()) {
+    for (const term of pathTerms) {
+      if (searchComponents(evidence.filePath).includes(term)) evidence.terms.add(term);
+    }
+    for (const hit of evidence.textHits) {
+      for (const term of hit.matchedTerms ?? []) evidence.terms.add(term);
+      if (hit.rank < 0) evidence.score += Math.min(0.08, Math.abs(hit.rank) / 100);
+    }
+  }
+
+  const reliablePool = [...nodes.values()]
+    .filter((entry) => isReliableLexicalSeed(entry) || isReliableRegionSeed(entry))
+    .sort(compareNodeEvidence);
+  const reliableSeeds: NodeEvidence[] = [];
+  const seededFiles = new Set<string>();
+  // Preserve the executable declarations from the best query-bearing source
+  // windows before file-diverse/global filling. This is the bounded local
+  // second stage that lets `caller in matched region -> semantic callee` beat
+  // unrelated helpers from the same large file.
+  const callsiteSeedsByRegion = new Map<number, NodeEvidence[]>();
+  for (const entry of reliablePool.filter((candidate) => candidate.regionCallsites.size > 0)) {
+    const bucket = callsiteSeedsByRegion.get(entry.bestRegionRank) ?? [];
+    bucket.push(entry);
+    callsiteSeedsByRegion.set(entry.bestRegionRank, bucket);
+  }
+  const callsiteSeeds = [...callsiteSeedsByRegion.entries()]
+    .sort(([left], [right]) => left - right).slice(0, 6)
+    .flatMap(([, entries]) => entries.sort((left, right) => left.bestRegionOverlapRank - right.bestRegionOverlapRank
+      || compareNodeEvidence(left, right)
+      || right.regionCallsites.size - left.regionCallsites.size).slice(0, 2));
+  const callbackBridgeSeeds = reliablePool.filter((entry) => entry.regionCallbackCallsites.size > 0)
+    .sort((left, right) => left.bestRegionRank - right.bestRegionRank || compareNodeEvidence(left, right))
+    .slice(0, 4);
+  const semanticPhraseSeeds = semanticPhraseBridges.map((bridge) => bridge.source);
+  for (const entry of [...semanticPhraseSeeds, ...fullQueryCallPairSeeds, ...callbackBridgeSeeds, ...callsiteSeeds]) {
+    if (reliableSeeds.includes(entry)) continue;
+    if (reliableSeeds.length >= 12) break;
+    reliableSeeds.push(entry);
+    seededFiles.add(entry.node.filePath);
+  }
+  // A monolithic file can contribute dozens of equally lexical declarations.
+  // First reserve one seed per file, then fill a small second pass. This keeps
+  // the graph expansion bounded while preventing one central module from
+  // hiding a coherent query region in another file.
+  for (const entry of reliablePool) {
+    if (reliableSeeds.length >= 18) break;
+    if (seededFiles.has(entry.node.filePath)) continue;
+    seededFiles.add(entry.node.filePath);
+    reliableSeeds.push(entry);
+  }
+  for (const entry of reliablePool) {
+    if (reliableSeeds.length >= 24) break;
+    if (reliableSeeds.includes(entry)) continue;
+    reliableSeeds.push(entry);
+  }
+  for (const entry of reliableSeeds) {
+    entry.reliable = true;
+    ensureFile(fileEvidence, entry.node.filePath).reliableGraph = true;
+  }
+  const queue = reliableSeeds.map((entry) => ({
+    entry,
+    depth: 0,
+    allowTypedExpansion: isReliableLexicalSeed(entry) || fullQueryCallPairSeedIds.has(entry.node.id),
+  }));
+  const visited = new Set(queue.map(({ entry }) => entry.node.id));
+  for (let cursor = 0; cursor < queue.length && cursor < 180; cursor++) {
+    const current = queue[cursor]!;
+    if (current.depth >= 2) continue;
+    const currentHits = fileEvidence.get(current.entry.node.filePath)?.textHits ?? [];
+    const neighbors = reliableNeighbors(access, current.entry.node.id)
+      .filter((neighbor) => current.allowTypedExpansion
+        || queryCallsiteHit(current.entry.node.id, neighbor.edge, current.entry.regionHits));
+    for (const neighbor of neighbors
+      .sort((left, right) => compareQueryNeighbor(
+        current.entry.node.id, left, right, currentHits, queryTerms,
+      )).slice(0, 18)) {
+      const evidence = ensureNode(nodes, neighbor.node);
+      evidence.reliable = true;
+      evidence.graph = Math.max(evidence.graph, (2 - current.depth) * 0.08 * (neighbor.edge.confidence ?? 1));
+      evidence.reasons.add(`graph:${neighbor.edge.kind}`);
+      let propagatedCallsite = 0;
+      let propagatedCallsiteWeight = 0;
+      if (queryCallsiteHit(current.entry.node.id, neighbor.edge, current.entry.regionHits)) {
+        // A compiler-resolved call made inside a query-bearing region is much
+        // stronger than a coincidental name/body match. Carry that evidence to
+        // the callee so its file can compete with broad utility modules.
+        propagatedCallsite = Math.min(2, regionStrength(current.entry) + 1);
+        propagatedCallsiteWeight = queryCallsiteWeight(neighbor.edge, current.entry.regionHits, concepts);
+        const callsiteKey = edgeKey(neighbor.edge);
+        current.entry.regionCallsites.add(callsiteKey);
+        queryRegionCallsiteRanks.set(callsiteKey, Math.min(
+          queryRegionCallsiteRanks.get(callsiteKey) ?? current.entry.bestRegionRank,
+          current.entry.bestRegionRank,
+        ));
+        queryRegionCallsiteWeights.set(callsiteKey, Math.max(
+          queryRegionCallsiteWeights.get(callsiteKey) ?? 0,
+          propagatedCallsiteWeight,
+        ));
+        evidence.region = Math.max(evidence.region, propagatedCallsite);
+        evidence.bestCallsiteRank = Math.min(evidence.bestCallsiteRank, current.entry.bestRegionRank);
+        evidence.reasons.add("source-region:callsite");
+        if (neighbor.edge.kind === "contains" && isUnnamedFlowNode(neighbor.node)) {
+          // Preserve the matched source window across the one permitted
+          // anonymous callback bridge. The callback's compiler-resolved call
+          // can then reach its real callee without pretending the enclosing
+          // declaration called it directly.
+          for (const hit of current.entry.regionHits) {
+            if (!evidence.regionHits.some((candidate) => candidate.filePath === hit.filePath
+              && candidate.startLine === hit.startLine && candidate.endLine === hit.endLine)) {
+              evidence.regionHits.push(hit);
+            }
+          }
+          evidence.bestRegionRank = Math.min(evidence.bestRegionRank, current.entry.bestRegionRank);
+          evidence.bestRegionOverlapRank = Math.min(
+            evidence.bestRegionOverlapRank, current.entry.bestRegionOverlapRank,
+          );
+        }
+      }
+      for (const term of queryTerms) if (nodeContains(neighbor.node, term.term, term.stem)) evidence.terms.add(term.term);
+      const nameComponents = new Set(searchComponents(neighbor.node.name));
+      for (const term of queryTerms) {
+        if (componentMatches(nameComponents, term.term, term.stem)) evidence.nameTerms.add(term.term);
+      }
+      const file = ensureFile(fileEvidence, neighbor.node.filePath);
+      file.reliableGraph = true;
+      file.callsiteRegion = Math.max(file.callsiteRegion, propagatedCallsite);
+      file.callsiteQueryWeight = Math.max(file.callsiteQueryWeight, propagatedCallsiteWeight);
+      if (propagatedCallsite > 0) {
+        file.bestCallsiteRank = Math.min(file.bestCallsiteRank, current.entry.bestRegionRank);
+      }
+      file.nodeIds.add(neighbor.node.id);
+      file.reasons.add(`graph:${neighbor.edge.kind}`);
+      if (!visited.has(neighbor.node.id)) {
+        visited.add(neighbor.node.id);
+        queue.push({
+          entry: evidence,
+          depth: current.depth + 1,
+          allowTypedExpansion: current.allowTypedExpansion
+            || propagatedCallsite > 0
+            || isReliableLexicalSeed(evidence),
+        });
       }
     }
   }
 
-  const directSeeds = [...pool.values()]
-    .filter((c) => c.category === "direct")
-    .sort((a, b) => b.score - a.score || a.node.id.localeCompare(b.node.id))
-    .slice(0, 6);
-  for (const seed of directSeeds) {
-    for (const caller of graph.getCallers(seed.node.id).slice(0, HOP_CAP)) add(caller, 0.3, "caller-of-seed", "neighbor");
-    for (const callee of graph.getCallees(seed.node.id).slice(0, HOP_CAP)) add(callee, 0.3, "callee-of-seed", "neighbor");
+  // Aggregate only the strongest few node/chunk signals per file. Summing every
+  // match makes large central files win merely because they declare more nodes.
+  const nodeScores = new Map<string, number[]>();
+  for (const evidence of nodes.values()) {
+    const file = ensureFile(fileEvidence, evidence.node.filePath);
+    file.nodeIds.add(evidence.node.id);
+    file.exact ||= evidence.exact;
+    for (const identifier of evidence.exactIdentifiers) file.exactIdentifiers.add(identifier);
+    for (const term of evidence.terms) file.terms.add(term);
+    for (const reason of evidence.reasons) file.reasons.add(reason);
+    const scores = nodeScores.get(evidence.node.filePath) ?? [];
+    scores.push(evidence.rrf + evidence.graph);
+    nodeScores.set(evidence.node.filePath, scores);
   }
 
-  const ranked = [...pool.values()].sort((a, b) => b.score - a.score || a.node.id.localeCompare(b.node.id));
-  const used: Record<SelectionCategory, number> = { direct: 0, neighbor: 0, test: 0 };
-  const candidates: ScopedCandidate[] = [];
-  for (const candidate of ranked) {
-    if (candidates.length >= maxNodes) break;
-    if (used[candidate.category] >= QUOTA[candidate.category]) continue;
-    used[candidate.category] += 1;
-    candidates.push({
-      id: candidate.node.id,
-      score: Number(candidate.score.toFixed(2)),
-      reasons: [...candidate.reasons].sort(),
-      category: candidate.category,
-    });
+  const fileCount = Math.max(1, fileEvidence.size);
+  const documentFrequency = new Map<string, number>();
+  for (const concept of concepts) {
+    documentFrequency.set(
+      concept.key,
+      [...fileEvidence.values()].filter((file) => conceptMatchesTerms(concept, file.terms)).length,
+    );
   }
-  return { candidates, matchedCount: pool.size };
+  const totalIdf = concepts.reduce(
+    (sum, concept) => sum + concept.weight * idf(fileCount, documentFrequency.get(concept.key) ?? 0), 0,
+  ) || 1;
+  for (const file of fileEvidence.values()) {
+    const strongestNodes = (nodeScores.get(file.filePath) ?? []).sort((left, right) => right - left);
+    file.score += (strongestNodes[0] ?? 0) + (strongestNodes[1] ?? 0) * 0.45 + (strongestNodes[2] ?? 0) * 0.2;
+    const strongestChunks = file.textHits.map((hit) => Math.abs(hit.rank)).sort((left, right) => right - left);
+    file.score += (strongestChunks[0] ?? 0) + (strongestChunks[1] ?? 0) * 0.35;
+    if (Number.isFinite(file.bestTextRank)) {
+      file.score += SOURCE_FILE_RRF_WEIGHT / (RRF_K + file.bestTextRank + 1);
+    }
+    const covered = concepts.reduce(
+      (sum, concept) => sum + (conceptMatchesTerms(concept, file.terms)
+        ? concept.weight * idf(fileCount, documentFrequency.get(concept.key) ?? 0) : 0), 0,
+    );
+    const coveredCount = concepts.filter((concept) => conceptMatchesTerms(concept, file.terms)).length;
+    // Corpus-wide coverage is supporting evidence. A single source region
+    // where several independent query concepts co-occur is substantially more
+    // useful than the same words scattered through a large central file.
+    file.score += (covered / totalIdf) * 0.4 + Math.max(0, coveredCount - 1) * 0.015;
+    const pathComponents = new Set(searchComponents(file.filePath));
+    const basenameComponents = new Set(searchComponents(file.filePath.split("/").at(-1) ?? file.filePath));
+    const adjacentPathMatches = adjacentPairs.filter(([left, right]) => pathComponents.has(left) && pathComponents.has(right)).length;
+    const bestLocalConcepts = file.textHits.reduce((best, hit) => {
+      const matchedTerms = new Set(hit.matchedTerms ?? []);
+      const matched = concepts.filter((concept) => conceptMatchesTerms(concept, matchedTerms));
+      const weight = matched.reduce(
+        (sum, concept) => sum + concept.weight * idf(fileCount, documentFrequency.get(concept.key) ?? 0), 0,
+      );
+      return weight > best.weight ? { weight, count: matched.length } : best;
+    }, { weight: 0, count: 0 });
+    const bestIdentifierCoverage = [...nodes.values()]
+      .filter((entry) => entry.node.filePath === file.filePath)
+      .reduce((best, entry) => {
+        const components = new Set(searchComponents(entry.node.name));
+        const matches = queryTerms.filter((term) => componentMatches(components, term.term, term.stem)).length;
+        return Math.max(best, matches);
+      }, 0);
+    const pathSignal = componentIdfSignal(pathComponents, concepts, fileCount, documentFrequency);
+    const basenameSignal = componentIdfSignal(basenameComponents, concepts, fileCount, documentFrequency);
+    file.score += adjacentPathMatches * 0.45
+      + pathSignal * 0.08
+      + basenameSignal * 0.18
+      + (bestLocalConcepts.weight / totalIdf) * 2
+      + Math.max(0, bestLocalConcepts.count - 1) * 0.2
+      + Math.max(0, bestIdentifierCoverage - 1) * 0.2;
+    // Direct text/declaration alignment and a compiler-proven callsite are
+    // independent retrieval channels. Preserve both instead of collapsing
+    // them with max(); their corroboration is what promotes a semantic callee
+    // over an unrelated broad utility file.
+    file.score += file.region * 1.4 + file.callsiteRegion * 0.7;
+    if (file.exact) file.score += 0.25;
+    if (!plan.asksForTests && isLowValueGraphPath(file.filePath)) file.score *= 0.55;
+  }
+
+  const allRankedFiles = [...fileEvidence.values()]
+    .sort((left, right) => right.score - left.score || left.filePath.localeCompare(right.filePath));
+  const selectedFiles = new Map<string, FileEvidence>();
+  // Pin one best file per explicitly named symbol. Ambiguous symbols should not
+  // consume the entire file budget by pinning every same-named declaration.
+  for (const identifier of plan.explicitIdentifiers) {
+    const best = allRankedFiles.find((file) => file.exactIdentifiers.has(identifier));
+    if (best && selectedFiles.size < maxFiles) selectedFiles.set(best.filePath, best);
+  }
+  // Preserve the bounded cross-file phrase destinations after explicit symbol
+  // pins and before aggregate source/file scoring can spend the remaining
+  // budget on several variants of the same lexical interpretation.
+  for (const filePath of semanticPhraseTargetPaths) {
+    if (selectedFiles.size >= maxFiles) break;
+    const file = fileEvidence.get(filePath);
+    if (file) selectedFiles.set(filePath, file);
+  }
+  const sourceReserve = Math.min(3, Math.max(0, maxFiles - 1));
+  const hasMultiConceptSource = (file: FileEvidence): boolean => file.textHits.some((hit) => {
+    const terms = new Set(hit.matchedTerms ?? []);
+    return concepts.filter((concept) => conceptMatchesTerms(concept, terms)).length >= 2;
+  });
+  const stronglyQualifiedSourcePaths = new Set([...fileEvidence.values()]
+    .filter((file) => file.region >= 0.55 || hasMultiConceptSource(file))
+    .map((file) => file.filePath));
+  // A source-channel quota may diversify otherwise node-heavy retrieval, but
+  // it must not displace independently strong graph evidence. Rank those
+  // protected slots by the best trustworthy declaration in each file rather
+  // than the file's aggregate score: a rare compound name is stronger intent
+  // evidence than many common words scattered through a central module. Pure
+  // propagated callsite targets are deliberately excluded here; flow ranking
+  // must still prove and promote those relationships below.
+  const strongGraphByFile = new Map<string, {
+    entry: NodeEvidence;
+    exactPinned: boolean;
+    nameConceptScore: number;
+    nameConceptCount: number;
+  }>();
+  for (const entry of nodes.values()) {
+    if (!isReliableLexicalSeed(entry) && !isReliableRegionSeed(entry)) continue;
+    const nameComponents = new Set(searchComponents(entry.node.name));
+    const matchedConcepts = concepts.filter((concept) => conceptMatchesComponents(concept, nameComponents));
+    // Exact search can return several same-named declarations, but only the
+    // best file was pinned above. Do not let every duplicate exact result
+    // bypass the multi-concept requirement and consume the remaining strong
+    // graph slots.
+    const exactPinned = entry.exact && selectedFiles.has(entry.node.filePath);
+    if (!exactPinned && matchedConcepts.length < 2) continue;
+    const nameConceptScore = matchedConcepts.reduce((score, concept) =>
+      score + concept.weight * idf(fileCount, documentFrequency.get(concept.key) ?? 0), 0);
+    const candidate = {
+      entry,
+      exactPinned,
+      nameConceptScore,
+      nameConceptCount: matchedConcepts.length,
+    };
+    const current = strongGraphByFile.get(entry.node.filePath);
+    if (!current
+      || Number(candidate.exactPinned) > Number(current.exactPinned)
+      || (candidate.exactPinned === current.exactPinned
+        && candidate.nameConceptScore > current.nameConceptScore)
+      || (candidate.exactPinned === current.exactPinned
+        && candidate.nameConceptScore === current.nameConceptScore
+        && candidate.nameConceptCount > current.nameConceptCount)
+      || (candidate.exactPinned === current.exactPinned
+        && candidate.nameConceptScore === current.nameConceptScore
+        && candidate.nameConceptCount === current.nameConceptCount
+        && compareNodeEvidence(candidate.entry, current.entry) < 0)) {
+      strongGraphByFile.set(entry.node.filePath, candidate);
+    }
+  }
+  const strongGraphFiles = [...strongGraphByFile.values()].sort((left, right) =>
+    Number(right.exactPinned) - Number(left.exactPinned)
+    || right.nameConceptScore - left.nameConceptScore
+    || right.nameConceptCount - left.nameConceptCount
+    || compareNodeEvidence(left.entry, right.entry)
+    || (fileEvidence.get(right.entry.node.filePath)?.score ?? 0)
+      - (fileEvidence.get(left.entry.node.filePath)?.score ?? 0)
+    || left.entry.node.filePath.localeCompare(right.entry.node.filePath));
+  // Source chunks are an independent retrieval channel, not just a small
+  // additive feature on node-heavy files. Reserve only evidence that is
+  // declaration-aligned, co-locates multiple query concepts, or remains close
+  // to the ordinary fused cutoff. This keeps the channel independent without
+  // allowing arbitrarily weak text hits to evict trustworthy graph files.
+  const cutoffIndex = Math.min(maxFiles, allRankedFiles.length) - 1;
+  const fusedCutoff = cutoffIndex >= 0 ? allRankedFiles[cutoffIndex]!.score : 0;
+  const eligibleSourcePaths = new Set([...fileEvidence.values()]
+    .filter((file) => {
+      const declarationAligned = file.region >= 0.55;
+      const multiConcept = hasMultiConceptSource(file);
+      const nearCutoff = fusedCutoff > 0 && file.score >= fusedCutoff * SOURCE_NEAR_CUTOFF_RATIO;
+      return declarationAligned || multiConcept || nearCutoff;
+    })
+    .map((file) => file.filePath));
+  // Direct-source candidates are defined only by actual FTS hits, ordered
+  // independently of compiler-propagated callsites. Repeated windows from one
+  // file count once. A separate bounded semantic slot below preserves the best
+  // proven callsite target without letting several such targets consume the
+  // whole source floor.
+  const directSourceCandidates = [...new Set(textHits.map((hit) => hit.filePath))]
+    .filter((filePath) => eligibleSourcePaths.has(filePath) && stronglyQualifiedSourcePaths.has(filePath))
+    .sort((left, right) => {
+      const leftLow = !plan.asksForTests && isLowValueGraphPath(left);
+      const rightLow = !plan.asksForTests && isLowValueGraphPath(right);
+      return Number(leftLow) - Number(rightLow)
+        || (fileEvidence.get(left)?.bestTextRank ?? Number.POSITIVE_INFINITY)
+          - (fileEvidence.get(right)?.bestTextRank ?? Number.POSITIVE_INFINITY)
+        || (fileEvidence.get(right)?.region ?? 0) - (fileEvidence.get(left)?.region ?? 0)
+        || (fileEvidence.get(right)?.score ?? 0) - (fileEvidence.get(left)?.score ?? 0)
+        || left.localeCompare(right);
+    });
+  const semanticCallsiteCandidates = [...fileEvidence.values()]
+    .filter((file) => file.callsiteRegion > 0
+      && file.callsiteQueryWeight > 0
+      && Number.isFinite(file.bestCallsiteRank))
+    .sort((left, right) => {
+      const leftLow = !plan.asksForTests && isLowValueGraphPath(left.filePath);
+      const rightLow = !plan.asksForTests && isLowValueGraphPath(right.filePath);
+      return Number(leftLow) - Number(rightLow)
+        || right.callsiteQueryWeight - left.callsiteQueryWeight
+        || left.bestCallsiteRank - right.bestCallsiteRank
+        || right.callsiteRegion - left.callsiteRegion
+        || right.score - left.score
+        || left.filePath.localeCompare(right.filePath);
+    });
+  const semanticWinner = semanticCallsiteCandidates[0];
+  let sourceFloor: string[];
+  if (sourceReserve === 0) {
+    sourceFloor = [];
+  } else if (!semanticWinner) {
+    sourceFloor = directSourceCandidates.slice(0, sourceReserve);
+  } else if (sourceReserve === 1) {
+    const directWinner = directSourceCandidates[0];
+    sourceFloor = !directWinner || directWinner === semanticWinner.filePath
+      ? [semanticWinner.filePath]
+      : [directWinner, semanticWinner.filePath].sort((left, right) =>
+        (fileEvidence.get(right)?.score ?? 0) - (fileEvidence.get(left)?.score ?? 0)
+        || left.localeCompare(right)).slice(0, 1);
+  } else {
+    sourceFloor = [
+      semanticWinner.filePath,
+      ...directSourceCandidates.filter((filePath) => filePath !== semanticWinner.filePath)
+        .slice(0, Math.max(0, sourceReserve - 1)),
+    ];
+  }
+  const sourceFloorPaths = new Set(sourceFloor);
+  const unrepresentedSourceFiles = sourceFloor
+    .filter((filePath) => !selectedFiles.has(filePath)).length;
+  // Exact pins remain protected. Reserve the slots still needed by the source
+  // floor, then spend the bounded graph capacity on the strongest declaration
+  // names. Proven flow targets may still replace a weaker file below.
+  const strongGraphLimit = Math.max(
+    selectedFiles.size,
+    maxFiles - Math.min(unrepresentedSourceFiles, Math.max(0, maxFiles - selectedFiles.size)),
+  );
+  for (const strong of strongGraphFiles) {
+    if (selectedFiles.size >= strongGraphLimit) break;
+    const file = fileEvidence.get(strong.entry.node.filePath);
+    if (file) selectedFiles.set(file.filePath, file);
+  }
+  let representedSourceFiles = [...selectedFiles.keys()]
+    .filter((filePath) => sourceFloorPaths.has(filePath)).length;
+  for (const filePath of sourceFloor) {
+    if (representedSourceFiles >= sourceFloor.length || selectedFiles.size >= maxFiles) break;
+    const file = fileEvidence.get(filePath);
+    if (!file) continue;
+    if (selectedFiles.has(filePath)) continue;
+    selectedFiles.set(filePath, file);
+    representedSourceFiles++;
+  }
+  for (const file of allRankedFiles) {
+    if (selectedFiles.size >= maxFiles) break;
+    selectedFiles.set(file.filePath, file);
+  }
+  let rankedFiles = [...selectedFiles.values()]
+    .sort((left, right) => right.score - left.score || left.filePath.localeCompare(right.filePath));
+  const selectedPaths = new Set(rankedFiles.map((file) => file.filePath));
+  const rankedNodes = [...nodes.values()]
+    .filter((entry) => selectedPaths.has(entry.node.filePath) && hasTrustworthyCandidateEvidence(entry))
+    .sort(compareNodeEvidence);
+  const picked = new Map<string, NodeEvidence>();
+  for (const identifier of plan.explicitIdentifiers) {
+    const entry = rankedNodes.find((candidate) => candidate.exactIdentifiers.has(identifier));
+    if (entry && picked.size < maxNodes) picked.set(entry.node.id, entry);
+  }
+  for (const entry of fullQueryCallPairSeeds) {
+    if (picked.size >= maxNodes) break;
+    if (!selectedPaths.has(entry.node.filePath)) continue;
+    picked.set(entry.node.id, entry);
+  }
+  // Whole-task BM25 is an independent declaration channel. Preserve exactly
+  // one of its trustworthy production declarations before source-window and
+  // callsite evidence fill the bounded candidate set. Without this reserve, a
+  // nearby chunk can move ahead after an unrelated source edit and evict the
+  // declaration that still ranks first for the complete request.
+  const fullQueryDeclaration = bestFullQueryDeclaration(rankedNodes, concepts);
+  if (fullQueryDeclaration && (picked.has(fullQueryDeclaration.node.id) || picked.size < maxNodes)) {
+    picked.set(fullQueryDeclaration.node.id, fullQueryDeclaration);
+  }
+  // Preserve declarations for distinct strong responsibilities before a
+  // single source window spends the per-file allowance on nearby helpers.
+  for (const entry of bestStrongIntentFacetDeclarations(
+    rankedNodes, concepts, access, MAX_STRONG_INTENT_FACET_DECLARATIONS,
+  )) {
+    if (picked.size >= maxNodes) break;
+    picked.set(entry.node.id, entry);
+  }
+  // Source FTS is an independent declaration channel. Reserve the declaration
+  // that the store aligned first to each selected file's best chunk before
+  // aggregate graph/lexical strength can fill that file's representation.
+  for (const file of rankedFiles) {
+    if (picked.size >= maxNodes) break;
+    const aligned = bestSourceAlignedDeclaration(
+      rankedNodes.filter((candidate) => candidate.node.filePath === file.filePath),
+    );
+    if (aligned) picked.set(aligned.node.id, aligned);
+  }
+  // Guarantee bounded representation for each cohesive file before filling
+  // globally. A reserved source declaration counts toward the existing
+  // three-entry per-file allowance rather than expanding it.
+  for (const file of rankedFiles) {
+    let represented = [...picked.values()].filter((entry) => entry.node.filePath === file.filePath).length;
+    for (const entry of rankedNodes.filter((candidate) => candidate.node.filePath === file.filePath)) {
+      if (represented >= 3) break;
+      if (picked.size >= maxNodes) break;
+      if (picked.has(entry.node.id)) continue;
+      picked.set(entry.node.id, entry);
+      represented++;
+    }
+  }
+  for (const entry of rankedNodes) {
+    if (picked.size >= maxNodes) break;
+    picked.set(entry.node.id, entry);
+  }
+
+  const pickedIds = new Set(picked.keys());
+  const reliablePicked = [...picked.values()].filter((entry) => entry.reliable);
+  const flowSeedRelevance = new Map([...nodes.values()].map((entry) => [
+    entry.node.id,
+    (entry.exact ? 6 : 0) + queryTerms.reduce((score, term) => score + (entry.nameTerms.has(term.term)
+      ? term.weight * idf(fileCount, documentFrequency.get(term.term) ?? 0) * (term.stem ? 1 : 4) : 0), 0)
+      + entry.terms.size * 0.1 + entry.rrf + regionStrength(entry) * 2,
+  ]));
+  const flowFilePriority = new Map(rankedFiles.map((file, index) => [file.filePath, rankedFiles.length - index]));
+  const flowNodeTerms = new Map([...nodes.values()].map((entry) => [entry.node.id, new Set(entry.terms)]));
+  const flowTermWeights = new Map(queryTerms.map((term) => [
+    term.term, term.weight * idf(fileCount, documentFrequency.get(term.term) ?? 0),
+  ]));
+  const relevanceForFlowSeed = (node: GraphNode): number => {
+    const known = flowSeedRelevance.get(node.id);
+    if (known !== undefined) return known;
+    const components = new Set(searchComponents(node.name));
+    return queryTerms.reduce((score, term) => score + (componentMatches(components, term.term, term.stem)
+      ? term.weight * idf(fileCount, documentFrequency.get(term.term) ?? 0) * (term.stem ? 1 : 4)
+      : 0), 0);
+  };
+
+  // Returned reliable declarations stay protected. Also restore the bounded
+  // query-region/callback seeds retained during relevance expansion: candidate
+  // quotas are an output concern and must not erase a proven callsite merely
+  // because its declaration ranked fourth within a selected file.
+  const pickedFlowEntries = [...reliablePicked].sort(compareNodeEvidence).slice(0, MAX_FLOW_SEEDS);
+  const pickedFlowIds = new Set(pickedFlowEntries.map((entry) => entry.node.id));
+  const semanticPhraseFlowEntries = semanticPhraseBridges.map((bridge) => bridge.source)
+    .filter((entry) => !pickedFlowIds.has(entry.node.id))
+    .slice(0, MAX_FLOW_SEEDS - pickedFlowEntries.length);
+  const semanticPhraseFlowIds = new Set(semanticPhraseFlowEntries.map((entry) => entry.node.id));
+  // Whole-query pairs have their exact direct edge (and, when proven, callback
+  // completion) reserved separately. Do not spend ordinary traversal slots on
+  // pair-only entries; pair endpoints with independent picked evidence remain
+  // ordinary seeds through `pickedFlowEntries`.
+  const provenanceFlowEntries = [...reliableSeeds]
+    .filter((entry) => !pickedFlowIds.has(entry.node.id)
+      && !semanticPhraseFlowIds.has(entry.node.id)
+      && (entry.regionCallsites.size > 0 || entry.regionCallbackCallsites.size > 0))
+    .sort(compareProvenanceFlowSeed)
+    .slice(0, MAX_FLOW_SEEDS - pickedFlowEntries.length - semanticPhraseFlowEntries.length);
+  const directFlowEntries = [
+    ...semanticPhraseFlowEntries, ...provenanceFlowEntries, ...pickedFlowEntries,
+  ];
+  const flowSeeds = new Map<string, GraphNode>(directFlowEntries.map((entry) => [entry.node.id, entry.node]));
+  const flowSeedCallsiteRanks = new Map<string, number>();
+  for (const entry of directFlowEntries) {
+    if (entry.regionCallsites.size > 0 && Number.isFinite(entry.bestRegionRank)) {
+      flowSeedCallsiteRanks.set(entry.node.id, entry.bestRegionRank);
+    }
+  }
+  const derivedSeeds = new Map<string, DerivedFlowSeed>();
+  const rememberDerivedSeed = (candidate: DerivedFlowSeed): void => {
+    if (flowSeeds.has(candidate.node.id)) return;
+    const prior = derivedSeeds.get(candidate.node.id);
+    if (!prior || compareDerivedFlowSeed(candidate, prior) < 0) derivedSeeds.set(candidate.node.id, candidate);
+  };
+  const remainingSeedSlots = MAX_FLOW_SEEDS - flowSeeds.size;
+  if (remainingSeedSlots > 0) {
+    for (const entry of directFlowEntries) {
+      for (const incoming of access.getIncoming(entry.node.id, FLOW_EDGE_KINDS)) {
+        if ((incoming.edge.confidence ?? 1) < 0.8) continue;
+        rememberDerivedSeed({
+          node: incoming.node,
+          relevance: relevanceForFlowSeed(incoming.node),
+          callsiteRank: queryRegionCallsiteRanks.get(edgeKey(incoming.edge)) ?? Number.POSITIVE_INFINITY,
+          confidence: incoming.edge.confidence ?? 1,
+        });
+      }
+    }
+
+    // Calls made inside a returned/nested callback are owned by the enclosing
+    // named declaration. Inspect owners only for the bounded best callback
+    // callers; fan-in therefore cannot create unbounded adjacency queries.
+    const ownerCandidates = [...derivedSeeds.values()].sort(compareDerivedFlowSeed)
+      .filter((candidate) => isUnnamedFlowNode(candidate.node)).slice(0, remainingSeedSlots);
+    for (const callback of ownerCandidates) {
+      for (const owner of access.getIncoming(callback.node.id, ["contains"])) {
+        if ((owner.edge.confidence ?? 1) < 0.8) continue;
+        rememberDerivedSeed({
+          node: owner.node,
+          relevance: relevanceForFlowSeed(owner.node),
+          callsiteRank: callback.callsiteRank,
+          confidence: Math.min(callback.confidence, owner.edge.confidence ?? 1),
+        });
+      }
+    }
+    for (const candidate of [...derivedSeeds.values()].sort(compareDerivedFlowSeed).slice(0, remainingSeedSlots)) {
+      flowSeeds.set(candidate.node.id, candidate.node);
+      flowSeedRelevance.set(candidate.node.id, candidate.relevance);
+      flowSeedCallsiteRanks.set(candidate.node.id, candidate.callsiteRank);
+      const terms = new Set<string>();
+      for (const term of queryTerms) {
+        if (nodeContains(candidate.node, term.term, term.stem)) terms.add(term.term);
+      }
+      flowNodeTerms.set(candidate.node.id, terms);
+    }
+  }
+  const traversedFlows = buildDirectedFlows(
+    access, [...flowSeeds.values()], pickedIds, 8, flowSeedRelevance, flowFilePriority,
+    flowNodeTerms, flowTermWeights, queryRegionCallsiteRanks, queryRegionCallsiteWeights,
+    flowSeedCallsiteRanks, fullQueryCallPairs,
+  );
+  // These edges already passed stricter evidence than ordinary flow seeds:
+  // both endpoints independently match one adjacent query phrase and the
+  // compiler proves the cross-file relationship. Emit them first, then spend
+  // the remaining global eight-step budget on normal directed traversal.
+  const flows: ScopeFlow[] = [];
+  const seenFlowKeys = new Set<string>();
+  let remainingFlowSteps = 8;
+  for (const flow of [
+    ...semanticPhraseBridges.map((bridge) => ({ steps: [bridge.edge] })),
+    ...traversedFlows,
+  ]) {
+    const key = flowKey(flow);
+    if (seenFlowKeys.has(key) || flow.steps.length > remainingFlowSteps) continue;
+    seenFlowKeys.add(key);
+    flows.push(flow);
+    remainingFlowSteps -= flow.steps.length;
+    if (remainingFlowSteps === 0) break;
+  }
+  // Flow construction is independent of the lexical file budget. Reserve slots
+  // for the best returned spine after traversal, evicting only lower-ranked
+  // non-pinned/non-spine files. This makes an otherwise invisible bridge file
+  // available to source planning without ever exceeding maxFiles.
+  const pinnedPaths = new Set([...selectedFiles.values()]
+    .filter((file) => file.exactIdentifiers.size > 0).map((file) => file.filePath));
+  for (const filePath of sourceFloorPaths) pinnedPaths.add(filePath);
+  for (const filePath of semanticPhraseTargetPaths) {
+    if (selectedFiles.has(filePath)) pinnedPaths.add(filePath);
+  }
+  // Preserve independently strong compound declarations through flow-spine
+  // promotion: `SmartRouter` should not be evicted by an incidental router
+  // call. Only declaration-name/IDF evidence is protected here; ordinary
+  // source/callsite files remain replaceable by a proven cross-file subsystem
+  // such as module resolution.
+  for (const strong of strongGraphFiles) {
+    const kind = strong.entry.node.kind;
+    const architecturalType = kind === "class" || kind === "struct" || kind === "trait"
+      || kind === "component" || kind === "interface" || kind === "protocol";
+    if (architecturalType && selectedFiles.has(strong.entry.node.filePath)) {
+      pinnedPaths.add(strong.entry.node.filePath);
+    }
+  }
+  const protectedFlowPaths = new Set<string>();
+  const flowNodeIds = new Set<string>();
+  const primaryFlowNodeIds = new Set((flows[0]?.steps ?? []).flatMap((edge) => [edge.source, edge.target]));
+  for (const id of flows.flatMap((flow) => flow.steps).flatMap((edge) => [edge.source, edge.target])) {
+    if (flowNodeIds.has(id)) continue;
+    flowNodeIds.add(id);
+    const node = access.getNode(id);
+    if (!node) continue;
+    const file = ensureFile(fileEvidence, node.filePath);
+    file.nodeIds.add(node.id);
+    file.reliableGraph = true;
+    file.reasons.add("flow-spine");
+    // Every returned flow remains available to candidate/source ordering when
+    // its file is already selected. Only the best cohesive flow may displace a
+    // lexical file; otherwise several small secondary flows can evict the
+    // actual query region under a tight max-files budget.
+    if (!primaryFlowNodeIds.has(id)) continue;
+    if (selectedFiles.has(file.filePath)) {
+      protectedFlowPaths.add(file.filePath);
+      continue;
+    }
+    if (selectedFiles.size >= maxFiles) {
+      const eviction = [...selectedFiles.values()]
+        .filter((candidate) => !pinnedPaths.has(candidate.filePath)
+          && !protectedFlowPaths.has(candidate.filePath))
+        .sort((left, right) => left.score - right.score || right.filePath.localeCompare(left.filePath))[0];
+      if (!eviction) continue;
+      selectedFiles.delete(eviction.filePath);
+    }
+    selectedFiles.set(file.filePath, file);
+    protectedFlowPaths.add(file.filePath);
+  }
+  rankedFiles = [...selectedFiles.values()]
+    .sort((left, right) => right.score - left.score || left.filePath.localeCompare(right.filePath));
+  // Flow-spine promotion can replace an initially selected lexical file. Build
+  // the returned candidate set against the FINAL bounded file set so a
+  // promoted file exposes its strongest direct/callsite declaration instead
+  // of carrying only an unrelated bridge node while stale candidates from the
+  // evicted file consume the node budget.
+  const finalSelectedPaths = new Set(rankedFiles.map((file) => file.filePath));
+  const finalRankedNodes = [...nodes.values()]
+    .filter((entry) => finalSelectedPaths.has(entry.node.filePath) && hasTrustworthyCandidateEvidence(entry))
+    .sort(compareNodeEvidence);
+  const finalPicked = new Map<string, NodeEvidence>();
+  for (const identifier of plan.explicitIdentifiers) {
+    const entry = finalRankedNodes.find((candidate) => candidate.exactIdentifiers.has(identifier));
+    if (entry && finalPicked.size < maxNodes) finalPicked.set(entry.node.id, entry);
+  }
+  for (const entry of fullQueryCallPairSeeds) {
+    if (finalPicked.size >= maxNodes) break;
+    if (!finalSelectedPaths.has(entry.node.filePath)) continue;
+    finalPicked.set(entry.node.id, entry);
+  }
+  const finalFullQueryDeclaration = bestFullQueryDeclaration(finalRankedNodes, concepts);
+  if (finalFullQueryDeclaration
+    && (finalPicked.has(finalFullQueryDeclaration.node.id) || finalPicked.size < maxNodes)) {
+    finalPicked.set(finalFullQueryDeclaration.node.id, finalFullQueryDeclaration);
+  }
+  for (const entry of bestStrongIntentFacetDeclarations(
+    finalRankedNodes, concepts, access, MAX_STRONG_INTENT_FACET_DECLARATIONS,
+  )) {
+    if (finalPicked.size >= maxNodes) break;
+    finalPicked.set(entry.node.id, entry);
+  }
+  const finalEntriesByFile = new Map(rankedFiles.map((file) => [
+    file.filePath,
+    finalRankedNodes.filter((candidate) => candidate.node.filePath === file.filePath),
+  ]));
+  for (const file of rankedFiles) {
+    if (finalPicked.size >= maxNodes) break;
+    const aligned = bestSourceAlignedDeclaration(finalEntriesByFile.get(file.filePath) ?? []);
+    if (aligned) finalPicked.set(aligned.node.id, aligned);
+  }
+  for (const file of rankedFiles) {
+    const fileEntries = finalEntriesByFile.get(file.filePath) ?? [];
+    const direct = fileEntries.filter((candidate) => candidate.regionHits.length > 0)
+      .sort((left, right) => directRegionStrength(right) - directRegionStrength(left)
+        || compareNodeEvidence(left, right));
+    const callsite = fileEntries.filter((candidate) => Number.isFinite(candidate.bestCallsiteRank))
+      .sort((left, right) => left.bestCallsiteRank - right.bestCallsiteRank
+        || compareNodeEvidence(left, right));
+    const representatives: NodeEvidence[] = [];
+    if (direct[0]) representatives.push(direct[0]);
+    for (const entry of callsite.slice(0, 2)) {
+      if (!representatives.includes(entry)) representatives.push(entry);
+    }
+    for (const entry of fileEntries) {
+      if (representatives.length >= 4) break;
+      if (!representatives.includes(entry)) representatives.push(entry);
+    }
+    let represented = [...finalPicked.values()].filter((entry) => entry.node.filePath === file.filePath).length;
+    for (const entry of representatives) {
+      if (represented >= 4) break;
+      if (finalPicked.size >= maxNodes) break;
+      if (finalPicked.has(entry.node.id)) continue;
+      finalPicked.set(entry.node.id, entry);
+      represented++;
+    }
+  }
+  for (const entry of finalRankedNodes) {
+    if (finalPicked.size >= maxNodes) break;
+    finalPicked.set(entry.node.id, entry);
+  }
+  const finalPickedIds = new Set(finalPicked.keys());
+  const coveredTerms = literalTerms(plan).filter((term) => rankedFiles.some((file) => file.terms.has(term))).sort();
+  const files: RankedScopeFile[] = rankedFiles.map((file) => {
+    const info = fileInfo.get(file.filePath);
+    const candidateRank = new Map([...finalPicked.keys()].map((id, index) => [id, index]));
+    const flowRank = new Map([...flowNodeIds].map((id, index) => [id, index]));
+    const nodeIds = [...file.nodeIds].filter((id) => finalPickedIds.has(id) || flowNodeIds.has(id))
+      .sort((left, right) => (candidateRank.get(left) ?? Number.MAX_SAFE_INTEGER)
+        - (candidateRank.get(right) ?? Number.MAX_SAFE_INTEGER)
+        || (flowRank.get(left) ?? Number.MAX_SAFE_INTEGER) - (flowRank.get(right) ?? Number.MAX_SAFE_INTEGER)
+        || left.localeCompare(right));
+    return {
+      filePath: file.filePath,
+      score: Number(file.score.toFixed(6)),
+      reasons: [...file.reasons].sort(),
+      nodeIds,
+      textHits: dedupeChunkHits(file.textHits),
+      textOnly: nodeIds.length === 0 || !file.reliableGraph || info?.parseStatus !== "ok",
+      parseStatus: info?.parseStatus ?? "failed",
+    };
+  });
+  const candidates = [...finalPicked.values()].map((entry) => ({
+    id: entry.node.id,
+    score: Number((entry.rrf + entry.graph + regionStrength(entry) + (entry.exact ? 2 : 0)).toFixed(6)),
+    reasons: [...entry.reasons].sort(),
+    category: (isLowValueGraphPath(entry.node.filePath) ? "test" : entry.graph > entry.rrf ? "neighbor" : "direct") as SelectionCategory,
+  }));
+  const evidenceStrength = files.length === 0 ? "none"
+    : files.some((file) => file.reasons.some((reason) => reason.startsWith("exact:")))
+      || coveredTerms.length >= Math.min(3, pathTerms.length) ? "strong"
+      : coveredTerms.length > 0 ? "moderate" : "weak";
+  return { candidates, files, flows, matchedCount: nodes.size, coveredTerms, evidenceStrength };
 }
 
 /**
- * Build a compact fact (structure + relationship counts) for a node id, or null
- * if the node no longer exists. `sourceIncluded` reflects whether the caller
- * intends to emit a companion source record (detail === "source").
+ * Preserve destination-file diversity inside the fixed per-node branch cap.
+ * A query-bearing compiler routine can call many helpers; taking the first
+ * eight globally ranked edges may omit an entire subsystem. Reserve one real
+ * semantic call per query-region/destination pair (the culminating callsite),
+ * then fill the remaining slots from the original relevance order.
  */
+function diverseFlowBranches(
+  entries: GraphNeighbor[],
+  limit: number,
+  callsiteRanks: Map<string, number>,
+): GraphNeighbor[] {
+  if (entries.length <= limit) return entries;
+  const index = new Map(entries.map((entry, position) => [edgeKey(entry.edge), position]));
+  const groups = new Map<string, GraphNeighbor[]>();
+  for (const entry of entries) {
+    const rank = callsiteRanks.get(edgeKey(entry.edge));
+    if (rank === undefined || !Number.isFinite(rank)) continue;
+    const key = `${rank}\0${entry.node.filePath}`;
+    const group = groups.get(key) ?? [];
+    group.push(entry);
+    groups.set(key, group);
+  }
+  const representatives = [...groups.entries()].flatMap(([key, group]) => {
+    const distinctSemanticTargets = new Set(group.flatMap((entry) => (
+      entry.edge.kind === "calls" || entry.edge.kind === "instantiates"
+        ? [entry.node.id] : []
+    ))).size;
+    const representative = group.sort((left, right) => {
+      const semanticPriority = (entry: GraphNeighbor): number => (
+        entry.edge.kind === "calls" || entry.edge.kind === "instantiates" ? 2
+          : entry.edge.kind === "references" ? 1 : 0
+      );
+      return semanticPriority(right) - semanticPriority(left)
+        || (right.edge.line ?? -1) - (left.edge.line ?? -1)
+        || (left.edge.column ?? Number.MAX_SAFE_INTEGER)
+          - (right.edge.column ?? Number.MAX_SAFE_INTEGER)
+        || (index.get(edgeKey(left.edge)) ?? Number.MAX_SAFE_INTEGER)
+          - (index.get(edgeKey(right.edge)) ?? Number.MAX_SAFE_INTEGER);
+    })[0];
+    const rank = Number(key.slice(0, key.indexOf("\0")));
+    return representative ? [{ representative, rank, distinctSemanticTargets }] : [];
+  }).sort((left, right) => left.rank - right.rank
+    || right.distinctSemanticTargets - left.distinctSemanticTargets
+    || (index.get(edgeKey(left.representative.edge)) ?? Number.MAX_SAFE_INTEGER)
+      - (index.get(edgeKey(right.representative.edge)) ?? Number.MAX_SAFE_INTEGER))
+    .map(({ representative }) => representative);
+  const selected = representatives.slice(0, limit);
+  const selectedKeys = new Set(selected.map((entry) => edgeKey(entry.edge)));
+  for (const entry of entries) {
+    if (selected.length >= limit) break;
+    const key = edgeKey(entry.edge);
+    if (selectedKeys.has(key)) continue;
+    selected.push(entry);
+    selectedKeys.add(key);
+  }
+  return selected;
+}
+
+function buildDirectedFlows(
+  access: ScopeRequestAccess,
+  seeds: GraphNode[],
+  selectedIds: Set<string>,
+  maxSteps: number,
+  seedRelevance = new Map<string, number>(),
+  filePriority = new Map<string, number>(),
+  nodeTerms = new Map<string, Set<string>>(),
+  termWeights = new Map<string, number>(),
+  queryRegionCallsiteRanks = new Map<string, number>(),
+  queryRegionCallsiteWeights = new Map<string, number>(),
+  seedCallsiteRanks = new Map<string, number>(),
+  fullQueryCallPairs: FullQueryCallPair[] = [],
+): ScopeFlow[] {
+  const flows: Array<{
+    flow: ScopeFlow;
+    startsSelected: boolean;
+    startsInTest: boolean;
+    selectedEndpoints: number;
+    relevantEndpoints: number;
+    executionPriority: number;
+    endpointRelevance: number;
+    endpointFilePriority: number;
+    pathRelevance: number;
+    terminalRelevance: number;
+    terminalNameRelevance: number;
+    seedRelevance: number;
+    queryCallsiteSteps: number;
+    bestQueryCallsiteRank: number;
+    bestQueryCallsiteWeight: number;
+    terminalPublic: boolean;
+    crossesFile: boolean;
+    terminalFile: string;
+    terminalFileCallsiteCount: number;
+    terms: Set<string>;
+  }> = [];
+  const hopLimit = Math.min(7, maxSteps);
+  let remainingWork = FLOW_TRAVERSAL_WORK_BUDGET;
+  const endpointNameRelevance = (node: GraphNode): number => {
+    const components = new Set(searchComponents(node.name));
+    return [...termWeights].reduce((score, [term, weight]) => {
+      const singular = term.length > 3 && term.endsWith("s") ? term.slice(0, -1) : undefined;
+      return score + (components.has(term) || (singular !== undefined && components.has(singular))
+        ? weight : 0);
+    }, 0);
+  };
+  const orderedSeeds = [...seeds].sort((left, right) => {
+    const leftCallsite = seedCallsiteRanks.get(left.id) ?? Number.POSITIVE_INFINITY;
+    const rightCallsite = seedCallsiteRanks.get(right.id) ?? Number.POSITIVE_INFINITY;
+    return Number(Number.isFinite(rightCallsite)) - Number(Number.isFinite(leftCallsite))
+      || leftCallsite - rightCallsite
+      || (seedRelevance.get(right.id) ?? 0) - (seedRelevance.get(left.id) ?? 0)
+      || Number(selectedIds.has(right.id)) - Number(selectedIds.has(left.id))
+      || Number(isLowValueGraphPath(left.filePath)) - Number(isLowValueGraphPath(right.filePath))
+      || left.id.localeCompare(right.id);
+  });
+  const queue: Array<{
+    seed: GraphNode; node: GraphNode; steps: GraphEdge[]; visited: Set<string>;
+    unnamedBridges: number; root: boolean;
+  }> = orderedSeeds.map((seed) => ({
+    seed, node: seed, steps: [], visited: new Set([seed.id]), unnamedBridges: 0, root: true,
+  }));
+  let pendingRootQueries = orderedSeeds.length;
+  while (queue.length > 0 && remainingWork > 0) {
+      const current = queue.shift()!;
+      const seed = current.seed;
+      if (current.steps.length >= hopLimit) continue;
+      if (current.root) pendingRootQueries--;
+      // One request-wide budget covers both adjacency lookups and accepted
+      // expansions. A large seed set can no longer receive 128 expansions each.
+      remainingWork--;
+      const outgoing = access.getOutgoing(current.node.id, FLOW_TRAVERSAL_EDGE_KINDS)
+        .filter((entry) => (entry.edge.confidence ?? 1) >= 0.8)
+        // `contains` is structural rather than executable. It is useful in a
+        // displayed flow only to enter one anonymous callback which then makes
+        // a real call/reference; named children and data properties are not
+        // execution-flow edges.
+        .filter((entry) => entry.edge.kind !== "contains" || isUnnamedFlowNode(entry.node))
+        // The expansion is deliberately bounded, so lexical/source order alone
+        // would permanently hide a relevant call which appears late in a long
+        // function. Spend the eight-way branch budget on query-relevant
+        // endpoints first, then use the stable structural ordering.
+        .sort((left, right) => {
+          const leftKey = edgeKey(left.edge);
+          const rightKey = edgeKey(right.edge);
+          const leftCallsiteRank = queryRegionCallsiteRanks.get(leftKey) ?? Number.POSITIVE_INFINITY;
+          const rightCallsiteRank = queryRegionCallsiteRanks.get(rightKey) ?? Number.POSITIVE_INFINITY;
+          return Number(Number.isFinite(rightCallsiteRank)) - Number(Number.isFinite(leftCallsiteRank))
+            || (queryRegionCallsiteWeights.get(rightKey) ?? 0) - (queryRegionCallsiteWeights.get(leftKey) ?? 0)
+            || leftCallsiteRank - rightCallsiteRank
+            || Number(selectedIds.has(right.node.id)) - Number(selectedIds.has(left.node.id))
+            || Number(right.node.isExported) - Number(left.node.isExported)
+            || (seedRelevance.get(right.node.id) ?? 0) - (seedRelevance.get(left.node.id) ?? 0)
+            || compareNeighbor(left, right);
+        });
+      const callsiteTargets = new Map<string, Set<string>>();
+      for (const neighbor of outgoing) {
+        if (neighbor.edge.kind !== "calls" && neighbor.edge.kind !== "instantiates") continue;
+        const rank = queryRegionCallsiteRanks.get(edgeKey(neighbor.edge));
+        if (rank === undefined || !Number.isFinite(rank)) continue;
+        const key = `${rank}\0${neighbor.node.filePath}`;
+        const targets = callsiteTargets.get(key) ?? new Set<string>();
+        targets.add(neighbor.node.id);
+        callsiteTargets.set(key, targets);
+      }
+      for (const neighbor of diverseFlowBranches(
+        outgoing, FLOW_BRANCH_LIMIT, queryRegionCallsiteRanks,
+      )) {
+        // Reserve one work unit for every seed root not yet inspected. This
+        // makes the global budget fair: an early broad seed cannot prevent a
+        // later query-region seed from contributing its direct callsite.
+        if (remainingWork <= pendingRootQueries) break;
+        if (current.visited.has(neighbor.node.id)) continue;
+        const unnamedBridges = current.unnamedBridges + (isUnnamedFlowNode(neighbor.node) ? 1 : 0);
+        if (unnamedBridges > 1) continue;
+        const steps = [...current.steps, neighbor.edge];
+        const visited = new Set(current.visited);
+        visited.add(neighbor.node.id);
+        remainingWork--;
+        const endpointIds = new Set([seed.id, ...steps.flatMap((step) => [step.source, step.target])]);
+        const endpointRelevance = [...endpointIds].map((id) => seedRelevance.get(id) ?? 0);
+        const startRelevance = seedRelevance.get(seed.id) ?? 0;
+        const terminalRelevance = seedRelevance.get(neighbor.node.id) ?? 0;
+        const flowTerms = new Set([...endpointIds].flatMap((id) => [...(nodeTerms.get(id) ?? [])]));
+        const executionPriority = steps.some((step) => step.kind === "calls" || step.kind === "instantiates") ? 2
+          : steps.some((step) => step.kind === "references") ? 1 : 0;
+        const queryCallsiteRanks = steps.flatMap((step) => {
+          const rank = queryRegionCallsiteRanks.get(edgeKey(step));
+          return rank === undefined || !Number.isFinite(rank) ? [] : [rank];
+        });
+        const queryCallsiteWeights = steps.map((step) => queryRegionCallsiteWeights.get(edgeKey(step)) ?? 0);
+        // A bare lexical-containment prefix is not an execution flow. Keep the
+        // real edge only once the anonymous callback performs a semantic step.
+        if (executionPriority === 0 || neighbor.edge.kind === "contains") {
+          if (steps.length < hopLimit) queue.push({
+            seed, node: neighbor.node, steps, visited, unnamedBridges, root: false,
+          });
+          continue;
+        }
+        flows.push({
+          flow: { steps },
+          startsSelected: selectedIds.has(seed.id),
+          startsInTest: isLowValueGraphPath(seed.filePath),
+          seedRelevance: seedRelevance.get(seed.id) ?? 0,
+          selectedEndpoints: [...endpointIds].filter((id) => selectedIds.has(id)).length,
+          relevantEndpoints: [startRelevance, terminalRelevance]
+            .filter((score) => score >= STRONG_FLOW_RELEVANCE).length,
+          executionPriority,
+          endpointRelevance: startRelevance + terminalRelevance,
+          endpointFilePriority: (filePriority.get(seed.filePath) ?? 0)
+            + (filePriority.get(neighbor.node.filePath) ?? 0),
+          pathRelevance: endpointRelevance.filter((score) => score >= STRONG_FLOW_RELEVANCE)
+            .reduce((sum, score) => sum + score, 0),
+          terminalRelevance,
+          terminalNameRelevance: endpointNameRelevance(neighbor.node),
+          queryCallsiteSteps: queryCallsiteRanks.length,
+          bestQueryCallsiteRank: Math.min(...queryCallsiteRanks, Number.POSITIVE_INFINITY),
+          bestQueryCallsiteWeight: Math.max(...queryCallsiteWeights, 0),
+          terminalPublic: neighbor.node.isExported === true,
+          crossesFile: seed.filePath !== neighbor.node.filePath,
+          terminalFile: neighbor.node.filePath,
+          terminalFileCallsiteCount: queryCallsiteRanks.length === 0 ? 0 : Math.max(
+            ...queryCallsiteRanks.map((rank) => (
+              callsiteTargets.get(`${rank}\0${neighbor.node.filePath}`)?.size ?? 0
+            )),
+          ),
+          terms: flowTerms,
+        });
+        if (steps.length < hopLimit) queue.push({
+          seed, node: neighbor.node, steps, visited, unnamedBridges, root: false,
+        });
+      }
+  }
+  const selected: ScopeFlow[] = [];
+  let selectedSteps = 0;
+  const sorted = flows.sort((left, right) => Number(left.startsInTest) - Number(right.startsInTest)
+    // Prefer a cohesive path joining multiple query-relevant nodes. Ranking by
+    // the seed alone over-promotes a highly lexical leaf's unrelated callees
+    // and hides the upstream relationship which explains why that leaf runs.
+    || right.executionPriority - left.executionPriority
+    || Number(right.queryCallsiteSteps > 0) - Number(left.queryCallsiteSteps > 0)
+    || right.bestQueryCallsiteWeight - left.bestQueryCallsiteWeight
+    || left.bestQueryCallsiteRank - right.bestQueryCallsiteRank
+    || Number(right.terminalPublic) - Number(left.terminalPublic)
+    || right.queryCallsiteSteps - left.queryCallsiteSteps
+    || right.relevantEndpoints - left.relevantEndpoints
+    || right.pathRelevance - left.pathRelevance
+    || right.endpointRelevance - left.endpointRelevance
+    || right.terminalRelevance - left.terminalRelevance
+    || right.endpointFilePriority - left.endpointFilePriority
+    || Number(right.startsSelected) - Number(left.startsSelected)
+    || right.selectedEndpoints - left.selectedEndpoints
+    || right.seedRelevance - left.seedRelevance
+    || left.flow.steps.length - right.flow.steps.length
+    || flowKey(left.flow).localeCompare(flowKey(right.flow)));
+  const seenFlowKeys = new Set<string>();
+  const unique = sorted.filter(({ flow }) => {
+    const key = flowKey(flow);
+    if (seenFlowKeys.has(key)) return false;
+    seenFlowKeys.add(key);
+    return true;
+  });
+  // Traversal starts from every reliable seed, so one semantic path can be
+  // discovered both whole and as prefixes/suffixes from its internal nodes.
+  // Retain the maximal contiguous explanation before applying the global step
+  // budget; otherwise the same edges consume the budget several times.
+  const provenanceRanks = [...new Set(unique.flatMap((entry) => (
+    entry.flow.steps.length === 1 && Number.isFinite(entry.bestQueryCallsiteRank)
+      ? [entry.bestQueryCallsiteRank] : []
+  )))].sort((left, right) => left - right);
+  const uniqueOrder = new Map(unique.map((entry, index) => [flowKey(entry.flow), index]));
+  const edgeLineWithin = (edge: GraphEdge, node: GraphNode): boolean => edge.line === undefined
+    || (edge.line >= node.startLine && edge.line <= node.endLine);
+  // The whole-query call-pair channel has already proved one ordered, bounded
+  // public-entry relationship using independent lexical evidence at both ends.
+  // Reload that exact real edge from cached adjacency before completing its
+  // direct planner callback. This remains available even when bounded traversal
+  // never materializes the one-edge prefix in `unique`, while arbitrary selected
+  // same-file flows cannot activate the reserve.
+  const callPairCallbackCompletion = fullQueryCallPairs.flatMap((pair, pairOrder) => {
+    const source = pair.source.node;
+    const target = pair.target.node;
+    if (source.id === target.id || pair.edge.source !== source.id || pair.edge.target !== target.id
+      || (pair.edge.kind !== "calls" && pair.edge.kind !== "instantiates")
+      || (pair.edge.confidence ?? 1) < 0.8
+      || isUnnamedFlowNode(source) || isUnnamedFlowNode(target)
+      || !isSourceAnchorKind(source) || !isSourceAnchorKind(target)
+      || isLowValueGraphPath(source.filePath) || isLowValueGraphPath(target.filePath)
+      || source.filePath !== target.filePath) return [];
+    const prefix = access.getOutgoing(source.id, ["calls", "instantiates"])
+      .filter(({ node, edge }) => edgeKey(edge) === edgeKey(pair.edge)
+        && (edge.kind === "calls" || edge.kind === "instantiates")
+        && (edge.confidence ?? 1) >= 0.8
+        && edge.source === source.id && edge.target === target.id && node.id === target.id
+        && edgeLineWithin(edge, source))
+      .sort((left, right) => (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+        || compareEdgeCallsite(left.edge, right.edge)
+        || edgeKey(left.edge).localeCompare(edgeKey(right.edge)))[0];
+    if (!prefix) return [];
+    return access.getOutgoing(target.id, ["contains"])
+      .filter(({ node: callback, edge }) => edge.kind === "contains"
+        && (edge.confidence ?? 1) >= 0.8
+        && edge.source === target.id && edge.target === callback.id
+        && callback.id !== source.id && callback.id !== target.id
+        && callback.containerId === target.id
+        && callback.filePath === target.filePath
+        && isUnnamedFlowNode(callback) && edgeLineWithin(edge, target))
+      .sort((left, right) => (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+        || compareEdgeCallsite(left.edge, right.edge)
+        || left.node.id.localeCompare(right.node.id))
+      .slice(0, CALL_PAIR_CALLBACKS_LIMIT)
+      .flatMap(({ node: callback, edge: containment }) => (
+        access.getOutgoing(callback.id, ["calls", "instantiates"])
+          .filter(({ node: terminal, edge }) => (edge.kind === "calls" || edge.kind === "instantiates")
+            && (edge.confidence ?? 1) >= 0.8
+            && edge.source === callback.id && edge.target === terminal.id
+            && terminal.id !== source.id && terminal.id !== target.id
+            && terminal.id !== callback.id
+            && !isUnnamedFlowNode(terminal) && isSourceAnchorKind(terminal)
+            && !isLowValueGraphPath(terminal.filePath)
+            && terminal.filePath !== target.filePath
+            && (terminal.isExported === true || terminal.visibility === "public")
+            && endpointNameRelevance(terminal) >= MIN_CALL_PAIR_CALLBACK_TERMINAL_NAME_RELEVANCE
+            && edgeLineWithin(edge, callback))
+          .sort((left, right) => endpointNameRelevance(right.node) - endpointNameRelevance(left.node)
+            || (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+            || compareEdgeCallsite(left.edge, right.edge)
+            || left.node.id.localeCompare(right.node.id))
+          .slice(0, CALL_PAIR_CALLBACK_EDGES_LIMIT)
+          .map(({ node: terminal, edge }) => ({
+            flow: { steps: [prefix.edge, containment, edge] },
+            terminalNameRelevance: endpointNameRelevance(terminal),
+            pairOrder,
+            terms: new Set([
+              ...(nodeTerms.get(source.id) ?? []),
+              ...(nodeTerms.get(target.id) ?? []),
+              ...(nodeTerms.get(callback.id) ?? []),
+              ...(nodeTerms.get(terminal.id) ?? []),
+            ]),
+          }))
+      ))
+  }).sort((left, right) => right.terminalNameRelevance - left.terminalNameRelevance
+    || left.pairOrder - right.pairOrder
+    || flowKey(left.flow).localeCompare(flowKey(right.flow)))[0];
+  const namedOwnerBridgeCache = new Map<string, GraphNeighbor | null>();
+  const namedOwnerBridge = (entry: (typeof unique)[number]): GraphNeighbor | null => {
+    if (entry.flow.steps.length !== 1) return null;
+    const orphanEdge = entry.flow.steps[0]!;
+    if (orphanEdge.kind !== "calls" && orphanEdge.kind !== "instantiates"
+      && orphanEdge.kind !== "references") return null;
+    const cached = namedOwnerBridgeCache.get(edgeKey(orphanEdge));
+    if (cached !== undefined) return cached;
+    const callback = access.getNode(orphanEdge.source);
+    if (!callback || !isUnnamedFlowNode(callback)) {
+      namedOwnerBridgeCache.set(edgeKey(orphanEdge), null);
+      return null;
+    }
+    const bridge = access.getIncoming(callback.id, ["contains"])
+      .filter((candidate) => (candidate.edge.confidence ?? 1) >= 0.8
+        && candidate.edge.source === candidate.node.id
+        && candidate.edge.target === callback.id
+        && candidate.node.kind !== "file"
+        && !isUnnamedFlowNode(candidate.node)
+        // `dispatch -> callback -> dispatch` is a real recursive shape, but it
+        // does not explain which named operation owns the requested call.
+        && candidate.node.id !== orphanEdge.target
+        && candidate.node.filePath === callback.filePath)
+      .sort((left, right) => Number(callback.containerId === right.node.id)
+        - Number(callback.containerId === left.node.id)
+        || Number(right.node.startLine <= callback.startLine && right.node.endLine >= callback.endLine)
+          - Number(left.node.startLine <= callback.startLine && left.node.endLine >= callback.endLine)
+        || (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+        || (left.node.endLine - left.node.startLine) - (right.node.endLine - right.node.startLine)
+        || left.node.id.localeCompare(right.node.id))[0] ?? null;
+    namedOwnerBridgeCache.set(edgeKey(orphanEdge), bridge);
+    return bridge;
+  };
+  const preferNamedOwnerFlow = (entry: (typeof unique)[number]): (typeof unique)[number] => {
+    if (entry.flow.steps.length !== 1) return entry;
+    const orphanEdge = entry.flow.steps[0]!;
+    const orphanSource = access.getNode(orphanEdge.source);
+    if (!orphanSource || !isUnnamedFlowNode(orphanSource)) return entry;
+
+    // A callback can be retained as a provenance seed independently of its
+    // enclosing declaration. When both traversals discover the same semantic
+    // edge, keep the maximal named-owner path: emitting only the callback
+    // suffix loses the relationship users asked for and spends another slot if
+    // the complete path is admitted later.
+    const containers = unique.filter((candidate) => {
+      if (candidate.flow.steps.length <= entry.flow.steps.length
+        || !isContiguousFlowSubpath(entry.flow, candidate.flow)) return false;
+      const orphanOffset = candidate.flow.steps.findIndex((edge) => edgeKey(edge) === edgeKey(orphanEdge));
+      // The orphan edge must remain the terminal relationship. Do not turn a
+      // provenance repair into an unrelated downstream extension merely
+      // because a longer traversal also happens to contain this edge.
+      if (orphanOffset <= 0 || orphanOffset !== candidate.flow.steps.length - 1) return false;
+      const bridge = candidate.flow.steps[orphanOffset - 1]!;
+      const owner = access.getNode(bridge.source);
+      return bridge.kind === "contains" && bridge.target === orphanEdge.source
+        && owner !== null && !isUnnamedFlowNode(owner);
+    }).sort((left, right) => right.flow.steps.length - left.flow.steps.length
+      || (uniqueOrder.get(flowKey(left.flow)) ?? Number.MAX_SAFE_INTEGER)
+        - (uniqueOrder.get(flowKey(right.flow)) ?? Number.MAX_SAFE_INTEGER));
+    if (containers[0]) return containers[0];
+
+    // The traversal budget may retain the callback while omitting its owner
+    // seed. Prepend the actual stored containment edge in that case.
+    const bridge = namedOwnerBridge(entry);
+    if (bridge) return { ...entry, flow: { steps: [bridge.edge, orphanEdge] } };
+
+    // A later recursive callback can win the bounded traversal while the
+    // query's enclosing operation was pruned as a seed. Look only at alternate
+    // real edges to the same target from the same matched source region, and
+    // recover one whose callback has a non-recursive named owner. This keeps
+    // the repair local to competing explanations of one relationship.
+    const alternate = access.getIncoming(orphanEdge.target, [orphanEdge.kind])
+      .flatMap((candidate) => {
+        if ((candidate.edge.confidence ?? 1) < 0.8
+          || candidate.edge.target !== orphanEdge.target
+          || candidate.edge.kind !== orphanEdge.kind
+          || edgeKey(candidate.edge) === edgeKey(orphanEdge)
+          || !isUnnamedFlowNode(candidate.node)) return [];
+        const candidateEntry = { ...entry, flow: { steps: [candidate.edge] } };
+        const candidateBridge = namedOwnerBridge(candidateEntry);
+        if (!candidateBridge) return [];
+        const candidateRank = queryRegionCallsiteRanks.get(edgeKey(candidate.edge));
+        const sameRank = candidateRank === entry.bestQueryCallsiteRank;
+        const ownerRelevant = selectedIds.has(candidateBridge.node.id)
+          || (seedRelevance.get(candidateBridge.node.id) ?? 0) >= STRONG_FLOW_RELEVANCE;
+        // Prefer the exact propagated source region. If bounded relevance
+        // expansion omitted that edge, a selected/query-relevant lexical owner
+        // is equivalent corroboration; unrelated callers remain ineligible.
+        return sameRank || ownerRelevant
+          ? [{ candidate, bridge: candidateBridge, rank: candidateRank ?? Number.POSITIVE_INFINITY }]
+          : [];
+      })
+      .sort((left, right) => Number(Number.isFinite(right.rank)) - Number(Number.isFinite(left.rank))
+        || left.rank - right.rank
+        || (queryRegionCallsiteWeights.get(edgeKey(right.candidate.edge)) ?? 0)
+        - (queryRegionCallsiteWeights.get(edgeKey(left.candidate.edge)) ?? 0)
+        || (seedRelevance.get(right.bridge.node.id) ?? 0) - (seedRelevance.get(left.bridge.node.id) ?? 0)
+        || Number(isLowValueGraphPath(left.bridge.node.filePath))
+          - Number(isLowValueGraphPath(right.bridge.node.filePath))
+        || (right.candidate.edge.line ?? -1) - (left.candidate.edge.line ?? -1)
+        || edgeKey(left.candidate.edge).localeCompare(edgeKey(right.candidate.edge)))[0];
+    return alternate
+      ? { ...entry, flow: { steps: [alternate.bridge.edge, alternate.candidate.edge] } }
+      : entry;
+  };
+  const recoveredOwnerCandidates = unique.flatMap((entry) => {
+    if (entry.flow.steps.length !== 1 || namedOwnerBridge(entry) !== null) return [];
+    const preferred = preferNamedOwnerFlow(entry);
+    return preferred.flow.steps.length > 1 ? [preferred] : [];
+  });
+  const recoveredOwnerKeys = new Set(recoveredOwnerCandidates.map((entry) => flowKey(entry.flow)));
+  const compareProvenanceCandidate = (left: (typeof unique)[number], right: (typeof unique)[number]): number => {
+    const leftEdge = left.flow.steps[0]!;
+    const rightEdge = right.flow.steps[0]!;
+    const sameRegionAndTarget = left.bestQueryCallsiteRank === right.bestQueryCallsiteRank
+      && leftEdge.target === rightEdge.target;
+    const namedOwnerPriority = sameRegionAndTarget
+      ? Number(namedOwnerBridge(right) !== null) - Number(namedOwnerBridge(left) !== null)
+      : 0;
+    // Three distinct calls into one destination are strong enough to identify
+    // a subsystem even when its symbols are lexically opaque (compiler
+    // resolvers are the motivating case). One or two calls are ordinary local
+    // evidence and should not leapfrog a better-ranked source region merely
+    // because they happen later in a broad adapter/helper routine.
+    const leftCohesive = left.terminalFileCallsiteCount >= 3;
+    const rightCohesive = right.terminalFileCallsiteCount >= 3;
+    const leftCrossFileCohesive = leftCohesive && left.crossesFile;
+    const rightCrossFileCohesive = rightCohesive && right.crossesFile;
+    return right.executionPriority - left.executionPriority
+      // A recursive callback suffix is replaced only when another real caller
+      // to the same target has a non-recursive named owner. Reserve that narrow
+      // repair ahead of ordinary provenance without promoting every callback.
+      || Number(recoveredOwnerKeys.has(flowKey(right.flow)))
+        - Number(recoveredOwnerKeys.has(flowKey(left.flow)))
+      // When one query region contains multiple callbacks invoking the same
+      // target, prefer the callback with a real non-recursive named owner. A
+      // later self-owned callback is an implementation suffix, not the fuller
+      // operation-to-target explanation.
+      || namedOwnerPriority
+      // A coherent cross-file fan-out is the strongest evidence that a query
+      // region delegates into another subsystem. Keep this ahead of local
+      // helper clusters so the selected primary flow can promote that file.
+      || Number(rightCrossFileCohesive) - Number(leftCrossFileCohesive)
+      || Number(rightCohesive) - Number(leftCohesive)
+      || (leftCohesive && rightCohesive
+        ? right.terminalFileCallsiteCount - left.terminalFileCallsiteCount
+        : left.bestQueryCallsiteRank - right.bestQueryCallsiteRank)
+      // Within an equally cohesive cross-file destination, the final callsite
+      // is the deterministic culmination (for example resolveModuleName after
+      // its prerequisite resolver setup). Same-file clusters continue through
+      // the ordinary relevance ordering below.
+      || (leftCrossFileCohesive && rightCrossFileCohesive
+        ? (rightEdge.line ?? -1) - (leftEdge.line ?? -1) : 0)
+      || right.selectedEndpoints - left.selectedEndpoints
+      || right.relevantEndpoints - left.relevantEndpoints
+      || right.terminalNameRelevance - left.terminalNameRelevance
+      || right.terminalRelevance - left.terminalRelevance
+      || right.endpointRelevance - left.endpointRelevance
+      || right.pathRelevance - left.pathRelevance
+      || right.bestQueryCallsiteWeight - left.bestQueryCallsiteWeight
+      || right.terminalFileCallsiteCount - left.terminalFileCallsiteCount
+      || Number(right.crossesFile) - Number(left.crossesFile)
+      || left.bestQueryCallsiteRank - right.bestQueryCallsiteRank
+      || (rightEdge.line ?? -1) - (leftEdge.line ?? -1)
+      || (leftEdge.column ?? Number.MAX_SAFE_INTEGER)
+        - (rightEdge.column ?? Number.MAX_SAFE_INTEGER)
+      || (uniqueOrder.get(flowKey(left.flow)) ?? Number.MAX_SAFE_INTEGER)
+        - (uniqueOrder.get(flowKey(right.flow)) ?? Number.MAX_SAFE_INTEGER);
+  };
+  const rawProvenanceCandidates = provenanceRanks.flatMap((rank) => {
+    const allCandidates = unique.filter((entry) => entry.flow.steps.length === 1
+      && entry.bestQueryCallsiteRank === rank);
+    const executableCandidates = allCandidates.filter((entry) => {
+      const kind = entry.flow.steps[0]?.kind;
+      return kind === "calls" || kind === "instantiates";
+    });
+    const candidates = executableCandidates.length > 0 ? executableCandidates : allCandidates;
+    const rankedAtSource = [...candidates].sort(compareProvenanceCandidate);
+    const primary = rankedAtSource[0];
+    if (!primary) return [];
+    const primaryTarget = primary.flow.steps[0]!.target;
+    const secondary = rankedAtSource.find((entry) => {
+      if (entry === primary || entry.flow.steps[0]!.target === primaryTarget) return false;
+      // A second edge from one source region is warranted only when its target
+      // is independently relevant/selected. This preserves paired operations
+      // such as digest + cache-key construction without admitting every helper
+      // called by a long routine.
+      return entry.relevantEndpoints >= 2
+        || entry.terminalRelevance >= STRONG_FLOW_RELEVANCE
+        || entry.selectedEndpoints >= 2;
+    });
+    return secondary ? [primary, secondary] : [primary];
+  });
+  const provenanceCandidates = [...new Map([...rawProvenanceCandidates, ...recoveredOwnerCandidates].map((entry) => {
+    const preferred = preferNamedOwnerFlow(entry);
+    return [flowKey(preferred.flow), preferred] as const;
+  })).values()];
+  // Provenance is a priority reserve, not the whole flow budget. Rank all
+  // source regions together before applying the cap so a strong later FTS hit
+  // cannot be hidden by three incidental earlier windows, and leave at least
+  // half of the eight-step allowance for maximal directed explanations.
+  const provenanceReserve = Math.max(1, Math.ceil(maxSteps / 2));
+  const provenanceRepresentatives = provenanceCandidates
+    .sort(compareProvenanceCandidate)
+    .slice(0, provenanceReserve);
+  const provenanceKeys = new Set(provenanceRepresentatives.map((entry) => flowKey(entry.flow)));
+  const recoveredRepresentativeFlows = provenanceRepresentatives
+    .filter((entry) => recoveredOwnerKeys.has(flowKey(entry.flow)))
+    .map((entry) => entry.flow);
+  const explainedCallbackTargets = new Set(provenanceRepresentatives.flatMap((entry) => {
+    if (entry.flow.steps.length < 2) return [];
+    const terminal = entry.flow.steps.at(-1)!;
+    const bridge = entry.flow.steps.at(-2)!;
+    const owner = access.getNode(bridge.source);
+    return bridge.kind === "contains" && bridge.target === terminal.source
+      && owner !== null && owner.kind !== "file" && !isUnnamedFlowNode(owner)
+      && owner.id !== terminal.target
+      ? [`${entry.bestQueryCallsiteRank}\0${terminal.target}`] : [];
+  }));
+  const isExplainedCallbackSuffix = (entry: (typeof unique)[number]): boolean => {
+    if (entry.flow.steps.length !== 1) return false;
+    const edge = entry.flow.steps[0]!;
+    const source = access.getNode(edge.source);
+    return source !== null && isUnnamedFlowNode(source)
+      && explainedCallbackTargets.has(`${entry.bestQueryCallsiteRank}\0${edge.target}`);
+  };
+  const ranked = unique.filter(({ flow }, index) => !provenanceKeys.has(flowKey(flow))
+    && !isExplainedCallbackSuffix(unique[index]!)
+    // Once a recovered named-owner explanation is reserved, a longer path
+    // which merely prepends upstream callers repeats the same semantic spine.
+    && !recoveredRepresentativeFlows.some((recovered) => flow.steps.length > recovered.steps.length
+      && isTerminalFlowSubpath(recovered, flow))
+    && !unique.some(({ flow: other }, otherIndex) =>
+    index !== otherIndex
+      && flow.steps.length < other.steps.length
+      && isContiguousFlowSubpath(flow, other)));
+  const deferredOverlap: ScopeFlow[] = [];
+  const admit = (flow: ScopeFlow): boolean => {
+    const keys = new Set(flow.steps.map(edgeKey));
+    if (selected.some((prior) => [...keys].every((key) => prior.steps.some((step) => edgeKey(step) === key)))) return false;
+    const remaining = maxSteps - selectedSteps;
+    if (remaining <= 0 || flow.steps.length > remaining) return false;
+    const admitted = { steps: flow.steps };
+    selected.push(admitted);
+    selectedSteps += admitted.steps.length;
+    return true;
+  };
+  const coveredTerms = new Set<string>();
+  if (callPairCallbackCompletion && admit(callPairCallbackCompletion.flow)) {
+    for (const term of callPairCallbackCompletion.terms) coveredTerms.add(term);
+  }
+  for (const representative of provenanceRepresentatives) {
+    if (!admit(representative.flow)) continue;
+    for (const term of representative.terms) coveredTerms.add(term);
+  }
+  const first = ranked.shift();
+  if (first && admit(first.flow)) {
+    for (const term of first.terms) coveredTerms.add(term);
+  }
+  ranked.sort((left, right) => Number(right.startsSelected) - Number(left.startsSelected)
+    || marginalTermScore(right.terms, coveredTerms, termWeights)
+      - marginalTermScore(left.terms, coveredTerms, termWeights));
+  for (const { flow } of ranked) {
+    if (selectedSteps >= maxSteps) break;
+    if (selected.length > 0 && selected.some((prior) => flow.steps.some((step) =>
+      prior.steps.some((priorStep) => edgeKey(priorStep) === edgeKey(step))))) {
+      deferredOverlap.push(flow);
+      continue;
+    }
+    admit(flow);
+    if (selectedSteps >= maxSteps) break;
+  }
+  // If every useful branch shares an upstream prefix, retain the best such
+  // branch rather than forcing a single-flow result. Disjoint explanations win
+  // whenever they exist, which prevents two slots restating the same spine.
+  for (const flow of deferredOverlap) {
+    if (selectedSteps >= maxSteps) break;
+    admit(flow);
+  }
+  return selected;
+}
+
+function marginalTermScore(terms: Set<string>, covered: Set<string>, weights: Map<string, number>): number {
+  return [...terms].filter((term) => !covered.has(term))
+    .reduce((score, term) => score + (weights.get(term) ?? 0), 0);
+}
+
+function isUnnamedFlowNode(node: GraphNode): boolean {
+  return node.name.length === 0 || /^<.*>$/.test(node.name) || node.name.startsWith("<callback:");
+}
+
+function compareSemanticPhraseNeighbor(left: GraphNeighbor, right: GraphNeighbor): number {
+  return (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+    || compareEdgeCallsite(left.edge, right.edge)
+    || left.node.filePath.localeCompare(right.node.filePath)
+    || left.node.id.localeCompare(right.node.id);
+}
+
+/** Total callsite order; graph-store row order must never decide a phrase bridge. */
+function compareEdgeCallsite(left: GraphEdge, right: GraphEdge): number {
+  return (left.line ?? Number.MAX_SAFE_INTEGER) - (right.line ?? Number.MAX_SAFE_INTEGER)
+    || (left.column ?? Number.MAX_SAFE_INTEGER) - (right.column ?? Number.MAX_SAFE_INTEGER)
+    || left.source.localeCompare(right.source)
+    || left.target.localeCompare(right.target)
+    || left.kind.localeCompare(right.kind)
+    || (left.resolutionMethod ?? "").localeCompare(right.resolutionMethod ?? "")
+    || (left.provenance ?? "").localeCompare(right.provenance ?? "");
+}
+
+function edgeKey(edge: GraphEdge): string {
+  return `${edge.source}\0${edge.target}\0${edge.kind}\0${edge.line ?? -1}\0${edge.column ?? -1}`;
+}
+
+function flowKey(flow: ScopeFlow): string {
+  return flow.steps.map(edgeKey).join("\n");
+}
+
+function isContiguousFlowSubpath(candidate: ScopeFlow, container: ScopeFlow): boolean {
+  if (candidate.steps.length > container.steps.length) return false;
+  const candidateKeys = candidate.steps.map(edgeKey);
+  const containerKeys = container.steps.map(edgeKey);
+  for (let offset = 0; offset <= containerKeys.length - candidateKeys.length; offset += 1) {
+    if (candidateKeys.every((key, index) => key === containerKeys[offset + index])) return true;
+  }
+  return false;
+}
+
+function isTerminalFlowSubpath(candidate: ScopeFlow, container: ScopeFlow): boolean {
+  if (candidate.steps.length > container.steps.length) return false;
+  const offset = container.steps.length - candidate.steps.length;
+  return candidate.steps.every((edge, index) => edgeKey(edge) === edgeKey(container.steps[offset + index]!));
+}
+
+function normalizeNodeSearch(query: string): string {
+  return query.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function createScopeRequestAccess(graph: GraphEngine): ScopeRequestAccess {
+  const nodeCache = new Map<string, GraphNode | null>();
+  const incomingCache = new Map<string, GraphNeighbor[]>();
+  const outgoingCache = new Map<string, GraphNeighbor[]>();
+  const adjacencyKey = (id: string, kinds: EdgeKind[]): string =>
+    `${id}\0${[...new Set(kinds)].sort().join(",")}`;
+  const rememberNeighbors = (neighbors: GraphNeighbor[]): GraphNeighbor[] => {
+    for (const neighbor of neighbors) nodeCache.set(neighbor.node.id, neighbor.node);
+    return neighbors;
+  };
+  const cachedNeighbors = (
+    cache: Map<string, GraphNeighbor[]>,
+    id: string,
+    kinds: EdgeKind[],
+    load: () => GraphNeighbor[],
+  ): GraphNeighbor[] => {
+    const key = adjacencyKey(id, kinds);
+    const cached = cache.get(key);
+    if (cached) return cached;
+    const loaded = rememberNeighbors(load());
+    cache.set(key, loaded);
+    return loaded;
+  };
+  return {
+    rememberNode(node): void { nodeCache.set(node.id, node); },
+    getNode(id): GraphNode | null {
+      if (nodeCache.has(id)) return nodeCache.get(id) ?? null;
+      const node = graph.getNode(id);
+      nodeCache.set(id, node);
+      return node;
+    },
+    getIncoming(id, kinds): GraphNeighbor[] {
+      return cachedNeighbors(incomingCache, id, kinds, () => graph.getIncoming(id, kinds));
+    },
+    getOutgoing(id, kinds): GraphNeighbor[] {
+      return cachedNeighbors(outgoingCache, id, kinds, () => graph.getOutgoing(id, kinds));
+    },
+  };
+}
+
+function compareDerivedFlowSeed(left: DerivedFlowSeed, right: DerivedFlowSeed): number {
+  return Number(Number.isFinite(right.callsiteRank)) - Number(Number.isFinite(left.callsiteRank))
+    || left.callsiteRank - right.callsiteRank
+    || right.relevance - left.relevance
+    || right.confidence - left.confidence
+    || Number(isLowValueGraphPath(left.node.filePath)) - Number(isLowValueGraphPath(right.node.filePath))
+    || left.node.id.localeCompare(right.node.id);
+}
+
+function reliableNeighbors(access: ScopeRequestAccess, id: string): GraphNeighbor[] {
+  const current = access.getNode(id);
+  return [...access.getIncoming(id, RELEVANCE_EDGE_KINDS), ...access.getOutgoing(id, RELEVANCE_EDGE_KINDS)]
+    .filter((entry) => {
+      if ((entry.edge.confidence ?? 1) < 0.8) return false;
+      if (entry.edge.kind !== "contains") return true;
+      // Containment may promote a declaration to its non-file owner, or enter
+      // the one anonymous callback bridge needed for compiler-backed calls.
+      // It must never fan out from a file/class into named children: that turns
+      // one lexical hit into every sibling declaration on the second hop.
+      return entry.edge.source === id
+        ? current?.kind !== "file" && isUnnamedFlowNode(entry.node)
+        : entry.node.kind !== "file" && current?.kind !== "file";
+    }).sort(compareNeighbor);
+}
+
+function compareNeighbor(left: GraphNeighbor, right: GraphNeighbor): number {
+  return (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+    || Number(isLowValueGraphPath(left.node.filePath)) - Number(isLowValueGraphPath(right.node.filePath))
+    || (left.edge.line ?? Number.MAX_SAFE_INTEGER) - (right.edge.line ?? Number.MAX_SAFE_INTEGER)
+    || left.node.id.localeCompare(right.node.id);
+}
+
+function compareQueryNeighbor(
+  currentId: string,
+  left: GraphNeighbor,
+  right: GraphNeighbor,
+  hits: SourceChunkMatch[],
+  terms: Array<{ term: string; weight: number; stem: boolean }>,
+): number {
+  const callsiteScore = (entry: GraphNeighbor): number => {
+    if (entry.edge.source !== currentId || entry.edge.line === undefined) return 0;
+    return hits.some((hit) => entry.edge.line! >= hit.startLine && entry.edge.line! <= hit.endLine) ? 1 : 0;
+  };
+  const nameScore = (entry: GraphNeighbor): number => {
+    const components = new Set(searchComponents(entry.node.name));
+    return terms.reduce((score, term) => score
+      + (componentMatches(components, term.term, term.stem) ? term.weight : 0), 0);
+  };
+  return callsiteScore(right) - callsiteScore(left)
+    || nameScore(right) - nameScore(left)
+    || compareNeighbor(left, right);
+}
+
+function queryCallsiteHit(currentId: string, edge: GraphEdge, hits: SourceChunkMatch[]): boolean {
+  if (edge.source !== currentId || edge.line === undefined) return false;
+  return hits.some((hit) => edge.line! >= hit.startLine && edge.line! <= hit.endLine);
+}
+
+function queryCallsiteWeight(
+  edge: GraphEdge,
+  hits: SourceChunkMatch[],
+  concepts: QueryConcept[],
+): number {
+  if (edge.line === undefined) return 0;
+  return hits.filter((hit) => edge.line! >= hit.startLine && edge.line! <= hit.endLine)
+    .reduce((best, hit) => {
+      const terms = new Set(hit.matchedTerms ?? []);
+      const weight = concepts.filter((concept) => conceptMatchesTerms(concept, terms))
+        .reduce((sum, concept) => sum + concept.weight, 0);
+      return Math.max(best, weight);
+    }, 0);
+}
+
+function isReliableLexicalSeed(entry: NodeEvidence): boolean {
+  if (entry.exact) return true;
+  const literalTermReasons = [...entry.reasons]
+    .filter((reason) => reason.startsWith("term:"))
+    .map((reason) => reason.slice("term:".length));
+  if (literalTermReasons.length === 0 || entry.nameTerms.size === 0) return false;
+  const normalizedName = entry.node.name.replace(/^#/, "").toLowerCase();
+  if (literalTermReasons.includes(normalizedName)) return true;
+  // BM25 plus a distinctive name component (or two ordinary components) is a
+  // corroborated symbol hit. Docstring/signature-only hits never qualify.
+  const matchedNameTerms = literalTermReasons.filter((term) => entry.nameTerms.has(term));
+  const generic = new Set(["class", "code", "file", "function", "graph", "method", "node", "source", "symbol"]);
+  return entry.reasons.has("bm25-node") && (
+    matchedNameTerms.length >= 2
+    || matchedNameTerms.some((term) => term.length >= 5 && !generic.has(term))
+  );
+}
+
+function isReliableRegionSeed(entry: NodeEvidence): boolean {
+  // A region match is traversable only when the declaration name independently
+  // corroborates it. Body-only FTS remains useful source evidence but must not
+  // manufacture graph flow from an incidental overlap. The source index orders
+  // overlapping declarations by substantive coverage, so a strong body-only
+  // chunk may bootstrap its single primary declaration, but never every
+  // sibling that happens to share the same 80-line window.
+  const primaryBodyMatch = entry.bestRegionOverlapRank === 0 && entry.regionHits.some((hit) => (
+    new Set(hit.matchedTerms ?? []).size >= 3
+  ));
+  if (regionStrength(entry) >= 0.55 && (entry.nameTerms.size > 0 || primaryBodyMatch)) return true;
+  // A named declaration that demonstrably owns an anonymous callback inside a
+  // two-concept source hit is safe to traverse at a slightly lower lexical
+  // threshold: the compiler-backed containment and subsequent call still have
+  // to satisfy the normal confidence and one-bridge gates.
+  return entry.regionCallbackCallsites.size > 0 && directRegionStrength(entry) >= 0.4
+    && entry.regionHits.some((hit) => new Set(hit.matchedTerms ?? []).size >= 2);
+}
+
+/**
+ * Only declarations with declaration-local lexical evidence or a trusted graph
+ * relationship become candidates/facts. Source-chunk terms describe an entire
+ * 80-line window, so an overlapping sibling is not a structural claim merely
+ * because several query terms occur elsewhere in that window. The file and its
+ * raw text hit remain independently selectable through the source channel.
+ */
+function hasTrustworthyCandidateEvidence(entry: NodeEvidence): boolean {
+  return entry.exact
+    || entry.reliable
+    || isReliableLexicalSeed(entry)
+    || isReliableRegionSeed(entry);
+}
+
+function isSourceAnchorKind(node: GraphNode): boolean {
+  if (node.name.startsWith("<callback:")) return false;
+  switch (node.kind) {
+    case "function": case "method": case "class": case "struct": case "trait":
+    case "component": case "route": case "interface": case "protocol": case "type_alias":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function compareNodeEvidence(left: NodeEvidence, right: NodeEvidence): number {
+  return Number(right.exact) - Number(left.exact)
+    || nodeSelectionPriority(right.node) - nodeSelectionPriority(left.node)
+    || left.bestCallsiteRank - right.bestCallsiteRank
+    || regionStrength(right) - regionStrength(left)
+    || right.nameTerms.size - left.nameTerms.size
+    || right.terms.size - left.terms.size
+    || (right.rrf + right.graph) - (left.rrf + left.graph)
+    || left.node.id.localeCompare(right.node.id);
+}
+
+function bestFullQueryCallPairs(
+  entries: NodeEvidence[],
+  concepts: QueryConcept[],
+  access: ScopeRequestAccess,
+  limit: number,
+): FullQueryCallPair[] {
+  const byId = new Map(entries.map((entry) => [entry.node.id, entry]));
+  const eligibleSources = entries.filter((entry) => entry.fullQueryRank < MAX_FULL_QUERY_CALL_PAIR_RANK
+    && !isLowValueGraphPath(entry.node.filePath)
+    && isSourceAnchorKind(entry.node)
+    && (entry.node.isExported === true || entry.node.visibility === "public"))
+    .sort((left, right) => left.fullQueryRank - right.fullQueryRank
+      || left.node.id.localeCompare(right.node.id))
+    .slice(0, MAX_FULL_QUERY_CALL_PAIR_RANK);
+  return eligibleSources.map((entry) => {
+    const declarationConcepts = concepts.filter((concept) => nodeMatchesConcept(entry.node, concept));
+    const identityConcepts = concepts.filter((concept) => nodeMatchesConceptInIdentity(entry.node, concept));
+    const declarationWeight = declarationConcepts.reduce((sum, concept) => sum + concept.weight, 0);
+    const strongConcepts = declarationConcepts.filter((concept) => concept.weight >= 1);
+    const identityKeys = new Set(identityConcepts.map((concept) => concept.key));
+    const corroboratingTarget = access.getOutgoing(entry.node.id, ["calls", "instantiates"])
+      .filter(({ edge }) => (edge.confidence ?? 1) >= 0.8)
+      .flatMap(({ node, edge }) => {
+        const target = byId.get(node.id);
+        if (!target || target.fullQueryRank >= MAX_FULL_QUERY_CALL_PAIR_RANK
+          || isLowValueGraphPath(target.node.filePath) || !isSourceAnchorKind(target.node)) return [];
+        const targetConcepts = concepts.filter((concept) => nodeMatchesConceptInIdentity(target.node, concept));
+        if (targetConcepts.length < 2 || !targetConcepts.some((concept) => !identityKeys.has(concept.key))) return [];
+        const union = new Map([...identityConcepts, ...targetConcepts].map((concept) => [concept.key, concept]));
+        const unionWeight = [...union.values()].reduce((sum, concept) => sum + concept.weight, 0);
+        const unionStrong = [...union.values()].filter((concept) => concept.weight >= 1).length;
+        if (!((unionStrong > 0 && union.size >= 3 && unionWeight >= 1.7)
+          || (union.size >= 4 && unionWeight >= 1.4))) return [];
+        return [{ target, edge, unionWeight, unionSize: union.size }];
+      }).sort((left, right) => left.target.fullQueryRank - right.target.fullQueryRank
+        || right.unionWeight - left.unionWeight
+        || right.unionSize - left.unionSize
+        || (right.edge.confidence ?? 1) - (left.edge.confidence ?? 1)
+        || compareEdgeCallsite(left.edge, right.edge))[0];
+    return {
+      entry, declarationConcepts, identityConcepts, declarationWeight, strongConcepts, corroboratingTarget,
+    };
+  }).filter(({ entry, declarationConcepts, identityConcepts, declarationWeight, strongConcepts, corroboratingTarget }) => (
+    identityConcepts.length > 0
+    && declarationConcepts.length >= 3
+    && ((strongConcepts.length > 0 && declarationWeight >= 1.7)
+      || (declarationConcepts.length >= 4 && identityConcepts.length >= 2 && declarationWeight >= 1.4))
+    && corroboratingTarget !== undefined
+  )).sort((left, right) => left.entry.fullQueryRank - right.entry.fullQueryRank
+    || left.corroboratingTarget!.target.fullQueryRank - right.corroboratingTarget!.target.fullQueryRank
+    || right.strongConcepts.length - left.strongConcepts.length
+    || right.declarationWeight - left.declarationWeight
+    || right.identityConcepts.length - left.identityConcepts.length
+    || compareNodeEvidence(left.entry, right.entry))
+    .slice(0, Math.floor(limit / 2))
+    .map(({ entry, corroboratingTarget }) => ({
+      source: entry,
+      target: corroboratingTarget!.target,
+      edge: corroboratingTarget!.edge,
+    }));
+}
+
+function bestStrongIntentFacetDeclarations(
+  entries: NodeEvidence[],
+  concepts: QueryConcept[],
+  access: ScopeRequestAccess,
+  limit: number,
+): NodeEvidence[] {
+  const lexicalCandidates = entries.map((entry) => {
+    const matched = concepts.filter((concept) => nodeMatchesConceptInIdentity(entry.node, concept));
+    const strong = matched.filter((concept) => concept.weight >= MIN_SEMANTIC_PHRASE_CONCEPT_WEIGHT);
+    const weight = matched.reduce((sum, concept) => sum + concept.weight, 0);
+    return { entry, matched, strong, weight };
+  }).filter(({ entry, matched, strong, weight }) => (
+    !isLowValueGraphPath(entry.node.filePath)
+    && isSourceAnchorKind(entry.node)
+    && (entry.node.isExported === true || entry.node.visibility === "public")
+    && matched.length >= 2
+    && strong.length > 0
+    // A responsibility must stay grounded in at least one code-domain concept;
+    // two ordinary English words such as "entry points" are one phrase, not a
+    // second independent responsibility.
+    && matched.some((concept) => concept.weight < MIN_SEMANTIC_PHRASE_CONCEPT_WEIGHT)
+    && weight >= 1
+  )).sort((left, right) => right.weight - left.weight
+    || right.matched.length - left.matched.length
+    || compareNodeEvidence(left.entry, right.entry))
+    .slice(0, 16);
+  const candidates = lexicalCandidates.filter(({ entry }) => {
+    const incoming = access.getIncoming(entry.node.id, FLOW_EDGE_KINDS)
+      .filter(({ edge, node }) => (edge.confidence ?? 1) >= 0.8
+        && !isLowValueGraphPath(node.filePath));
+    // Cross-file invocation proves a boundary entry. An unreferenced exported
+    // declaration remains a plausible library entry; a helper used only by
+    // siblings in its own file does not consume the facet reserve.
+    return incoming.length === 0
+      || incoming.some(({ node }) => node.filePath !== entry.node.filePath);
+  });
+  const selected: NodeEvidence[] = [];
+  const covered = new Set<string>();
+  while (selected.length < limit) {
+    const next = candidates.filter(({ entry, strong }) => !selected.includes(entry)
+      && strong.some((concept) => !covered.has(concept.key)))
+      .sort((left, right) => {
+        const leftMarginal = left.strong.filter((concept) => !covered.has(concept.key));
+        const rightMarginal = right.strong.filter((concept) => !covered.has(concept.key));
+        return rightMarginal.reduce((sum, concept) => sum + concept.weight, 0)
+          - leftMarginal.reduce((sum, concept) => sum + concept.weight, 0)
+          || rightMarginal.length - leftMarginal.length
+          || right.weight - left.weight
+          || right.matched.length - left.matched.length
+          || compareNodeEvidence(left.entry, right.entry);
+      })[0];
+    if (!next) break;
+    selected.push(next.entry);
+    for (const concept of next.strong) covered.add(concept.key);
+  }
+  return selected;
+}
+
+function bestFullQueryDeclaration(
+  entries: NodeEvidence[],
+  concepts: QueryConcept[],
+): NodeEvidence | undefined {
+  return entries.filter((entry) => (
+    Number.isFinite(entry.fullQueryRank)
+    && !isLowValueGraphPath(entry.node.filePath)
+    // Stems and inflections of one user token are one concept, not independent
+    // corroboration. Require two raw concepts in the declaration's leaf name
+    // whose combined planner weight reaches one ordinary-strength signal. This
+    // retains a focused compound such as planFileSource while rejecting both a
+    // lone `supported` family and ubiquitous low-signal pairs such as source+file.
+    && (hasIndependentNameConcepts(entry.node, concepts) || (isReliableLexicalSeed(entry)
+      && [...entry.reasons].some((reason) => (
+        reason === `term:${entry.node.name.replace(/^#/, "").toLowerCase()}`
+      ))))
+  )).sort((left, right) => left.fullQueryRank - right.fullQueryRank
+    || compareNodeEvidence(left, right)
+    || left.node.id.localeCompare(right.node.id))[0];
+}
+
+function hasIndependentNameConcepts(node: GraphNode, concepts: QueryConcept[]): boolean {
+  const components = new Set(searchComponents(node.name));
+  const matched = concepts.filter((concept) => conceptMatchesComponents(concept, components));
+  return matched.length >= 2 && matched.reduce((sum, concept) => sum + concept.weight, 0) >= 1;
+}
+
+function bestSourceAlignedDeclaration(entries: NodeEvidence[]): NodeEvidence | undefined {
+  return entries.filter((entry) => entry.directRegion > 0 && Number.isFinite(entry.bestRegionRank))
+    .sort((left, right) => left.bestRegionRank - right.bestRegionRank
+      || right.nameTerms.size - left.nameTerms.size
+      || directRegionStrength(right) - directRegionStrength(left)
+      || left.bestRegionOverlapRank - right.bestRegionOverlapRank
+      || compareNodeEvidence(left, right))[0];
+}
+
+function compareProvenanceFlowSeed(left: NodeEvidence, right: NodeEvidence): number {
+  return left.bestRegionRank - right.bestRegionRank
+    || left.bestRegionOverlapRank - right.bestRegionOverlapRank
+    || Number(right.regionCallbackCallsites.size > 0) - Number(left.regionCallbackCallsites.size > 0)
+    || right.regionCallsites.size - left.regionCallsites.size
+    || compareNodeEvidence(left, right);
+}
+
+function nodeSelectionPriority(node: GraphNode): number {
+  if (node.name.startsWith("<callback:")) return 0;
+  switch (node.kind) {
+    case "function": case "method": case "class": case "struct": case "trait": case "component": return 3;
+    case "interface": case "protocol": case "type_alias": case "enum": return 2;
+    case "constant": case "variable": case "route": return 1.5;
+    case "property": case "field": case "parameter": return 1;
+    default: return 0.5;
+  }
+}
+
+function ensureNode(nodes: Map<string, NodeEvidence>, node: GraphNode): NodeEvidence {
+  const existing = nodes.get(node.id);
+  if (existing) return existing;
+  const created: NodeEvidence = {
+    node, rrf: 0, fullQueryRank: Number.POSITIVE_INFINITY,
+    region: 0, directRegion: 0, regionHits: [], bestRegionRank: Number.POSITIVE_INFINITY,
+    bestRegionOverlapRank: Number.POSITIVE_INFINITY,
+    regionCallsites: new Set(), regionCallbackCallsites: new Set(), bestCallsiteRank: Number.POSITIVE_INFINITY,
+    exact: false, exactIdentifiers: new Set(), graph: 0,
+    terms: new Set(), nameTerms: new Set(), reasons: new Set(), reliable: false,
+  };
+  nodes.set(node.id, created);
+  return created;
+}
+
+function regionStrength(entry: NodeEvidence): number {
+  // Repeated overlapping windows are supporting evidence, not independent
+  // votes. A small saturating bonus lets a substantive enclosing declaration
+  // beat a two-line wrapper without making very long files dominate.
+  return entry.region + Math.min(0.3, Math.max(0, entry.regionHits.length - 1) * 0.06);
+}
+
+function directRegionStrength(entry: NodeEvidence): number {
+  return entry.directRegion + Math.min(0.3, Math.max(0, entry.regionHits.length - 1) * 0.06);
+}
+
+function ensureFile(files: Map<string, FileEvidence>, filePath: string): FileEvidence {
+  const existing = files.get(filePath);
+  if (existing) return existing;
+  const created: FileEvidence = {
+    filePath, score: 0, region: 0, callsiteRegion: 0, callsiteQueryWeight: 0,
+    bestCallsiteRank: Number.POSITIVE_INFINITY,
+    terms: new Set(), reasons: new Set(), nodeIds: new Set(), textHits: [], bestTextRank: Number.POSITIVE_INFINITY, exact: false,
+    exactIdentifiers: new Set(), reliableGraph: false,
+  };
+  files.set(filePath, created);
+  return created;
+}
+
+function exactIdentifierMatch(node: GraphNode, identifier: string): boolean {
+  const wanted = identifier.replaceAll(".", "::");
+  const name = node.name;
+  const qualified = node.qualifiedName.replaceAll(".", "::");
+  return name === wanted || qualified === wanted || qualified.endsWith(`::${wanted}`);
+}
+
+function caseFoldedIdentifierMatch(node: GraphNode, identifier: string): boolean {
+  const wanted = identifier.toLowerCase().replaceAll(".", "::");
+  const name = node.name.toLowerCase();
+  const qualified = node.qualifiedName.toLowerCase().replaceAll(".", "::");
+  return name === wanted || qualified === wanted || qualified.endsWith(`::${wanted}`);
+}
+
+function nodeContains(node: GraphNode, term: string, prefix = false): boolean {
+  const indexed = new Set([
+    ...searchComponents(node.name),
+    ...searchComponents(node.qualifiedName),
+    ...searchComponents(node.signature ?? ""),
+    ...searchComponents(node.docstring ?? ""),
+  ]);
+  return componentMatches(indexed, term, prefix);
+}
+
+function componentMatches(components: Set<string>, term: string, prefix: boolean): boolean {
+  return components.has(term) || (prefix && term.length >= 3 && [...components].some((component) => component.startsWith(term)));
+}
+
+function searchComponents(value: string): string[] {
+  return [...new Set((value.match(/[A-Za-z_$][A-Za-z0-9_$]*/g) ?? []).flatMap(identifierComponents))];
+}
+
+function literalTerms(plan: ReturnType<typeof planGraphQuery>): string[] {
+  return [...new Set(plan.terms.filter((term) => !term.stem).map((term) => term.term))];
+}
+
+function weightedTerms(plan: ReturnType<typeof planGraphQuery>): Array<{ term: string; weight: number; stem: boolean }> {
+  const weights = new Map<string, { weight: number; stem: boolean }>();
+  for (const entry of plan.terms) {
+    const current = weights.get(entry.term);
+    weights.set(entry.term, {
+      weight: Math.max(current?.weight ?? 0, entry.weight),
+      stem: (current?.stem ?? true) && entry.stem,
+    });
+  }
+  return [...weights].map(([term, value]) => ({ term, ...value }));
+}
+
+/**
+ * Group inflections and compound-identifier components by the token the user
+ * actually supplied. Coverage should reward independent query concepts, not
+ * count `compose`, `composed`, and `compos` as three separate signals.
+ */
+function queryConcepts(plan: ReturnType<typeof planGraphQuery>): QueryConcept[] {
+  const concepts = new Map<string, QueryConcept>();
+  for (const entry of plan.terms) {
+    const key = entry.raw.toLowerCase();
+    const concept = concepts.get(key) ?? { key, raw: entry.raw, weight: 0, terms: [] };
+    concept.weight = Math.max(concept.weight, entry.weight);
+    if (!concept.terms.some((term) => term.term === entry.term && term.stem === entry.stem)) {
+      concept.terms.push({ term: entry.term, stem: entry.stem });
+    }
+    concepts.set(key, concept);
+  }
+  return [...concepts.values()];
+}
+
+function conceptMatchesTerms(concept: QueryConcept, terms: Set<string>): boolean {
+  return concept.terms.some((entry) => terms.has(entry.term));
+}
+
+function conceptMatchesComponents(concept: QueryConcept, components: Set<string>): boolean {
+  return concept.terms.some((entry) => componentMatches(components, entry.term, entry.stem));
+}
+
+function nodeMatchesConcept(node: GraphNode, concept: QueryConcept): boolean {
+  return concept.terms.some((entry) => nodeContains(node, entry.term, entry.stem));
+}
+
+function nodeMatchesConceptInIdentity(node: GraphNode, concept: QueryConcept): boolean {
+  const components = new Set([
+    ...searchComponents(node.name),
+    ...searchComponents(node.qualifiedName),
+    ...searchComponents(node.signature ?? ""),
+  ]);
+  return conceptMatchesComponents(concept, components);
+}
+
+function addConceptEvidence(entry: NodeEvidence, concept: QueryConcept): void {
+  const nameComponents = new Set(searchComponents(entry.node.name));
+  for (const term of concept.terms) {
+    if (nodeContains(entry.node, term.term, term.stem)) entry.terms.add(term.term);
+    if (componentMatches(nameComponents, term.term, term.stem)) entry.nameTerms.add(term.term);
+  }
+}
+
+function componentIdfSignal(
+  components: Set<string>,
+  concepts: QueryConcept[],
+  documents: number,
+  documentFrequency: Map<string, number>,
+): number {
+  let score = 0;
+  for (const component of components) {
+    const singleton = new Set([component]);
+    const strongest = concepts.filter((concept) => conceptMatchesComponents(concept, singleton))
+      .reduce((best, concept) => Math.max(
+        best,
+        concept.weight * idf(documents, documentFrequency.get(concept.key) ?? 0),
+      ), 0);
+    score += strongest;
+  }
+  return score;
+}
+
+function idf(documents: number, frequency: number): number {
+  return Math.log((documents + 1) / (frequency + 1)) + 1;
+}
+
+function safeSourceSearch(graph: GraphEngine, query: string, limit: number): SourceChunkMatch[] {
+  try { return graph.searchSource?.(query, limit) ?? []; } catch { return []; }
+}
+
+function safeIndexedFiles(graph: GraphEngine): IndexedFileInfo[] {
+  try { return graph.getIndexedFiles?.() ?? []; } catch { return []; }
+}
+
+function dedupeChunkHits(hits: SourceChunkMatch[]): SourceChunkMatch[] {
+  const seen = new Set<string>();
+  return hits.filter((hit) => {
+    const key = `${hit.filePath}:${hit.startLine}:${hit.endLine}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  }).slice(0, 4);
+}
+
+function emptySelection(): ScopeSelection {
+  return { candidates: [], files: [], flows: [], matchedCount: 0, coveredTerms: [], evidenceStrength: "none" };
+}
+
 export function compactFact(graph: GraphEngine, id: string, detail: DetailLevel): CompactFact | null {
   const node = graph.getNode(id);
   if (!node) return null;
   return {
-    id: node.id,
-    kind: node.kind,
-    name: node.name,
-    qualifiedName: node.qualifiedName,
-    filePath: node.filePath,
-    lineStart: node.startLine,
-    lineEnd: node.endLine,
-    signature: node.signature,
-    callerCount: graph.getCallers(id).length,
-    calleeCount: graph.getCallees(id).length,
-    detail,
-    // False at build time; the emitter flips it true only for facts whose source
-    // record actually fit the budget (see planSource). Defaulting false keeps the
-    // accounted record shape >= the emitted one, so the token ceiling stays hard.
-    sourceIncluded: false,
-    bodyHash: node.bodyHash,
+    id: node.id, kind: node.kind, name: node.name, qualifiedName: node.qualifiedName,
+    filePath: node.filePath, lineStart: node.startLine, lineEnd: node.endLine,
+    signature: node.signature, callerCount: graph.getCallers(id).length,
+    calleeCount: graph.getCallees(id).length, detail, sourceIncluded: false, bodyHash: node.bodyHash,
   };
 }
 
-/**
- * Read a node's source body from disk, capped at `maxLines` (0 = unlimited).
- * Returns null when the file cannot be read.
- */
 export function readNodeSource(node: GraphNode, rootDir: string, maxLines: number): SourceRange | null {
   let lines: string[];
-  try {
-    lines = readFileSync(resolve(rootDir, node.filePath), "utf-8").split("\n");
-  } catch {
-    return null;
-  }
+  try { lines = readFileSync(resolve(rootDir, node.filePath), "utf-8").split("\n"); }
+  catch { return null; }
   const body = lines.slice(node.startLine - 1, node.endLine);
   const truncated = maxLines > 0 && body.length > maxLines;
   const kept = truncated ? body.slice(0, maxLines) : body;
   return {
-    startLine: node.startLine,
-    endLine: truncated ? node.startLine + kept.length - 1 : node.endLine,
-    nodeIds: [node.id],
-    content: kept.join("\n"),
-    truncated,
+    startLine: node.startLine, endLine: node.startLine + Math.max(0, kept.length - 1), nodeIds: [node.id],
+    content: numbered(kept, node.startLine), truncated, reason: truncated ? "signature" : "complete-symbol",
   };
 }
 
-/** Group nodes by file path, preserving first-seen order of both files and nodes. */
+/** Plan small whole files, complete symbols, or tight query/callsite windows. */
+export function planFileSource(
+  filePath: string,
+  nodes: GraphNode[],
+  textHits: SourceChunkMatch[],
+  rootDir: string,
+  query: string,
+  maxLines = 160,
+  callsiteLines: number[] = [],
+): SourceRange[] {
+  let lines: string[];
+  try { lines = readFileSync(resolve(rootDir, filePath), "utf-8").split("\n"); }
+  catch { return []; }
+  // `split` creates a synthetic 201st entry for a 200-line file ending in a
+  // newline. Do not let that formatting detail disable the whole-file policy.
+  if (lines.length > 1 && lines.at(-1) === "") lines.pop();
+  type PlannedRange = {
+    start: number;
+    end: number;
+    nodeIds: string[];
+    reason: SourceRange["reason"];
+    priority: number;
+    rangeKind: "whole" | "symbol" | "signature" | "window";
+    intrinsicallyTruncated?: boolean;
+  };
+  const ranges: PlannedRange[] = [];
+  const lineBudget = Math.max(1, maxLines);
+  if (lines.length <= 200 && lines.length <= maxLines) {
+    ranges.push({
+      start: 1, end: lines.length, nodeIds: nodes.map((node) => node.id), reason: "whole-file",
+      priority: 0, rangeKind: "whole",
+    });
+  } else {
+    const queryTerms = literalTerms(planGraphQuery(query));
+    const queryLines: number[] = [];
+    lines.forEach((line, index) => {
+      const lower = line.toLowerCase();
+      if (queryTerms.some((term) => lower.includes(term))) queryLines.push(index + 1);
+    });
+
+    for (const [nodeIndex, node] of nodes.entries()) {
+      const start = Math.max(1, Math.min(lines.length, node.startLine));
+      const end = Math.max(start, Math.min(lines.length, node.endLine));
+      const length = end - start + 1;
+      const basePriority = nodeIndex * 10;
+      if (length <= 160 && length <= lineBudget) {
+        ranges.push({
+          start, end, nodeIds: [node.id], reason: "complete-symbol",
+          priority: basePriority, rangeKind: "symbol",
+        });
+        continue;
+      }
+
+      // Long declarations retain their real declaration header, followed by at
+      // most two bounded windows from inside that declaration. Callsites are
+      // more useful for reconstructing a flow, so they win ties over text hits.
+      ranges.push({
+        start, end: Math.min(end, start + 5), nodeIds: [node.id], reason: "signature",
+        priority: basePriority, rangeKind: "signature", intrinsicallyTruncated: end > start + 5,
+      });
+      const relevantCallsites = callsiteLines.filter((line) => line >= start && line <= end);
+      const relevantQueryLines = queryLines.filter((line) => line >= start && line <= end);
+      const seenLines = new Set<number>();
+      const windowLines: Array<{ line: number; reason: "callsite" | "query-hit" }> = [];
+      for (const line of relevantCallsites) {
+        if (seenLines.has(line)) continue;
+        seenLines.add(line);
+        windowLines.push({ line, reason: "callsite" });
+      }
+      for (const line of relevantQueryLines) {
+        if (seenLines.has(line)) continue;
+        seenLines.add(line);
+        windowLines.push({ line, reason: "query-hit" });
+      }
+      for (const [windowIndex, hit] of windowLines.slice(0, 2).entries()) {
+        ranges.push({
+          start: Math.max(start, hit.line - 12), end: Math.min(end, hit.line + 12), nodeIds: [node.id],
+          reason: hit.reason, priority: basePriority + windowIndex + 1, rangeKind: "window",
+        });
+      }
+    }
+
+    // Text-only files do not have trustworthy node spans. Return no more than
+    // two real 25-line windows, preferring precise query/callsite lines and then
+    // falling back to the centers of matching FTS chunks.
+    if (nodes.length === 0) {
+      const seenLines = new Set<number>();
+      const liveWindows: Array<{ line: number; reason: "callsite" | "query-hit" | "text-only" }> = [];
+      for (const line of callsiteLines) {
+        if (seenLines.has(line)) continue;
+        seenLines.add(line);
+        liveWindows.push({ line, reason: "callsite" });
+      }
+      for (const line of queryLines) {
+        if (seenLines.has(line)) continue;
+        seenLines.add(line);
+        liveWindows.push({ line, reason: "query-hit" });
+      }
+      for (const hit of textHits) {
+        const line = Math.floor((hit.startLine + hit.endLine) / 2);
+        if (seenLines.has(line)) continue;
+        seenLines.add(line);
+        liveWindows.push({ line, reason: "text-only" });
+      }
+      for (const [index, hit] of liveWindows.slice(0, 2).entries()) {
+        ranges.push({
+          start: Math.max(1, hit.line - 12), end: Math.min(lines.length, hit.line + 12), nodeIds: [],
+          reason: hit.reason, priority: index, rangeKind: "window",
+        });
+      }
+    }
+  }
+
+  const merged = normalizeSourceRanges(ranges, 10);
+  let remaining = lineBudget;
+  const out: SourceRange[] = [];
+  for (const range of merged) {
+    if (remaining <= 0) break;
+    const end = Math.min(range.end, range.start + remaining - 1);
+    const selected = lines.slice(range.start - 1, end);
+    out.push({
+      startLine: range.start, endLine: end, nodeIds: range.nodeIds,
+      content: numbered(selected, range.start),
+      truncated: Boolean(range.intrinsicallyTruncated) || end < range.end,
+      reason: range.reason,
+    });
+    remaining -= selected.length;
+  }
+  return out;
+}
+
+function normalizeSourceRanges<T extends {
+  start: number;
+  end: number;
+  nodeIds: string[];
+  reason: SourceRange["reason"];
+  priority: number;
+  rangeKind: "whole" | "symbol" | "signature" | "window";
+  intrinsicallyTruncated?: boolean;
+}>(
+  ranges: T[],
+  gap: number,
+): T[] {
+  const valid = ranges.filter((range) => range.end >= range.start)
+    .map((range) => ({ ...range, nodeIds: [...new Set(range.nodeIds)] }));
+
+  // A complete parent already carries its child's source. Keep the parent once,
+  // but retain every covered node id so source-backed fact accounting is exact.
+  const symbols: T[] = [];
+  for (const range of valid.filter((entry) => entry.rangeKind === "symbol")
+    .sort((left, right) => left.start - right.start || right.end - left.end || left.priority - right.priority)) {
+    const container = symbols.find((entry) => entry.start <= range.start && entry.end >= range.end);
+    if (container) {
+      container.nodeIds = [...new Set([...container.nodeIds, ...range.nodeIds])];
+      container.priority = Math.min(container.priority, range.priority);
+      continue;
+    }
+    symbols.push({ ...range });
+  }
+
+  // Only source windows use the ten-line coalescing rule. This avoids turning
+  // adjacent but distinct declarations into one oversized pseudo-symbol.
+  const windows: T[] = [];
+  for (const range of valid.filter((entry) => entry.rangeKind === "window")
+    .sort((left, right) => left.start - right.start || left.end - right.end || left.priority - right.priority)) {
+    const prior = windows.at(-1);
+    if (prior && range.start <= prior.end + gap + 1) {
+      prior.end = Math.max(prior.end, range.end);
+      prior.nodeIds = [...new Set([...prior.nodeIds, ...range.nodeIds])];
+      if (range.priority < prior.priority) {
+        prior.priority = range.priority;
+        prior.reason = range.reason;
+      }
+    } else windows.push({ ...range });
+  }
+
+  const base = [
+    ...valid.filter((entry) => entry.rangeKind === "whole" || entry.rangeKind === "signature"),
+    ...symbols,
+  ];
+  const keptWindows: T[] = [];
+  for (const window of windows) {
+    const containing = base.find((range) => range.start <= window.start && range.end >= window.end);
+    if (containing) {
+      containing.nodeIds = [...new Set([...containing.nodeIds, ...window.nodeIds])];
+      containing.priority = Math.min(containing.priority, window.priority);
+      continue;
+    }
+    // Eliminate overlapping lines without widening near-but-disjoint ranges.
+    const overlapping = base.find((range) => range.start <= window.end && range.end >= window.start);
+    if (overlapping) {
+      overlapping.start = Math.min(overlapping.start, window.start);
+      overlapping.end = Math.max(overlapping.end, window.end);
+      overlapping.nodeIds = [...new Set([...overlapping.nodeIds, ...window.nodeIds])];
+      overlapping.priority = Math.min(overlapping.priority, window.priority);
+      continue;
+    }
+    keptWindows.push(window);
+  }
+
+  return [...base, ...keptWindows].sort((left, right) =>
+    left.priority - right.priority || left.start - right.start || left.end - right.end);
+}
+
+function numbered(lines: string[], startLine: number): string {
+  const width = String(startLine + Math.max(0, lines.length - 1)).length;
+  return lines.map((line, index) => `${String(startLine + index).padStart(width)}: ${line}`).join("\n");
+}
+
 export function groupByFile(nodes: GraphNode[]): Map<string, GraphNode[]> {
   const groups = new Map<string, GraphNode[]>();
   for (const node of nodes) {
     const bucket = groups.get(node.filePath);
-    if (bucket) bucket.push(node);
-    else groups.set(node.filePath, [node]);
+    if (bucket) bucket.push(node); else groups.set(node.filePath, [node]);
   }
   return groups;
+}
+
+export function sourceHash(filePath: string, rootDir: string): string | null {
+  try { return createHash("sha256").update(readFileSync(resolve(rootDir, filePath))).digest("hex"); }
+  catch { return null; }
 }

--- a/src/graph/traversal/traversal.ts
+++ b/src/graph/traversal/traversal.ts
@@ -8,7 +8,8 @@
 // the targets of outgoing `calls` edges. Synchronous by design so the grounding
 // checker (Track B) can stay synchronous.
 
-import type { GraphNode } from "../types.js";
+import type { EdgeKind, GraphNode } from "../types.js";
+import type { GraphNeighbor } from "../engine.js";
 import type { GraphStore } from "../db/store.js";
 
 /**
@@ -27,6 +28,34 @@ export function getCallers(store: GraphStore, id: string): GraphNode[] {
 export function getCallees(store: GraphStore, id: string): GraphNode[] {
   const edges = store.getOutgoingEdges(id, ["calls"]);
   return fetchEndpoints(store, edges.map((e) => e.target));
+}
+
+/** Incoming typed relationships with their source nodes. */
+export function getIncoming(
+  store: GraphStore,
+  id: string,
+  kinds?: EdgeKind[],
+): GraphNeighbor[] {
+  const edges = store.getIncomingEdges(id, kinds);
+  const nodes = store.getNodesByIds(edges.map((edge) => edge.source));
+  return edges.flatMap((edge) => {
+    const node = nodes.get(edge.source);
+    return node ? [{ node, edge }] : [];
+  });
+}
+
+/** Outgoing typed relationships with their target nodes. */
+export function getOutgoing(
+  store: GraphStore,
+  id: string,
+  kinds?: EdgeKind[],
+): GraphNeighbor[] {
+  const edges = store.getOutgoingEdges(id, kinds);
+  const nodes = store.getNodesByIds(edges.map((edge) => edge.target));
+  return edges.flatMap((edge) => {
+    const node = nodes.get(edge.target);
+    return node ? [{ node, edge }] : [];
+  });
 }
 
 /** Fetch the unique endpoint nodes, preserving first-seen edge order. */

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -128,6 +128,10 @@ export interface GraphNode {
   kind: NodeKind;
   name: string;
   qualifiedName: string;
+  /** Canonical lexical owner (class/function/module) when one exists. */
+  containerId?: string;
+  /** Stable, unhashed identity material used to detect accidental id collisions. */
+  identityKey?: string;
   filePath: string;
   language: Language;
   startLine: number;
@@ -162,7 +166,13 @@ export interface GraphEdge {
   target: string;
   kind: EdgeKind;
   metadata?: Record<string, unknown>;
+  /** Resolver confidence. Only edges at or above 0.8 are eligible for flows. */
+  confidence?: number;
+  /** Stable resolver identifier (for example `typescript-compiler`). */
+  resolutionMethod?: string;
+  /** All independent pieces of evidence which support this semantic callsite. */
+  evidence?: Array<Record<string, unknown>>;
   line?: number;
   column?: number;
-  provenance?: "tree-sitter" | "heuristic";
+  provenance?: "tree-sitter" | "typescript-compiler" | "callback-synthesis" | "lexical" | "framework" | "heuristic";
 }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -22,6 +22,10 @@ const TELEMETRY_KEY = "phc_wdwbBPQMrM6vKWMzz5yqWT357i2hSjMhnAvCuofJdMpg";
 const HOST = "https://us.i.posthog.com";
 const EVENT = "command_run";
 const FLUSH_TIMEOUT_MS = 800;
+// A short-lived CLI must never inherit the SDK's 10 second request timeout.
+// Keep the network attempt inside the command-level flush deadline so an
+// offline endpoint cannot dominate graph/eval latency.
+const REQUEST_TIMEOUT_MS = 650;
 
 // ── Opt-out check ──
 
@@ -117,17 +121,24 @@ export function getPayloadPreview(
 // ── PostHog client (lazy, with test seam) ──
 
 type TransportFn = (event: string, properties: Record<string, unknown>) => void;
+type TelemetryClient = Pick<PostHog, "captureImmediate" | "flush" | "shutdown">;
 
-let client: PostHog | null = null;
+let client: TelemetryClient | null = null;
 let customTransport: TransportFn | null = null;
 const pendingCaptures = new Set<Promise<void>>();
 
-function getClient(): PostHog {
+function getClient(): TelemetryClient {
   if (!client) {
     client = new PostHog(TELEMETRY_KEY, {
       host: HOST,
       flushAt: 1,       // flush after every event (short-lived CLI)
       flushInterval: 0, // don't auto-flush on interval — we call flush() explicitly
+      requestTimeout: REQUEST_TIMEOUT_MS,
+      // Retries are appropriate for a daemon, but their default three-second
+      // backoff keeps a one-shot CLI alive after our flush deadline. A future
+      // invocation is the retry for anonymous command-count telemetry.
+      fetchRetryCount: 0,
+      fetchRetryDelay: 0,
     });
   }
   return client;
@@ -139,6 +150,12 @@ function getClient(): PostHog {
  */
 export function __setTransport(fn: TransportFn | null): void {
   customTransport = fn;
+}
+
+/** Test seam for proving a non-responsive SDK client cannot hold the CLI open. */
+export function __setClientForTest(next: TelemetryClient | null): void {
+  client = next;
+  pendingCaptures.clear();
 }
 
 // ── Capture + flush ──
@@ -202,34 +219,56 @@ export function captureCommand(command: string, scaffoldId?: string): void {
  * interval timer so the Node.js process can exit promptly.
  */
 export async function flush(): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const activeClient = client;
+  const deadline = Date.now() + FLUSH_TIMEOUT_MS;
   try {
-    if (customTransport || !client) {
+    if (customTransport || !activeClient) {
       // No real client to flush — nothing to do.
       return;
     }
 
-    const timeoutPromise = new Promise<void>((resolve) => {
-      timer = setTimeout(resolve, FLUSH_TIMEOUT_MS);
-    });
-    await Promise.race([
-      Promise.allSettled([...pendingCaptures]).then(() => client!.flush()),
-      timeoutPromise,
-    ]);
+    await settleByDeadline(
+      Promise.allSettled([...pendingCaptures]).then(() => activeClient.flush()),
+      deadline,
+    );
   } catch {
     // Swallow — delivery is best-effort.
   } finally {
-    // Clear the race timer so a fast flush doesn't leave it pending and delay
-    // process exit.
-    if (timer) clearTimeout(timer);
     try {
-      if (client) {
-        await client.shutdown();
-        client = null;
+      if (activeClient) {
+        // PostHog otherwise defaults shutdown to 30 seconds. Pass the remaining
+        // command deadline to the SDK *and* guard it ourselves so alternate or
+        // future clients cannot make telemetry command-blocking.
+        const remaining = Math.max(1, deadline - Date.now());
+        await settleByDeadline(Promise.resolve(activeClient.shutdown(remaining)), deadline);
       }
     } catch {
       // Swallow shutdown errors too.
+    } finally {
+      if (client === activeClient) client = null;
+      pendingCaptures.clear();
     }
+  }
+}
+
+async function settleByDeadline(work: Promise<unknown>, deadline: number): Promise<void> {
+  // Attach the rejection handler even when the deadline has already elapsed.
+  // The SDK's own bounded shutdown rejects on timeout; leaving that late
+  // rejection detached would corrupt JSONL commands with an unhandled error.
+  const settled = work.then(() => undefined, () => undefined);
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    void settled;
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      settled,
+      new Promise<void>((resolve) => { timer = setTimeout(resolve, remaining); }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/templates/.tool-configs/.cursorrules
+++ b/templates/.tool-configs/.cursorrules
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/templates/.tool-configs/.windsurfrules
+++ b/templates/.tool-configs/.windsurfrules
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/templates/.tool-configs/copilot-instructions.md
+++ b/templates/.tool-configs/copilot-instructions.md
@@ -36,12 +36,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## After Every Task

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -37,12 +37,12 @@ last_updated: [YYYY-MM-DD]
 ## Code Graph
 The repo is indexed into `.mex/graph.db`. Use it to avoid re-reading code you already have — it is one tool alongside Grep/Glob, not a replacement for them.
 - If you know the symbol name, go straight to it: `mex graph query <who-calls|what-calls|where-defined> <symbol>` and `mex graph get <id>` are exact and cheap. This is the strongest part of the graph. Give it exact names — an approximate name can return a confident wrong match.
-- Exploring an unfamiliar task? `mex graph scope "<task>"` returns a compact JSONL manifest (`meta`, `fact`s, `summary`). Scope matches on words, not meaning: if your phrasing does not share vocabulary with the code, results will be weak. Treat it as a starting point, never as a complete answer.
-- If the manifest does not clearly contain what you need, use Grep/Glob instead. Do not expand node ids that look irrelevant, and do not re-run `scope` with reworded phrasing more than once — that costs more than searching directly.
-- Treat any source the graph DOES return as ALREADY READ; do not re-open those files.
-- Pick 1-3 relevant node ids from the manifest and expand only those with `mex graph get <id> --detail source`.
+- Exploring an unfamiliar task? `mex graph scope "<task>"` returns bounded, source-backed JSONL context plus trustworthy execution flows. Scope matches on words, not meaning, so treat it as starting evidence rather than a complete answer.
+- Treat source returned by the graph as ALREADY READ; do not re-open those files.
+- Read the summary status and evidence. `status: "ok"` remains usable when `truncated: true`; only optional evidence was omitted. For `partial` or `degraded`, narrow the task or follow `suggestedNextCommands`.
+- Use `mex graph get <id> --detail source` only when source is missing, you need exact expansion, or a partial/degraded summary suggests it. Do not expand nodes by quota.
+- If the evidence is insufficient or the task wording does not match the code, use Grep/Glob instead. Do not re-run `scope` with reworded phrasing more than once.
 - Before editing a symbol, run `mex impact <symbol|file>` to see affected callers and scaffold memory.
-- If a result is `truncated`, do NOT repeat the broad query — narrow the task or use the summary's `suggestedNextCommands`. Scale through a few focused calls, never one giant response.
 - During `mex sync`, adjudicate any AMBIGUOUS grounding; after repairs, ensure the refreshed grounding is re-emitted.
 
 ## Scaffold Growth

--- a/test/graph-cli-agent.test.ts
+++ b/test/graph-cli-agent.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { runGraphQuery, runGraphScope, runImpact, type AgentCommandDeps } from "../src/graph/cli-agent.js";
 import type { GraphEngine } from "../src/graph/engine.js";
-import type { GraphNode } from "../src/graph/types.js";
-import { __setTransport, captureCommand, flush } from "../src/telemetry/index.js";
-import { mkdtempSync, rmSync } from "node:fs";
+import type { GraphEdge, GraphNode } from "../src/graph/types.js";
+import { __setClientForTest, __setTransport, captureCommand, flush } from "../src/telemetry/index.js";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -11,17 +12,45 @@ function node(id: string, name: string, file = "src/a.ts", line = 1): GraphNode 
   return { id, name, kind: "function", qualifiedName: name, filePath: file, language: "typescript", startLine: line, endLine: line + 1, startColumn: 0, endColumn: 1, updatedAt: 1 };
 }
 
-function deps(): { deps: AgentCommandDeps; output: string[]; close: ReturnType<typeof vi.fn> } {
+function deps(indexedSources: Record<string, string> = {}): {
+  deps: AgentCommandDeps;
+  output: string[];
+  close: ReturnType<typeof vi.fn>;
+} {
   const leaf = node("function:leaf", "leaf");
   const parent = node("function:parent", "parent", "src/parent.ts", 4);
   const top = node("function:top", "top", "src/top.ts", 7);
   const nodes = [leaf, parent, top];
+  const edges: GraphEdge[] = [
+    {
+      source: parent.id, target: leaf.id, kind: "calls", line: 5, column: 2,
+      confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+    },
+    {
+      source: top.id, target: parent.id, kind: "calls", line: 8, column: 2,
+      confidence: 1, resolutionMethod: "typescript-compiler", provenance: "typescript-compiler",
+    },
+  ];
   const graph: GraphEngine = {
     build: vi.fn(), sync: vi.fn(), close: vi.fn(),
     getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
-    searchNodes: (query) => nodes.filter((entry) => entry.name.includes(query)),
+    searchNodes: (query) => nodes.filter((entry) => entry.name.toLowerCase().includes(query.toLowerCase())),
     getCallers: (id) => id === leaf.id ? [parent] : id === parent.id ? [top] : [],
     getCallees: (id) => id === top.id ? [parent] : id === parent.id ? [leaf] : [],
+    getIncoming: (id) => edges.filter((edge) => edge.target === id).map((edge) => ({
+      edge, node: nodes.find((entry) => entry.id === edge.source)!,
+    })),
+    getOutgoing: (id) => edges.filter((edge) => edge.source === id).map((edge) => ({
+      edge, node: nodes.find((entry) => entry.id === edge.target)!,
+    })),
+    getIndexedFiles: () => Object.entries(indexedSources).map(([path, source]) => ({
+      path,
+      contentHash: createHash("sha256").update(source).digest("hex"),
+      parseStatus: "ok" as const,
+      diagnosticCount: 0,
+      errorCoverage: 0,
+      nodeCount: nodes.filter((entry) => entry.filePath === path).length,
+    })),
   };
   const close = vi.fn();
   const db = {
@@ -65,17 +94,67 @@ describe("agent graph commands", () => {
     }
   });
 
-  it("scope emits seeds and their one-hop neighborhood as hydrated facts", () => {
+  it("abstains when a targeted symbol lookup has only fuzzy matches", () => {
     const fixture = deps();
-    runGraphScope("leaf", "/repo", fixture.deps);
-    const facts = fixture.output.map((line) => JSON.parse(line)).filter((row) => row.type === "fact");
-    expect(facts.map((row) => row.id)).toEqual(["function:leaf", "function:parent"]);
+    runGraphQuery("where-defined", "lea", "/repo", fixture.deps);
+    expect(fixture.output.map((line) => JSON.parse(line))).toEqual([
+      { type: "error", code: "TARGET_NOT_FOUND", target: "lea" },
+    ]);
+  });
+
+  it("minimal Scope pins a named seed and hydrates its reliable typed neighborhood", () => {
+    const fixture = deps();
+    runGraphScope("Leaf", "/repo", fixture.deps, { detail: "minimal" });
+    const rows = fixture.output.map((line) => JSON.parse(line));
+    expect(rows[0]).toMatchObject({ type: "meta", protocolVersion: 3, detail: "minimal" });
+    expect(rows[1]).toMatchObject({ type: "health" });
+    const facts = rows.filter((row) => row.type === "fact");
+    expect(facts.map((row) => row.id)).toEqual(["function:leaf", "function:parent", "function:top"]);
     expect(facts[0]).toMatchObject({
-      type: "fact", kind: "function", name: "leaf", qualifiedName: "leaf",
-      filePath: "src/a.ts", callerCount: 1, calleeCount: 0, sourceIncluded: false,
+      type: "fact", kind: "function", name: "leaf",
+      filePath: "src/a.ts", callerCount: 1, calleeCount: 0,
     });
+    expect(facts[0]).not.toHaveProperty("qualifiedName");
     expect(facts[0]).not.toHaveProperty("source");
     expect(facts[0]).not.toHaveProperty("callers");
+    expect(facts[0]).not.toHaveProperty("sourceIncluded");
+  });
+
+  it("returns line-numbered source and a directed flow in one default Scope call", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-scope-v3-"));
+    try {
+      const sources = {
+        "src/a.ts": "export function leaf() {\n  return 1;\n}\n",
+        "src/parent.ts": "\n\n\nexport function parent() {\n  return leaf();\n}\n",
+        "src/top.ts": "\n\n\n\n\n\nexport function top() {\n  return parent();\n}\n",
+      };
+      mkdirSync(join(root, "src"));
+      for (const [path, source] of Object.entries(sources)) writeFileSync(join(root, path), source);
+      const fixture = deps(sources);
+
+      runGraphScope("Top", root, fixture.deps);
+      const rows = fixture.output.map((line) => JSON.parse(line));
+      expect(rows[0]).toMatchObject({ type: "meta", protocolVersion: 3, detail: "source" });
+      const sourceRecords = rows.filter((row) => row.type === "source");
+      expect(sourceRecords.length).toBeGreaterThan(0);
+      expect(JSON.stringify(sourceRecords)).toMatch(/7: export function top/);
+      const flows = rows.filter((row) => row.type === "flow");
+      const flowSteps = flows.flatMap((flow) => flow.steps);
+      expect(flows.some((flow) => flow.steps.length === 2
+        && flow.steps[0].source === "function:top" && flow.steps[0].target === "function:parent"
+        && flow.steps[1].source === "function:parent" && flow.steps[1].target === "function:leaf")).toBe(true);
+      expect(flowSteps.length).toBeLessThanOrEqual(8);
+      expect(rows.findIndex((row) => row.type === "source")).toBeLessThan(rows.findIndex((row) => row.type === "flow"));
+      expect(rows.at(-1)).toMatchObject({
+        type: "summary", returnedEdges: flowSteps.length, suggestedNextCommands: [],
+        returnedFiles: expect.arrayContaining(["src/top.ts", "src/parent.ts", "src/a.ts"]),
+      });
+      fixture.output.length = 0;
+      runGraphScope("Top", root, fixture.deps);
+      expect(fixture.output.map((line) => JSON.parse(line)).filter((row) => row.type === "flow")).toEqual(flows);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("scope degrades to a machine-readable error when the graph is absent", () => {
@@ -135,6 +214,50 @@ describe("agent graph commands", () => {
       expect(results[0]).toMatchObject({ type: "result", relation: "where-defined", name: "leaf" });
     } finally {
       __setTransport(null);
+      process.chdir(cwd);
+      if (home === undefined) delete process.env.MEX_HOME;
+      else process.env.MEX_HOME = home;
+      if (env.dnt === undefined) delete process.env.DO_NOT_TRACK; else process.env.DO_NOT_TRACK = env.dnt;
+      if (env.telemetry === undefined) delete process.env.MEX_TELEMETRY; else process.env.MEX_TELEMETRY = env.telemetry;
+      if (env.dev === undefined) delete process.env.MEX_DEV; else process.env.MEX_DEV = env.dev;
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds offline telemetry for a machine-facing graph command", async () => {
+    const fixture = deps();
+    const never = new Promise<void>(() => undefined);
+    const offlineClient = {
+      captureImmediate: vi.fn(() => never),
+      flush: vi.fn(() => never),
+      shutdown: vi.fn(() => never),
+    };
+    const cwd = process.cwd();
+    const home = process.env.MEX_HOME;
+    const env = { dnt: process.env.DO_NOT_TRACK, telemetry: process.env.MEX_TELEMETRY, dev: process.env.MEX_DEV };
+    const isolated = mkdtempSync(join(tmpdir(), "mex-bounded-offline-command-"));
+    try {
+      process.chdir(isolated);
+      process.env.MEX_HOME = isolated;
+      delete process.env.DO_NOT_TRACK;
+      delete process.env.MEX_TELEMETRY;
+      delete process.env.MEX_DEV;
+      __setClientForTest(offlineClient);
+
+      const started = Date.now();
+      captureCommand("graph scope");
+      runGraphScope("leaf", "/repo", fixture.deps, { detail: "minimal" });
+      await flush();
+
+      // Leave scheduler headroom for loaded CI workers while still proving the
+      // SDK's former multi-second retry/shutdown path cannot return.
+      expect(Date.now() - started).toBeLessThan(2_000);
+      expect(offlineClient.captureImmediate).toHaveBeenCalledOnce();
+      expect(offlineClient.shutdown).toHaveBeenCalledOnce();
+      expect(offlineClient.shutdown.mock.calls[0][0]).toBeLessThanOrEqual(800);
+      expect(fixture.output.some((line) => JSON.parse(line).type === "summary")).toBe(true);
+    } finally {
+      __setClientForTest(null);
       process.chdir(cwd);
       if (home === undefined) delete process.env.MEX_HOME;
       else process.env.MEX_HOME = home;

--- a/test/graph-grounding.test.ts
+++ b/test/graph-grounding.test.ts
@@ -24,10 +24,10 @@ function database(): DatabaseSync {
 
 function insertNode(db: DatabaseSync, id: string, bodyHash = "hash"): void {
   db.prepare(
-    `INSERT INTO nodes (id, kind, name, qualified_name, file_path, language,
+    `INSERT INTO nodes (id, kind, name, qualified_name, identity_key, file_path, language,
       start_line, end_line, start_column, end_column, body_hash, updated_at)
-     VALUES (?, 'function', ?, ?, 'src/a.ts', 'typescript', 1, 2, 0, 1, ?, 1)`,
-  ).run(id, id, id, bodyHash);
+     VALUES (?, 'function', ?, ?, ?, 'src/a.ts', 'typescript', 1, 2, 0, 1, ?, 1)`,
+  ).run(id, id, id, id, bodyHash);
 }
 
 function fingerprint(matches: number, neighbors: string[] = ["neighbor"], tokenCount = 40): Fingerprint {
@@ -66,6 +66,25 @@ describe("FingerprintStore and MinHashReconciler", () => {
     store.upsert("candidate", value);
     expect(store.get("candidate")).toEqual(value);
     expect(store.lookup(value).map((entry) => entry.nodeId)).toEqual(["candidate"]);
+    db.close();
+  });
+
+  it("resolves legacy aliases for fingerprints and grounding baselines", () => {
+    const db = database();
+    insertNode(db, "canonical");
+    db.prepare(
+      `INSERT INTO node_aliases (alias_id, canonical_node_id, match_method, confidence, created_at)
+       VALUES ('legacy', 'canonical', 'body-hash', 0.95, 1)`,
+    ).run();
+    const store = new FingerprintStore(db);
+    const value = fingerprint(64);
+    store.upsert("canonical", value);
+    store.saveGroundedSource({
+      scaffoldFile: "docs/unit.md", nodeId: "legacy", source: "old", bodyHash: "hash",
+      fingerprint: serializeFingerprint(value),
+    });
+    expect(store.get("legacy")).toEqual(value);
+    expect(store.getGroundedSource("docs/unit.md", "canonical")).toMatchObject({ nodeId: "legacy", source: "old" });
     db.close();
   });
 
@@ -122,6 +141,7 @@ function graph(nodes: GraphNode[]): GraphEngine {
     searchNodes: () => [],
     getNode: (id) => nodes.find((entry) => entry.id === id) ?? null,
     getCallers: () => [], getCallees: () => [], close: () => {},
+    getIncoming: () => [], getOutgoing: () => [],
   };
 }
 

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -108,7 +108,7 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
       .toEqual({ captured: 2, skipped: 0 });
     const clean = await runDriftCheck(config);
     expect(clean.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toEqual([]);
-  });
+  }, 15_000);
 
   it("skips and warns when authored grounding no longer resolves", async () => {
     const root = mkdtempSync(join(tmpdir(), "mex-setup-grounding-miss-"));


### PR DESCRIPTION
## Summary

- replace minimal-first Scope with bounded source-backed retrieval and trustworthy directed flows
- add compiler-backed TypeScript extraction, stronger Python/Rust resolution, schema-v2 storage, and protocol-v3 output
- harden graph integrity, deterministic evaluation, headless tool policy, identity drift checks, and rate-limit recovery
- update CI actions while retaining the supported Node 22/24 matrix
- prepare package metadata, documentation, changelog, and release notes for v0.7.2

## Why

The released retrieval path often required agents to expand several graph IDs before they had enough source to answer. Scope now returns a bounded, source-backed first response with graph evidence and reliable flows, reducing follow-up tool use and model context while preserving a hard output budget.

## Evaluation

The descriptive two-arm pilot used 24 valid Claude Sonnet sessions across 12 MEX and Hono tasks, one repetition, comparing the candidate with files-only retrieval (not released `main`):

- blind correctness: 7/12 candidate vs 6/12 files-only
- new tokens: -54.5%
- processed tokens: -72.5%
- estimated cost: -56.6%
- mean latency: -22.9%
- required source spans: 22/23
- graph evidence: 12/12
- required Hono directed flows: 6/6

Because this is a small one-repetition pilot, the quality comparison is descriptive rather than a definitive significance claim. Frozen native TypeScript, Hono, synthetic, and MEX suites additionally cover first-response retrieval, flow, budget, integrity, and deterministic rebuild behavior.

## Validation

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm test` — 514/514
- [x] `npm run eval:test` — 82/82
- [x] `npm run build`
- [x] `git diff --check`
- [x] `npm publish --dry-run --access public`
- [x] isolated 0.7.2 tarball install and TypeScript/Python/Rust graph smoke
- [x] isolated published-package dependency audit — zero vulnerabilities

## Compatibility and migration

- Node.js 22.5+ remains required.
- Existing schema-v1 `.mex/graph.db` files require a one-time `mex graph` rebuild and otherwise fail with `GRAPH_REBUILD_REQUIRED`.
- TypeScript 5.9.3 is now an exact runtime dependency because compiler APIs are used during indexing.

## Known tradeoff

The richer graph stores more nodes, edges, source chunks, import bindings, and integrity metadata. Measured database size was approximately 4.1x the released baseline on Hono and 2.23x on the TypeScript compiler subtree. Storage and no-op/incremental rebuild optimization are intentionally deferred to follow-up work.
