### PR TITLE
feat(graph): add provenance-bound freshness and safe recovery

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -14,7 +14,7 @@ edges:
     condition: when setting up the dev environment or running the project for the first time
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-08-22
+last_updated: 2026-08-23
 ---
 
 # Session Bootstrap
@@ -43,6 +43,12 @@ Then read this file fully before doing anything else in this session.
 **Known Issues:**
 - The teammate Wiki implementation branch/commit is not yet available, so the
   consumer contract remains provisional.
+- Agent-facing `graph query` and `graph get` still use the legacy manifest-only
+  session path; until they adopt the exact freshness handshake, they can serve
+  stale graph facts or pair an old node with newer live source text.
+- Graph evaluator normalization currently excludes the entire
+  `graph_snapshot_v1` row. It should ignore volatile timestamps/Git coordinates
+  while retaining semantic compiler, resolver, config, corpus, and input provenance.
 - The current scaffold architecture, conventions, decisions, stack, and setup
   context files are still largely unpopulated placeholders.
 - Real parser, filesystem, index, migration, and graph-grounding compliance must

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -33,22 +33,22 @@ Then read this file fully before doing anything else in this session.
   and graph protocol goldens cover the consumer-side Checkpoint 0 work.
 - Versioned graph snapshot provenance and read-only freshness inspection gate
   grounding in check, doctor, and dashboard flows without implicit graph sync.
+- Explicit graph status, refresh, and isolated rebuild/recovery commands preserve
+  the last trustworthy index behind one cross-process maintenance lease.
+- Targeted graph get/query/impact consumers use one provenance-bound immutable
+  snapshot and discard output if graph or exact source identity changes.
+- Graph evaluator determinism includes semantic snapshot provenance while
+  excluding only operational timestamps and Git coordinates.
 
 **Not Built:**
 - The real Wiki adapter and type-parity registration against the teammate engine.
-- Project Hub, workflow persistence, explicit graph refresh, isolated candidate
-  rebuild/atomic recovery, and later delivery checkpoints from the human-team program.
+- Project Hub, workflow persistence, and later delivery checkpoints from the
+  human-team program.
 - Public package-root exports for the provisional team contracts.
 
 **Known Issues:**
 - The teammate Wiki implementation branch/commit is not yet available, so the
   consumer contract remains provisional.
-- Agent-facing `graph query` and `graph get` still use the legacy manifest-only
-  session path; until they adopt the exact freshness handshake, they can serve
-  stale graph facts or pair an old node with newer live source text.
-- Graph evaluator normalization currently excludes the entire
-  `graph_snapshot_v1` row. It should ignore volatile timestamps/Git coordinates
-  while retaining semantic compiler, resolver, config, corpus, and input provenance.
 - The current scaffold architecture, conventions, decisions, stack, and setup
   context files are still largely unpopulated placeholders.
 - Real parser, filesystem, index, migration, and graph-grounding compliance must

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -31,11 +31,13 @@ Then read this file fully before doing anything else in this session.
   codes are available under `src/team/contracts` as a provisional boundary.
 - A behavioral WikiPort mock, realistic fixture, reusable conformance suite,
   and graph protocol goldens cover the consumer-side Checkpoint 0 work.
+- Versioned graph snapshot provenance and read-only freshness inspection gate
+  grounding in check, doctor, and dashboard flows without implicit graph sync.
 
 **Not Built:**
 - The real Wiki adapter and type-parity registration against the teammate engine.
-- Project Hub, workflow persistence, graph freshness/recovery, and later delivery
-  checkpoints from the human-team program.
+- Project Hub, workflow persistence, explicit graph refresh, isolated candidate
+  rebuild/atomic recovery, and later delivery checkpoints from the human-team program.
 - Public package-root exports for the provisional team contracts.
 
 **Known Issues:**

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -5,3 +5,4 @@ Lookup table for project-specific pattern files.
 | Pattern | Use when |
 |---------|----------|
 | [`contract-first-external-adapter.md`](contract-first-external-adapter.md) | Freezing a consumer port before an independently owned implementation is pinned |
+| [`safe-graph-snapshot-evolution.md`](safe-graph-snapshot-evolution.md) | Changing graph indexing, freshness inspection, or recovery without publishing mixed or unsafe snapshots |

--- a/.mex/patterns/safe-graph-snapshot-evolution.md
+++ b/.mex/patterns/safe-graph-snapshot-evolution.md
@@ -45,12 +45,19 @@ belong only to explicit maintenance workflows.
    rollback-journal, containment, and file identity. Validate every schema
    object and data shape required by graph readers before reporting `fresh`.
 7. Preserve the prior trustworthy graph when an explicit rebuild candidate is
-   incomplete or failed, and surface failure rather than printing a successful
-   no-op summary.
+   incomplete or failed. Build under a repository-scoped owner-token lock,
+   validate a same-directory candidate, revalidate the live database, and only
+   then publish by atomic rename. Surface failure rather than printing a
+   successful no-op summary.
 8. Guard graph-derived reads for their complete use window. If the database or
-   selected path changes, discard the whole batch of derived findings.
+   selected path changes, discard the whole batch of derived findings. Bind any
+   returned live source to one contained fd-stable byte buffer whose decoded
+   hash matches the indexed row, so an A→B→A edit cannot escape validation.
 9. Keep retrieval ranking and protocol-v3 record shapes untouched unless the
    task explicitly changes that public boundary; rerun the exact JSONL goldens.
+10. Normalize evaluator provenance field-by-field. Exclude only explicitly
+    operational snapshot fields; malformed or future snapshot shapes must fail
+    closed instead of disappearing from the semantic graph hash.
 
 ## Gotchas
 
@@ -67,6 +74,9 @@ belong only to explicit maintenance workflows.
   cannot detect facts extracted from B; extraction must be bound to A.
 - Graph diagnostics and remediation commands must be truthful. Do not recommend
   a command for a state it cannot safely repair.
+- Wall-clock status timings vary by machine and process-start overhead. Keep
+  the benchmark non-gating, record its environment, and protect correctness
+  with deterministic race, non-mutation, and bounded-work tests.
 
 ## Verify
 
@@ -79,8 +89,12 @@ belong only to explicit maintenance workflows.
 - [ ] Source/config symlink escape, retarget, atomic replacement, and ABA tests
       preserve the prior snapshot.
 - [ ] Failed parse/stage/publication tests preserve prior facts and metadata.
+- [ ] Candidate replacement, candidate WAL, rollback, maintenance-lock, and
+      first-publication failure tests leave either the prior graph or no graph.
 - [ ] Ordinary check, doctor, dashboard, and status paths do not change graph
       bytes, sidecars, metadata, or directory mtimes.
+- [ ] `get`, `query`, and `impact` return no partial records when freshness,
+      source identity, sidecars, or the selected database change mid-read.
 - [ ] `npm run typecheck`, `npm test`, `npm run eval:test`, and `npm run build`
       pass, along with protocol-v3 goldens and `git diff --check`.
 - [ ] Only intended paths are staged; generated graph databases and unrelated

--- a/.mex/patterns/safe-graph-snapshot-evolution.md
+++ b/.mex/patterns/safe-graph-snapshot-evolution.md
@@ -1,0 +1,102 @@
+---
+name: safe-graph-snapshot-evolution
+description: Evolve graph indexing or freshness checks without publishing mixed facts, mutating reads, or losing the last trustworthy snapshot.
+triggers:
+  - "graph freshness"
+  - "graph snapshot"
+  - "graph indexing"
+  - "graph recovery"
+  - "SQLite graph"
+edges:
+  - target: "../context/architecture.md"
+    condition: "when changing the graph data plane or its consumers"
+  - target: "../context/conventions.md"
+    condition: "when verifying a graph implementation change"
+grounds_to: []
+last_updated: 2026-08-22
+---
+
+# Safe Graph Snapshot Evolution
+
+## Context
+
+The graph database is both a query surface and the grounding baseline for drift
+checks. A graph that is internally valid but represents mixed source, config,
+Git, or compiler observations is not trustworthy. Ordinary inspection must also
+remain read-only: SQLite recovery, schema repair, indexing, and grounding writes
+belong only to explicit maintenance workflows.
+
+## Steps
+
+1. Define source extensions, ignore rules, config inputs, grammar identity, and
+   extractor/resolver versions in one corpus policy shared by indexing and
+   freshness inspection.
+2. Discover source and config inputs through repository-contained canonical
+   paths. Bind each read to a regular-file descriptor and verify the original
+   path still resolves to the same inode after the read.
+3. Make parsers and compiler extraction consume the captured bytes. Do not let
+   a downstream compiler host silently re-read live source or config files.
+4. Revalidate Git coordinates, the exact source corpus, config inputs, and any
+   additional semantic inputs at the final boundary before publication.
+5. Persist a versioned provenance snapshot in the same transaction as graph
+   facts. A failed stage, parse, invariant check, or publication race must not
+   advance snapshot metadata.
+6. Inspect with raw read-only/immutable SQLite access only after checking WAL,
+   rollback-journal, containment, and file identity. Validate every schema
+   object and data shape required by graph readers before reporting `fresh`.
+7. Preserve the prior trustworthy graph when an explicit rebuild candidate is
+   incomplete or failed, and surface failure rather than printing a successful
+   no-op summary.
+8. Guard graph-derived reads for their complete use window. If the database or
+   selected path changes, discard the whole batch of derived findings.
+9. Keep retrieval ranking and protocol-v3 record shapes untouched unless the
+   task explicitly changes that public boundary; rerun the exact JSONL goldens.
+
+## Gotchas
+
+- Size and mtime are hints, not content identity. Same-size edits can restore an
+  mtime and still require reindexing.
+- An immutable SQLite connection assumes its file never changes. A clean probe
+  before opening is insufficient; revalidate around and after graph use.
+- A live WAL may contain the current schema while the main file looks stale or
+  corrupt. Treat writer activity as transient/degraded, never durable damage.
+- `PRAGMA quick_check` does not prove application compatibility. FTS shadow
+  tables, fingerprint JSON, LSH bands, ownership, and dangling references need
+  explicit invariants.
+- Source bytes can change A→B→A while a compiler runs. Final source hashing alone
+  cannot detect facts extracted from B; extraction must be bound to A.
+- Graph diagnostics and remediation commands must be truthful. Do not recommend
+  a command for a state it cannot safely repair.
+
+## Verify
+
+- [ ] Added, modified, deleted, same-size/restored-mtime, branch, config,
+      grammar, extractor, and policy drift cases are deterministic.
+- [ ] Active/unreadable WAL and rollback journals never produce `fresh` or a
+      false corruption diagnosis.
+- [ ] Missing, legacy, newer, malformed, and structurally corrupt schemas have
+      accurate diagnostics and safe remediation.
+- [ ] Source/config symlink escape, retarget, atomic replacement, and ABA tests
+      preserve the prior snapshot.
+- [ ] Failed parse/stage/publication tests preserve prior facts and metadata.
+- [ ] Ordinary check, doctor, dashboard, and status paths do not change graph
+      bytes, sidecars, metadata, or directory mtimes.
+- [ ] `npm run typecheck`, `npm test`, `npm run eval:test`, and `npm run build`
+      pass, along with protocol-v3 goldens and `git diff --check`.
+- [ ] Only intended paths are staged; generated graph databases and unrelated
+      working-tree files remain excluded.
+
+## Debug
+
+First separate transient writer activity from durable corruption. Compare the
+persisted snapshot, exact `files(path, content_hash)` rows, current corpus and
+config hashes, Git observations, and required reader invariants. When a race
+test fails, verify which layer re-read the filesystem after secure discovery;
+fix that boundary instead of adding timing delays.
+
+## Update Scaffold
+
+- [ ] Update `.mex/ROUTER.md` when freshness, refresh, or recovery capabilities
+      move from "Not Built" to "Working".
+- [ ] Add new graph failure modes to this pattern after they are reproduced and
+      covered by a deterministic regression.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,13 @@ The code remains the source of truth. The wiki becomes its maintained explanatio
 mex builds a deterministic local code graph using Tree-sitter and SQLite. It indexes symbols and relationships across TypeScript, TSX, JavaScript, JSX, Python, and Rust, including framework-aware Express route-to-handler relationships.
 
 ```bash
-mex graph
+mex graph rebuild
 ```
+
+Graph reads never rebuild implicitly. Use `mex graph status` for a read-only
+freshness check, `mex graph refresh` to explicitly republish a compatible index,
+and `mex graph rebuild` for an isolated full rebuild. The legacy bare
+`mex graph` command remains a safe rebuild alias.
 
 ### 2. Build the wiki
 
@@ -188,6 +193,8 @@ mex impact requireSession
 ```
 
 Agent-facing graph commands use deterministic JSONL envelopes so tools can reliably distinguish metadata, results, and summaries.
+Targeted `get`, `query`, and `impact` reads abstain when freshness cannot be
+proved; they never combine an older node identity with newer source text.
 
 ## Results
 
@@ -247,7 +254,10 @@ All commands run from the project root. Replace `mex` with `npx mex-agent` if it
 | `mex setup` | Create and populate the living wiki |
 | `mex check` | Check wiki health and calculate a drift score |
 | `mex sync` | Repair stale or inconsistent knowledge |
-| `mex graph` | Build or refresh the local code graph |
+| `mex graph` | Backward-compatible alias for a safe isolated rebuild |
+| `mex graph status` | Inspect graph freshness without writing |
+| `mex graph refresh` | Explicitly refresh a compatible graph index |
+| `mex graph rebuild` | Build and validate an isolated candidate, then publish it atomically |
 | `mex graph scope <task>` | Retrieve compact, task-relevant context |
 | `mex graph get <node-id...>` | Expand exact symbols from a retrieval result |
 | `mex graph query <relation> <symbol>` | Query structural code relationships |
@@ -264,7 +274,7 @@ All commands run from the project root. Replace `mex` with `npx mex-agent` if it
 Projects created before mex 0.7 can add graph grounding without regenerating or rewriting their existing documentation:
 
 ```bash
-mex graph
+mex graph rebuild
 mex graph ground
 ```
 

--- a/docs/design/graph-freshness-recovery.md
+++ b/docs/design/graph-freshness-recovery.md
@@ -1,0 +1,75 @@
+# Graph freshness and recovery
+
+Status inspection and graph maintenance are intentionally separate. Ordinary
+reads call the immutable inspector and never create, migrate, checkpoint,
+refresh, or rebuild `.mex/graph.db`. Maintenance happens only after a user runs
+an explicit graph command or another already-mutating workflow such as setup or
+grounding sync acquires the same maintenance lease.
+
+## Commands
+
+- `mex graph status` inspects repository, corpus, compiler inputs, schema,
+  snapshot provenance, graph invariants, fingerprints, and SQLite sidecars.
+- `mex graph refresh` restages the semantic corpus through the existing
+  correctness-first sync path. “Refresh” is not a claim of incremental speed.
+- `mex graph rebuild` builds a same-directory candidate, validates it, and
+  atomically publishes it. Bare `mex graph` is a compatibility alias.
+
+Refresh accepts only a compatible, inspectable live index. Rebuild also handles
+missing, incompatible, and corrupt indexes. A per-project owner-token lock spans
+staging, publication, and any subsequent grounding writes. Candidates and
+rollback copies use uniquely owned ignored paths. Before publication, MEX
+revalidates the live database, candidate identity, exact snapshot bytes, and
+absence of authoritative WAL or rollback-journal data. A failed operation leaves
+the prior trustworthy graph byte-identical; a replaced corrupt or incompatible
+database is retained locally as `.mex/graph.db.recovery-*`.
+
+## Targeted retrieval handshake
+
+`graph get`, `graph query`, and `impact` first require a stable `fresh` status
+observation. They then adopt one immutable SQLite connection for graph and
+grounding reads, bind it to the inspected inode and exact `graph_snapshot_v1`
+bytes, and buffer the complete JSONL response. Source ranges come from one
+contained, fd-stable byte buffer whose UTF-8 decoded hash matches the indexed
+file row. Immediately before output, MEX repeats freshness and database identity
+validation; any mismatch discards the whole response and emits one bounded
+`GRAPH_UNAVAILABLE` record.
+
+`graph scope` deliberately retains its existing stale-file text-only fallback.
+It now uses a single stable immutable database snapshot, but it does not claim
+that stale live text is an indexed graph fact. Retrieval ranking and successful
+protocol-v3 records remain unchanged.
+
+## Evaluator identity
+
+The normalized evaluator hash includes all semantic snapshot fields: schema,
+compiler/extractor/resolver versions, grammar/config/manifest hashes, source
+corpus identity, semantic positive and negative inputs, and parse health. It
+excludes only indexing timestamps, Git branch/HEAD, and the metadata row
+timestamp. Malformed, unknown, or future snapshot shapes fail closed.
+
+## Performance characterization
+
+Run the non-gating benchmark after a build:
+
+```bash
+npm run benchmark:graph-status
+```
+
+The harness creates deterministic committed TypeScript repositories, performs
+an explicit rebuild, warms the CLI, and reports fresh `graph status --json`
+latency plus source/database sizes and the full Node/SQLite/OS/CPU environment.
+It never applies a wall-clock pass/fail threshold.
+
+An Apple M4 / Node 22.17.1 / SQLite 3.50.0 characterization on 2026-08-23 used
+two warmups and seven measured fresh-status processes per fixture:
+
+| Sources | Source bytes | Graph DB | Status median | Status p95 | Rebuild |
+|---:|---:|---:|---:|---:|---:|
+| 100 | 81,329 | 9,715,712 B | 579 ms | 656 ms | 1,211 ms |
+| 400 | 326,129 | 38,195,200 B | 714 ms | 1,035 ms | 4,037 ms |
+
+These numbers include CLI process startup and are a local trend reference, not a
+release claim. The 400-file graph was roughly four times the stored graph size;
+fresh status remained sub-second at the median on this machine. Larger source
+corpora and graphs still require ongoing measurement.

--- a/evaluate/graph/lib/integrity.mjs
+++ b/evaluate/graph/lib/integrity.mjs
@@ -12,6 +12,31 @@ process.emitWarning = ((warning, ...rest) => {
 });
 const { DatabaseSync } = require("node:sqlite");
 
+const GRAPH_SNAPSHOT_METADATA_KEY = "graph_snapshot_v1";
+const GRAPH_SNAPSHOT_VERSION = 1;
+const GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS = 1_024;
+const GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUT_PATH_LENGTH = 4_096;
+const GRAPH_SNAPSHOT_KEYS = [
+  "version",
+  "indexedAt",
+  "lastSuccessfulIndexAt",
+  "indexedBranch",
+  "indexedHead",
+  "schemaVersion",
+  "compilerVersion",
+  "extractorVersion",
+  "resolverVersion",
+  "grammarHash",
+  "configHash",
+  "manifestHash",
+  "sourceCorpusDigest",
+  "sourceCount",
+  "semanticInputs",
+  "parseHealth",
+];
+const GRAPH_SNAPSHOT_SEMANTIC_INPUT_KEYS = ["path", "contentHash"];
+const GRAPH_SNAPSHOT_PARSE_HEALTH_KEYS = ["total", "ok", "partial", "failed"];
+
 const NORMALIZED_TABLES = [
   {
     name: "nodes",
@@ -67,10 +92,7 @@ const NORMALIZED_TABLES = [
     name: "project_metadata",
     columns: ["key", "value"],
     order: ["key"],
-    // Successful-index provenance contains observation timestamps and Git
-    // coordinates. It is operational state, not part of the semantic graph
-    // whose clean-build parity this hash protects.
-    where: "key != 'graph_snapshot_v1'",
+    normalize: normalizeProjectMetadataRow,
   },
   {
     name: "node_fingerprints",
@@ -131,6 +153,154 @@ function groupedCounts(db, table, column, where = null) {
   return Object.fromEntries(result.map((row) => [row.key ?? "<null>", Number(row.count)]));
 }
 
+function normalizeProjectMetadataRow(row) {
+  if (row.key !== GRAPH_SNAPSHOT_METADATA_KEY) return row;
+  if (typeof row.value !== "string") invalidGraphSnapshot("metadata value must be JSON text");
+  let snapshot;
+  try {
+    snapshot = JSON.parse(row.value);
+  } catch {
+    invalidGraphSnapshot("metadata value must contain valid JSON");
+  }
+  return { ...row, value: semanticGraphSnapshot(snapshot) };
+}
+
+/**
+ * Keep successful-build provenance that can change graph meaning while removing
+ * only observation timestamps and Git coordinates. The persisted writer emits
+ * one canonical v1 shape; unknown or non-canonical input must invalidate an
+ * evaluation instead of being silently omitted from the determinism hash.
+ */
+function semanticGraphSnapshot(snapshot) {
+  assertExactKeys(snapshot, GRAPH_SNAPSHOT_KEYS, "snapshot");
+  if (snapshot.version !== GRAPH_SNAPSHOT_VERSION) {
+    invalidGraphSnapshot(`unsupported version (expected ${GRAPH_SNAPSHOT_VERSION})`);
+  }
+  if (!isIsoTimestamp(snapshot.indexedAt) || !isIsoTimestamp(snapshot.lastSuccessfulIndexAt)) {
+    invalidGraphSnapshot("timestamps must be canonical ISO-8601 values");
+  }
+  if (!isNullableString(snapshot.indexedBranch) || !isNullableString(snapshot.indexedHead)) {
+    invalidGraphSnapshot("Git coordinates must be strings or null");
+  }
+  if (!isNonNegativeInteger(snapshot.schemaVersion)
+    || !isNonNegativeInteger(snapshot.sourceCount)) {
+    invalidGraphSnapshot("schemaVersion and sourceCount must be non-negative integers");
+  }
+  if (!isNonEmptyString(snapshot.compilerVersion)
+    || !isNonEmptyString(snapshot.extractorVersion)
+    || !isNonEmptyString(snapshot.resolverVersion)) {
+    invalidGraphSnapshot("compiler, extractor, and resolver versions must be non-empty strings");
+  }
+  if (!isDigest(snapshot.grammarHash)
+    || !isDigest(snapshot.configHash)
+    || !isDigest(snapshot.manifestHash)
+    || !isDigest(snapshot.sourceCorpusDigest)) {
+    invalidGraphSnapshot("semantic hashes must be lowercase SHA-256 digests");
+  }
+  if (!Array.isArray(snapshot.semanticInputs)
+    || snapshot.semanticInputs.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS) {
+    invalidGraphSnapshot("semanticInputs must be a bounded array");
+  }
+
+  let previousPath;
+  const semanticInputs = snapshot.semanticInputs.map((input) => {
+    assertExactKeys(input, GRAPH_SNAPSHOT_SEMANTIC_INPUT_KEYS, "semantic input");
+    if (!isSafeRelativePath(input.path) || !isNullableDigest(input.contentHash)) {
+      invalidGraphSnapshot("semantic inputs must contain a safe path and nullable SHA-256 digest");
+    }
+    if (previousPath !== undefined && compareText(previousPath, input.path) >= 0) {
+      invalidGraphSnapshot("semantic input paths must be unique and strictly code-point sorted");
+    }
+    previousPath = input.path;
+    return { path: input.path, contentHash: input.contentHash };
+  });
+
+  assertExactKeys(snapshot.parseHealth, GRAPH_SNAPSHOT_PARSE_HEALTH_KEYS, "parseHealth");
+  const { total, ok, partial, failed } = snapshot.parseHealth;
+  if (!isNonNegativeInteger(total)
+    || !isNonNegativeInteger(ok)
+    || !isNonNegativeInteger(partial)
+    || !isNonNegativeInteger(failed)
+    || total !== snapshot.sourceCount
+    || ok + partial + failed !== total) {
+    invalidGraphSnapshot("parseHealth totals must be non-negative and match sourceCount");
+  }
+
+  return {
+    version: snapshot.version,
+    schemaVersion: snapshot.schemaVersion,
+    compilerVersion: snapshot.compilerVersion,
+    extractorVersion: snapshot.extractorVersion,
+    resolverVersion: snapshot.resolverVersion,
+    grammarHash: snapshot.grammarHash,
+    configHash: snapshot.configHash,
+    manifestHash: snapshot.manifestHash,
+    sourceCorpusDigest: snapshot.sourceCorpusDigest,
+    sourceCount: snapshot.sourceCount,
+    semanticInputs,
+    parseHealth: { total, ok, partial, failed },
+  };
+}
+
+function assertExactKeys(value, expected, label) {
+  if (!isRecord(value)) invalidGraphSnapshot(`${label} must be an object`);
+  const actual = Object.keys(value).sort(compareText);
+  const canonical = [...expected].sort(compareText);
+  if (actual.length !== canonical.length
+    || actual.some((key, index) => key !== canonical[index])) {
+    invalidGraphSnapshot(`${label} contains missing or unknown fields`);
+  }
+}
+
+function invalidGraphSnapshot(reason) {
+  throw new Error(`invalid ${GRAPH_SNAPSHOT_METADATA_KEY}: ${reason}`);
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isIsoTimestamp(value) {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isNullableString(value) {
+  return value === null || typeof value === "string";
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isNonNegativeInteger(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isDigest(value) {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
+function isNullableDigest(value) {
+  return value === null || isDigest(value);
+}
+
+function isSafeRelativePath(value) {
+  if (typeof value !== "string"
+    || value.length === 0
+    || value.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUT_PATH_LENGTH
+    || value.includes("\\")
+    || value.includes("\0")
+    || value.startsWith("/")
+    || /^[A-Za-z]:\//.test(value)) return false;
+  return value.split("/").every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function normalizedRows(db, spec) {
   const available = tableColumns(db, spec.name);
   if (!available.size) return null;
@@ -140,7 +310,8 @@ function normalizedRows(db, spec) {
   const sql = `SELECT ${columns.map(identifier).join(", ")} FROM ${identifier(spec.name)}`
     + `${spec.where ? ` WHERE ${spec.where}` : ""}`
     + `${order.length ? ` ORDER BY ${order.map(identifier).join(", ")}` : ""}`;
-  return rows(db, sql);
+  const selected = rows(db, sql);
+  return spec.normalize ? selected.map((row) => spec.normalize(row)) : selected;
 }
 
 function normalizedGraphHash(db) {

--- a/evaluate/graph/lib/integrity.mjs
+++ b/evaluate/graph/lib/integrity.mjs
@@ -67,6 +67,10 @@ const NORMALIZED_TABLES = [
     name: "project_metadata",
     columns: ["key", "value"],
     order: ["key"],
+    // Successful-index provenance contains observation timestamps and Git
+    // coordinates. It is operational state, not part of the semantic graph
+    // whose clean-build parity this hash protects.
+    where: "key != 'graph_snapshot_v1'",
   },
   {
     name: "node_fingerprints",
@@ -133,7 +137,9 @@ function normalizedRows(db, spec) {
   const columns = spec.columns.filter((column) => available.has(column));
   if (!columns.length) return [];
   const order = spec.order.filter((column) => available.has(column));
-  const sql = `SELECT ${columns.map(identifier).join(", ")} FROM ${identifier(spec.name)}${order.length ? ` ORDER BY ${order.map(identifier).join(", ")}` : ""}`;
+  const sql = `SELECT ${columns.map(identifier).join(", ")} FROM ${identifier(spec.name)}`
+    + `${spec.where ? ` WHERE ${spec.where}` : ""}`
+    + `${order.length ? ` ORDER BY ${order.map(identifier).join(", ")}` : ""}`;
   return rows(db, sql);
 }
 

--- a/evaluate/graph/test/graph-eval.test.mjs
+++ b/evaluate/graph/test/graph-eval.test.mjs
@@ -141,6 +141,15 @@ test("v2 integrity hashing includes semantic metadata but ignores timestamps", (
   timestamps.close();
   assert.equal(inspectGraphDatabase(path).normalizedGraphSha256, first.normalizedGraphSha256);
 
+  const operational = new DatabaseSync(path);
+  operational.prepare("INSERT INTO project_metadata VALUES (?, ?, ?)").run(
+    "graph_snapshot_v1",
+    JSON.stringify({ version: 1, indexedAt: "2026-08-22T00:00:00.000Z" }),
+    600,
+  );
+  operational.close();
+  assert.equal(inspectGraphDatabase(path).normalizedGraphSha256, first.normalizedGraphSha256);
+
   const semantic = new DatabaseSync(path);
   semantic.exec("UPDATE edges SET confidence = 0.75");
   semantic.close();

--- a/evaluate/graph/test/graph-eval.test.mjs
+++ b/evaluate/graph/test/graph-eval.test.mjs
@@ -57,6 +57,67 @@ function fixture(gates = null) {
   return { subjectRoot, suite: loadGraphSuite(suitePath), outputDir: mkdtempSync(join(tmpdir(), "mex-graph-output-")) };
 }
 
+const digest = (character) => character.repeat(64);
+
+function completeGraphSnapshot(overrides = {}) {
+  return {
+    version: 1,
+    indexedAt: "2026-08-22T00:00:00.000Z",
+    lastSuccessfulIndexAt: "2026-08-22T00:00:00.000Z",
+    indexedBranch: "main",
+    indexedHead: "1".repeat(40),
+    schemaVersion: 2,
+    compilerVersion: "5.9.3",
+    extractorVersion: "typescript-5.9-v1+tree-sitter-v2",
+    resolverVersion: "compiler-first-v2",
+    grammarHash: digest("a"),
+    configHash: digest("b"),
+    manifestHash: digest("c"),
+    sourceCorpusDigest: digest("d"),
+    sourceCount: 1,
+    semanticInputs: [
+      { path: "config/base.json", contentHash: digest("e") },
+      { path: "config/missing.json", contentHash: null },
+    ],
+    parseHealth: { total: 1, ok: 0, partial: 1, failed: 0 },
+    ...overrides,
+  };
+}
+
+function snapshotIntegrityFixture() {
+  const root = mkdtempSync(join(tmpdir(), "mex-integrity-snapshot-"));
+  const path = join(root, "graph.db");
+  const db = new DatabaseSync(path);
+  db.exec(readFileSync(join(HARNESS_ROOT, "src", "graph", "schema.sql"), "utf8"));
+  db.prepare(`INSERT INTO files (
+    path, content_hash, language, size, modified_at, indexed_at, node_count, errors,
+    parse_status, diagnostic_count, missing_count, error_coverage, extractor_version
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    "src/a.ts", digest("f"), "typescript", 100, 1, 2, 0, "[]", "partial", 2, 1, 0.1, "typescript-5.9.3",
+  );
+  db.close();
+  return path;
+}
+
+function writeGraphSnapshot(path, snapshot, updatedAt = 600) {
+  writeRawGraphSnapshot(path, JSON.stringify(snapshot), updatedAt);
+}
+
+function writeRawGraphSnapshot(path, raw, updatedAt = 600) {
+  const db = new DatabaseSync(path);
+  db.prepare(`INSERT INTO project_metadata (key, value, updated_at) VALUES (?, ?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`).run(
+    "graph_snapshot_v1",
+    raw,
+    updatedAt,
+  );
+  db.close();
+}
+
+function normalizedHash(path) {
+  return inspectGraphDatabase(path).normalizedGraphSha256;
+}
+
 test("suite schema rejects empty, duplicate, and underspecified task fixtures", () => {
   assert.throws(() => validateGraphSuite(rawSuite([])), /tasks must be non-empty/);
   const duplicate = rawSuite([positiveTask(), positiveTask()]);
@@ -82,7 +143,7 @@ test("suite integrity thresholds must be finite numeric metric maps", () => {
   assert.throws(() => validateGraphSuite(wrongShape), /gates\.integrityCeilings must be an object/);
 });
 
-test("v2 integrity hashing includes semantic metadata but ignores timestamps", () => {
+test("v2 integrity hashing includes graph rows and semantic metadata but ignores row timestamps", () => {
   const root = mkdtempSync(join(tmpdir(), "mex-integrity-v2-"));
   const path = join(root, "graph.db");
   const db = new DatabaseSync(path);
@@ -141,21 +202,152 @@ test("v2 integrity hashing includes semantic metadata but ignores timestamps", (
   timestamps.close();
   assert.equal(inspectGraphDatabase(path).normalizedGraphSha256, first.normalizedGraphSha256);
 
-  const operational = new DatabaseSync(path);
-  operational.prepare("INSERT INTO project_metadata VALUES (?, ?, ?)").run(
-    "graph_snapshot_v1",
-    JSON.stringify({ version: 1, indexedAt: "2026-08-22T00:00:00.000Z" }),
-    600,
-  );
-  operational.close();
-  assert.equal(inspectGraphDatabase(path).normalizedGraphSha256, first.normalizedGraphSha256);
-
   const semantic = new DatabaseSync(path);
   semantic.exec("UPDATE edges SET confidence = 0.75");
   semantic.close();
   const changed = inspectGraphDatabase(path);
   assert.notEqual(changed.normalizedGraphSha256, first.normalizedGraphSha256);
   assert.equal(changed.belowFlowThresholdEdges, 1);
+});
+
+test("graph snapshot hashing excludes only timestamps and Git coordinates", () => {
+  const path = snapshotIntegrityFixture();
+  const absentHash = normalizedHash(path);
+  const base = completeGraphSnapshot();
+  writeGraphSnapshot(path, base);
+  const baseHash = normalizedHash(path);
+  assert.notEqual(baseHash, absentHash, "snapshot presence must participate in semantic identity");
+
+  const volatileVariants = [
+    ["indexedAt", { ...base, indexedAt: "2026-08-23T00:00:00.000Z" }],
+    ["lastSuccessfulIndexAt", { ...base, lastSuccessfulIndexAt: "2026-08-24T00:00:00.000Z" }],
+    ["indexedBranch", { ...base, indexedBranch: "feature/evaluator" }],
+    ["indexedHead", { ...base, indexedHead: "2".repeat(40) }],
+    ["all volatile fields", {
+      ...base,
+      indexedAt: "2026-08-25T00:00:00.000Z",
+      lastSuccessfulIndexAt: "2026-08-26T00:00:00.000Z",
+      indexedBranch: null,
+      indexedHead: null,
+    }],
+  ];
+  for (const [label, snapshot] of volatileVariants) {
+    writeGraphSnapshot(path, snapshot, 700);
+    assert.equal(normalizedHash(path), baseHash, `${label} must be excluded from semantic identity`);
+  }
+
+  const reordered = Object.fromEntries(Object.entries(base).reverse());
+  reordered.parseHealth = Object.fromEntries(Object.entries(base.parseHealth).reverse());
+  reordered.semanticInputs = base.semanticInputs.map(({ path: inputPath, contentHash }) => ({
+    contentHash,
+    path: inputPath,
+  }));
+  writeRawGraphSnapshot(path, JSON.stringify(reordered, null, 2), 800);
+  assert.equal(normalizedHash(path), baseHash, "JSON property order and whitespace must be normalized");
+
+  const timestamps = new DatabaseSync(path);
+  timestamps.exec("UPDATE project_metadata SET updated_at = 900 WHERE key = 'graph_snapshot_v1'");
+  timestamps.close();
+  assert.equal(normalizedHash(path), baseHash, "metadata row timestamps must remain operational");
+});
+
+test("graph snapshot hashing retains every semantic provenance field", () => {
+  const path = snapshotIntegrityFixture();
+  const base = completeGraphSnapshot();
+  writeGraphSnapshot(path, base);
+  const baseHash = normalizedHash(path);
+  const semanticVariants = [
+    ["schemaVersion", { ...base, schemaVersion: 3 }],
+    ["compilerVersion", { ...base, compilerVersion: "5.9.4" }],
+    ["extractorVersion", { ...base, extractorVersion: "typescript-5.9-v2+tree-sitter-v2" }],
+    ["resolverVersion", { ...base, resolverVersion: "compiler-first-v3" }],
+    ["grammarHash", { ...base, grammarHash: digest("0") }],
+    ["configHash", { ...base, configHash: digest("1") }],
+    ["manifestHash", { ...base, manifestHash: digest("2") }],
+    ["sourceCorpusDigest", { ...base, sourceCorpusDigest: digest("3") }],
+    ["sourceCount", {
+      ...base,
+      sourceCount: 2,
+      parseHealth: { total: 2, ok: 0, partial: 2, failed: 0 },
+    }],
+    ["semantic input path", {
+      ...base,
+      semanticInputs: [
+        { path: "config/alternate.json", contentHash: digest("e") },
+        base.semanticInputs[1],
+      ],
+    }],
+    ["semantic input digest", {
+      ...base,
+      semanticInputs: [
+        { path: base.semanticInputs[0].path, contentHash: digest("4") },
+        base.semanticInputs[1],
+      ],
+    }],
+    ["negative semantic input probe", {
+      ...base,
+      semanticInputs: [
+        base.semanticInputs[0],
+        { path: base.semanticInputs[1].path, contentHash: digest("5") },
+      ],
+    }],
+    ["parseHealth", { ...base, parseHealth: { total: 1, ok: 1, partial: 0, failed: 0 } }],
+  ];
+
+  for (const [label, snapshot] of semanticVariants) {
+    writeGraphSnapshot(path, snapshot);
+    assert.notEqual(normalizedHash(path), baseHash, `${label} must participate in semantic identity`);
+  }
+});
+
+test("graph snapshot hashing fails closed on non-canonical or unsupported provenance", () => {
+  const path = snapshotIntegrityFixture();
+  const base = completeGraphSnapshot();
+  const { manifestHash: _missingManifest, ...missingField } = base;
+  const invalidCases = [
+    ["malformed JSON", "{"],
+    ["incomplete snapshot", JSON.stringify({ version: 1 })],
+    ["missing field", JSON.stringify(missingField)],
+    ["unsupported version", JSON.stringify({ ...base, version: 2 })],
+    ["unknown snapshot field", JSON.stringify({ ...base, futureSemanticField: true })],
+    ["unknown semantic-input field", JSON.stringify({
+      ...base,
+      semanticInputs: [{ ...base.semanticInputs[0], kind: "config" }, base.semanticInputs[1]],
+    })],
+    ["unknown parse-health field", JSON.stringify({
+      ...base,
+      parseHealth: { ...base.parseHealth, unknown: 0 },
+    })],
+    ["duplicate semantic-input path", JSON.stringify({
+      ...base,
+      semanticInputs: [base.semanticInputs[0], { ...base.semanticInputs[0] }],
+    })],
+    ["unsorted semantic-input paths", JSON.stringify({
+      ...base,
+      semanticInputs: [...base.semanticInputs].reverse(),
+    })],
+    ["unsafe semantic-input path", JSON.stringify({
+      ...base,
+      semanticInputs: [{ path: "../outside.json", contentHash: digest("e") }],
+    })],
+    ["invalid semantic-input digest", JSON.stringify({
+      ...base,
+      semanticInputs: [{ path: "config/base.json", contentHash: "not-a-digest" }],
+    })],
+    ["inconsistent parse-health totals", JSON.stringify({
+      ...base,
+      parseHealth: { total: 1, ok: 1, partial: 1, failed: 0 },
+    })],
+  ];
+
+  for (const [label, raw] of invalidCases) {
+    writeRawGraphSnapshot(path, raw);
+    assert.throws(
+      () => inspectGraphDatabase(path),
+      /invalid graph_snapshot_v1/,
+      `${label} must invalidate evaluator normalization`,
+    );
+  }
 });
 
 test("production-to-test integrity permits proven callback wiring but rejects unsupported edges", () => {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "eval:e2e": "node evaluate/agent-e2e.mjs",
     "eval:compare": "node evaluate/compare/index.mjs",
     "eval:compare:test": "node --test evaluate/compare/test/*.test.mjs",
+    "benchmark:graph-status": "npm run build && node scripts/benchmark-graph-status.mjs",
     "typecheck": "tsc --noEmit",
     "prepare": "npm run build"
   },

--- a/scripts/benchmark-graph-status.mjs
+++ b/scripts/benchmark-graph-status.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  availableParallelism,
+  cpus,
+  endianness,
+  platform,
+  release,
+  tmpdir,
+  totalmem,
+  type,
+  version as osVersion,
+} from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_SIZES = Object.freeze([100, 400]);
+const DEFAULT_RUNS = 7;
+const DEFAULT_WARMUPS = 2;
+const DEFAULT_TIMEOUT_MS = 180_000;
+const MAX_PROCESS_OUTPUT_BYTES = 2 * 1024 * 1024;
+const MAX_GIT_OUTPUT_BYTES = 256 * 1024;
+const FIXED_GIT_DATE = "2026-01-01T00:00:00Z";
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_CLI_PATH = resolve(SCRIPT_DIR, "..", "dist", "cli.js");
+
+const options = parseArguments(process.argv.slice(2));
+if (options.help) {
+  printUsage();
+  process.exit(0);
+}
+
+assertBuiltCli(options.cliPath);
+
+const temporaryRoot = mkdtempSync(join(tmpdir(), "mex-graph-status-benchmark-"));
+const emptyGitConfig = join(temporaryRoot, "empty-gitconfig");
+const mexHome = join(temporaryRoot, "mex-home");
+writeFileSync(emptyGitConfig, "", "utf8");
+mkdirSync(mexHome);
+
+const childEnvironment = {
+  ...process.env,
+  DO_NOT_TRACK: "1",
+  GIT_CONFIG_GLOBAL: emptyGitConfig,
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_OPTIONAL_LOCKS: "0",
+  LANG: "C",
+  LC_ALL: "C",
+  MEX_HOME: mexHome,
+  MEX_TELEMETRY: "0",
+  NO_COLOR: "1",
+};
+delete childEnvironment.NODE_OPTIONS;
+delete childEnvironment.NODE_PATH;
+for (const key of [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_DIR",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_WORK_TREE",
+]) {
+  delete childEnvironment[key];
+}
+for (const key of Object.keys(childEnvironment)) {
+  if (/^GIT_CONFIG_(KEY|VALUE)_[0-9]+$/u.test(key)) delete childEnvironment[key];
+}
+
+try {
+  const results = [];
+  for (const fileCount of options.sizes) {
+    const fixture = createFixture(temporaryRoot, fileCount, childEnvironment);
+    const rebuild = runMexJson(
+      options.cliPath,
+      ["graph", "rebuild", "--root", fixture.root, "--json"],
+      fixture.root,
+      childEnvironment,
+      options.timeoutMs,
+      `graph rebuild (${fileCount} files)`,
+    );
+    assertSuccessfulRebuild(rebuild, fileCount);
+
+    for (let warmup = 0; warmup < options.warmups; warmup += 1) {
+      const status = runStatus(
+        options.cliPath,
+        fixture.root,
+        childEnvironment,
+        options.timeoutMs,
+      );
+      assertFreshStatus(status, fileCount, `warm-up ${warmup + 1}`);
+    }
+
+    const samplesMs = [];
+    for (let run = 0; run < options.runs; run += 1) {
+      const startedAt = performance.now();
+      const status = runStatus(
+        options.cliPath,
+        fixture.root,
+        childEnvironment,
+        options.timeoutMs,
+      );
+      const elapsedMs = performance.now() - startedAt;
+      assertFreshStatus(status, fileCount, `measured run ${run + 1}`);
+      samplesMs.push(elapsedMs);
+    }
+
+    const databasePath = join(fixture.root, ".mex", "graph.db");
+    const databaseBytes = statSync(databasePath).size;
+    results.push({
+      files: fileCount,
+      sourceBytes: fixture.sourceBytes,
+      databaseBytes,
+      sqliteFilesBytes: sqliteFilesSize(databasePath),
+      rebuild: {
+        durationMs: numberField(rebuild, "durationMs"),
+        nodesCreated: numberField(rebuild, "nodesCreated"),
+        edgesCreated: numberField(rebuild, "edgesCreated"),
+      },
+      statusMs: summarizeTimings(samplesMs),
+    });
+  }
+
+  const cpuList = cpus();
+  const report = {
+    benchmark: "mex graph status --json",
+    note: "Characterization only: elapsed times are reported without a pass/fail budget.",
+    environment: {
+      node: process.version,
+      v8: process.versions.v8,
+      sqlite: {
+        backend: "node:sqlite",
+        version: process.versions.sqlite ?? null,
+      },
+      libuv: process.versions.uv,
+      os: {
+        type: type(),
+        platform: platform(),
+        release: release(),
+        version: osVersion(),
+        architecture: process.arch,
+        endianness: endianness(),
+      },
+      cpu: {
+        model: cpuList[0]?.model ?? "unknown",
+        logicalCount: cpuList.length,
+        availableParallelism: availableParallelism(),
+      },
+      totalMemoryBytes: totalmem(),
+    },
+    configuration: {
+      cliPath: options.cliPath,
+      fixture: "deterministic committed TypeScript repository",
+      sizes: options.sizes,
+      warmups: options.warmups,
+      measuredRuns: options.runs,
+      commandTimeoutMs: options.timeoutMs,
+      maximumCapturedOutputBytes: MAX_PROCESS_OUTPUT_BYTES,
+    },
+    results,
+  };
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Graph status benchmark failed: ${message}\n`);
+  process.exitCode = 1;
+} finally {
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}
+
+function parseArguments(argv) {
+  const parsed = {
+    cliPath: DEFAULT_CLI_PATH,
+    help: false,
+    runs: DEFAULT_RUNS,
+    sizes: [...DEFAULT_SIZES],
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    warmups: DEFAULT_WARMUPS,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help" || argument === "-h") {
+      parsed.help = true;
+      continue;
+    }
+
+    const [name, inlineValue] = splitOption(argument);
+    if (!["--cli", "--runs", "--sizes", "--timeout-ms", "--warmups"].includes(name)) {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+    const value = inlineValue ?? argv[++index];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${name} requires a value.`);
+    }
+
+    if (name === "--cli") parsed.cliPath = resolve(value);
+    if (name === "--runs") parsed.runs = boundedInteger(value, name, 1, 100);
+    if (name === "--warmups") parsed.warmups = boundedInteger(value, name, 0, 20);
+    if (name === "--timeout-ms") parsed.timeoutMs = boundedInteger(value, name, 1_000, 600_000);
+    if (name === "--sizes") parsed.sizes = parseSizes(value);
+  }
+
+  return parsed;
+}
+
+function splitOption(argument) {
+  const separator = argument.indexOf("=");
+  return separator === -1
+    ? [argument, undefined]
+    : [argument.slice(0, separator), argument.slice(separator + 1)];
+}
+
+function boundedInteger(raw, name, minimum, maximum) {
+  if (!/^(0|[1-9][0-9]*)$/u.test(raw)) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}.`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} to ${maximum}.`);
+  }
+  return value;
+}
+
+function parseSizes(raw) {
+  const entries = raw.split(",");
+  if (entries.length === 0 || entries.length > 8 || entries.some((entry) => entry.length === 0)) {
+    throw new Error("--sizes must contain between one and eight comma-separated file counts.");
+  }
+  const sizes = entries.map((entry) => boundedInteger(entry, "--sizes", 1, 10_000));
+  if (new Set(sizes).size !== sizes.length) {
+    throw new Error("--sizes must not contain duplicate file counts.");
+  }
+  return sizes;
+}
+
+function printUsage() {
+  process.stdout.write(
+    "Usage: node scripts/benchmark-graph-status.mjs [options]\n\n"
+      + "Characterize fresh `mex graph status --json` latency against deterministic Git fixtures.\n\n"
+      + "Options:\n"
+      + `  --sizes <counts>     Comma-separated source-file counts (default: ${DEFAULT_SIZES.join(",")})\n`
+      + `  --warmups <n>        Warm-up status processes per fixture (default: ${DEFAULT_WARMUPS})\n`
+      + `  --runs <n>           Measured status processes per fixture (default: ${DEFAULT_RUNS})\n`
+      + `  --timeout-ms <n>     Per-process timeout (default: ${DEFAULT_TIMEOUT_MS})\n`
+      + `  --cli <path>         Built CLI entry point (default: ${DEFAULT_CLI_PATH})\n`
+      + "  -h, --help           Show this help\n",
+  );
+}
+
+function assertBuiltCli(cliPath) {
+  if (!existsSync(cliPath)) {
+    throw new Error(`Built CLI not found at ${cliPath}. Run \`npm run build\` first.`);
+  }
+  const stats = statSync(cliPath);
+  if (!stats.isFile()) throw new Error(`Built CLI path is not a regular file: ${cliPath}`);
+}
+
+function createFixture(parentRoot, fileCount, environment) {
+  const fixtureRoot = join(parentRoot, `files-${String(fileCount).padStart(5, "0")}`);
+  const sourceRoot = join(fixtureRoot, "src");
+  mkdirSync(sourceRoot, { recursive: true });
+  writeFileSync(
+    join(fixtureRoot, ".gitignore"),
+    ".mex/graph.db*\n.mex/recovery/graph/\n",
+    "utf8",
+  );
+  writeFileSync(
+    join(fixtureRoot, "tsconfig.json"),
+    `${JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        noEmit: true,
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["src/**/*.ts"],
+    }, null, 2)}\n`,
+    "utf8",
+  );
+
+  const width = Math.max(4, String(fileCount - 1).length);
+  let sourceBytes = 0;
+  for (let index = 0; index < fileCount; index += 1) {
+    const suffix = String(index).padStart(width, "0");
+    const previousSuffix = String(Math.max(0, index - 1)).padStart(width, "0");
+    const source = typescriptModule(index, suffix, previousSuffix);
+    writeFileSync(join(sourceRoot, `module-${suffix}.ts`), source, "utf8");
+    sourceBytes += Buffer.byteLength(source, "utf8");
+  }
+
+  runGit(fixtureRoot, ["init", "--quiet", "--initial-branch=benchmark"], environment);
+  runGit(fixtureRoot, ["config", "user.name", "MEX Benchmark"], environment);
+  runGit(fixtureRoot, ["config", "user.email", "benchmark@example.invalid"], environment);
+  runGit(fixtureRoot, ["add", "--", ".gitignore", "tsconfig.json", "src"], environment);
+  runGit(
+    fixtureRoot,
+    ["commit", "--quiet", "--no-gpg-sign", "--message", "benchmark fixture"],
+    {
+      ...environment,
+      GIT_AUTHOR_DATE: FIXED_GIT_DATE,
+      GIT_COMMITTER_DATE: FIXED_GIT_DATE,
+    },
+  );
+
+  return { root: fixtureRoot, sourceBytes };
+}
+
+function typescriptModule(index, suffix, previousSuffix) {
+  const dependency = index === 0
+    ? ""
+    : `import { service${previousSuffix} } from \"./module-${previousSuffix}.js\";\n\n`;
+  const upstream = index === 0 ? "input + 17" : `service${previousSuffix}(input)`;
+  return `${dependency}`
+    + `export interface Payload${suffix} {\n`
+    + "  readonly id: number;\n"
+    + "  readonly label: string;\n"
+    + "  readonly values: readonly number[];\n"
+    + "}\n\n"
+    + `export function normalize${suffix}(input: number): Payload${suffix} {\n`
+    + `  const upstream = ${upstream};\n`
+    + "  return {\n"
+    + `    id: ${index},\n`
+    + `    label: \"module-${suffix}\",\n`
+    + "    values: [upstream, upstream + 1, upstream + 2],\n"
+    + "  };\n"
+    + "}\n\n"
+    + `export class Worker${suffix} {\n`
+    + `  constructor(private readonly offset = ${index + 3}) {}\n\n`
+    + `  execute(payload: Payload${suffix}): number {\n`
+    + "    return payload.values.reduce((total, value) => total + value, this.offset);\n"
+    + "  }\n"
+    + "}\n\n"
+    + `export function service${suffix}(input: number): number {\n`
+    + `  const payload = normalize${suffix}(input);\n`
+    + `  return new Worker${suffix}().execute(payload);\n`
+    + "}\n\n"
+    + `export const descriptor${suffix} = Object.freeze({\n`
+    + `  key: \"service-${suffix}\",\n`
+    + `  run: service${suffix},\n`
+    + "});\n";
+}
+
+function runGit(cwd, args, environment) {
+  runProcess("git", args, {
+    cwd,
+    environment,
+    label: `git ${args[0]}`,
+    maxOutputBytes: MAX_GIT_OUTPUT_BYTES,
+    timeoutMs: 30_000,
+  });
+}
+
+function runStatus(cliPath, root, environment, timeoutMs) {
+  return runMexJson(
+    cliPath,
+    ["graph", "status", "--root", root, "--json"],
+    root,
+    environment,
+    timeoutMs,
+    "graph status",
+  );
+}
+
+function runMexJson(cliPath, args, cwd, environment, timeoutMs, label) {
+  const stdout = runProcess(process.execPath, [cliPath, ...args], {
+    cwd,
+    environment,
+    label,
+    maxOutputBytes: MAX_PROCESS_OUTPUT_BYTES,
+    timeoutMs,
+  });
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`${label} did not emit valid JSON (${reason}); stdout: ${boundedText(stdout)}`);
+  }
+}
+
+function runProcess(command, args, { cwd, environment, label, maxOutputBytes, timeoutMs }) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    env: environment,
+    killSignal: "SIGKILL",
+    maxBuffer: maxOutputBytes,
+    shell: false,
+    timeout: timeoutMs,
+    windowsHide: true,
+  });
+  if (result.error) {
+    const code = typeof result.error === "object" && result.error !== null && "code" in result.error
+      ? ` (${String(result.error.code)})`
+      : "";
+    throw new Error(`${label} could not complete${code}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${label} exited with status ${String(result.status)}${result.signal ? ` (${result.signal})` : ""}; `
+        + `stderr: ${boundedText(result.stderr)}; stdout: ${boundedText(result.stdout)}`,
+    );
+  }
+  return result.stdout;
+}
+
+function assertSuccessfulRebuild(result, expectedFiles) {
+  assertRecord(result, "graph rebuild result");
+  if (result.state !== "succeeded") {
+    throw new Error(`graph rebuild did not succeed: state=${String(result.state)}`);
+  }
+  if (result.filesIndexed !== expectedFiles) {
+    throw new Error(
+      `graph rebuild indexed ${String(result.filesIndexed)} files; expected ${expectedFiles}.`,
+    );
+  }
+  assertFreshStatus(result.status, expectedFiles, "rebuild result");
+}
+
+function assertFreshStatus(status, expectedFiles, phase) {
+  assertRecord(status, `${phase} graph status`);
+  if (status.status !== "fresh") {
+    throw new Error(`${phase} graph status was ${String(status.status)}, not fresh.`);
+  }
+  if (typeof status.observedAt !== "string" || !Number.isFinite(Date.parse(status.observedAt))) {
+    throw new Error(`${phase} graph status has an invalid observedAt timestamp.`);
+  }
+  assertRecord(status.currentRepo, `${phase} currentRepo`);
+  if (status.currentRepo.branch !== "benchmark"
+    || typeof status.currentRepo.head !== "string"
+    || !/^[a-f0-9]{40}$/u.test(status.currentRepo.head)
+    || status.currentRepo.dirty !== false) {
+    throw new Error(`${phase} graph status has invalid or dirty repository provenance.`);
+  }
+  if (!Number.isInteger(status.schemaVersion) || status.schemaVersion <= 0) {
+    throw new Error(`${phase} graph status has an invalid schema version.`);
+  }
+  assertRecord(status.parseHealth, `${phase} parseHealth`);
+  for (const field of ["total", "ok", "partial", "failed"]) numberField(status.parseHealth, field);
+  if (status.parseHealth.total !== expectedFiles
+    || status.parseHealth.ok + status.parseHealth.partial + status.parseHealth.failed !== expectedFiles) {
+    throw new Error(`${phase} graph status has inconsistent parse-health totals.`);
+  }
+  assertRecord(status.changes, `${phase} changes`);
+  if (status.changes.total !== 0
+    || !Array.isArray(status.changes.added)
+    || !Array.isArray(status.changes.modified)
+    || !Array.isArray(status.changes.deleted)
+    || status.changes.added.length !== 0
+    || status.changes.modified.length !== 0
+    || status.changes.deleted.length !== 0) {
+    throw new Error(`${phase} graph status reports source changes for a fresh fixture.`);
+  }
+  if (!Array.isArray(status.diagnostics)) {
+    throw new Error(`${phase} graph status diagnostics must be an array.`);
+  }
+}
+
+function assertRecord(value, label) {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be a JSON object.`);
+  }
+}
+
+function numberField(record, field) {
+  const value = record[field];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a finite non-negative number.`);
+  }
+  return value;
+}
+
+function sqliteFilesSize(databasePath) {
+  return [databasePath, `${databasePath}-wal`, `${databasePath}-shm`]
+    .filter((path) => existsSync(path))
+    .reduce((total, path) => total + statSync(path).size, 0);
+}
+
+function summarizeTimings(samples) {
+  if (samples.length === 0) throw new Error("At least one measured status run is required.");
+  const sorted = [...samples].sort((left, right) => left - right);
+  return {
+    samples: sorted.map(roundMilliseconds),
+    min: roundMilliseconds(sorted[0]),
+    median: roundMilliseconds(median(sorted)),
+    p95: roundMilliseconds(nearestRank(sorted, 0.95)),
+    max: roundMilliseconds(sorted.at(-1)),
+  };
+}
+
+function median(sorted) {
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+}
+
+function nearestRank(sorted, percentile) {
+  const index = Math.max(0, Math.ceil(percentile * sorted.length) - 1);
+  return sorted[index];
+}
+
+function roundMilliseconds(value) {
+  return Math.round(value * 1_000) / 1_000;
+}
+
+function boundedText(value) {
+  const normalized = typeof value === "string" ? value.trim() : String(value ?? "");
+  if (normalized.length <= 1_000) return JSON.stringify(normalized);
+  return JSON.stringify(`${normalized.slice(0, 1_000)}…`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -198,13 +198,67 @@ program
 // ── Code Graph ──
 const graphCommand = program
   .command("graph")
-  .description("Build/rebuild the code knowledge graph into .mex/graph.db")
+  .description("Inspect or explicitly maintain the code knowledge graph")
   .option("--json", "Output the build summary as JSON")
   .option("--root <dir>", "Project root to index (defaults to current directory)")
   .action(async (opts) => {
     try {
       const { runGraph } = await import("./graph/cli-graph.js");
       await runGraph({ root: opts.root, json: opts.json });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+graphCommand
+  .command("status")
+  .description("Inspect graph freshness without writing or rebuilding")
+  .option("--json", "Output the complete graph status as JSON")
+  .option("--root <dir>", "Project root to inspect (defaults to current directory)")
+  .action(async (opts) => {
+    try {
+      const { runGraphStatus } = await import("./graph/cli-graph.js");
+      await runGraphStatus({
+        root: opts.root ?? graphCommand.opts().root,
+        json: opts.json ?? graphCommand.opts().json,
+      });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+graphCommand
+  .command("refresh")
+  .description("Explicitly refresh a compatible graph from the current repository")
+  .option("--json", "Output the complete refresh result as JSON")
+  .option("--root <dir>", "Project root to refresh (defaults to current directory)")
+  .action(async (opts) => {
+    try {
+      const { runGraphRefresh } = await import("./graph/cli-graph.js");
+      await runGraphRefresh({
+        root: opts.root ?? graphCommand.opts().root,
+        json: opts.json ?? graphCommand.opts().json,
+      });
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+graphCommand
+  .command("rebuild")
+  .description("Rebuild in isolation, validate, and atomically publish the graph")
+  .option("--json", "Output the complete rebuild result as JSON")
+  .option("--root <dir>", "Project root to rebuild (defaults to current directory)")
+  .action(async (opts) => {
+    try {
+      const { runGraphRebuild } = await import("./graph/cli-graph.js");
+      await runGraphRebuild({
+        root: opts.root ?? graphCommand.opts().root,
+        json: opts.json ?? graphCommand.opts().json,
+      });
     } catch (err) {
       console.error((err as Error).message);
       process.exit(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,7 +130,7 @@ program
   .action(async (opts) => {
     try {
       const config = loadConfig();
-      const { runDriftCheck } = await import("./drift/index.js");
+      const { runDriftCheckWithGraphStatus } = await import("./drift/index.js");
       const { DEFAULT_STALENESS_THRESHOLDS } = await import("./drift/checkers/staleness.js");
 
       const stalenessThresholds = {
@@ -140,7 +140,7 @@ program
         errorCommits: opts.staleErrorCommits ?? config.stalenessThresholds?.errorCommits ?? DEFAULT_STALENESS_THRESHOLDS.errorCommits,
       };
 
-      const report = await runDriftCheck(
+      const report = await runDriftCheckWithGraphStatus(
         { ...config, stalenessThresholds },
         { verbose: opts.verbose },
       );

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -2,35 +2,57 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import chalk from "chalk";
 import type { MexConfig } from "./types.js";
-import { runDriftCheck } from "./drift/index.js";
+import {
+  runDriftCheckWithGraphStatus,
+  type GraphAwareDriftReport,
+} from "./drift/index.js";
 import { checkHeartbeat } from "./heartbeat.js";
 import { readEvents } from "./events.js";
+import {
+  graphChangeDetail,
+  graphPrimaryDiagnostic,
+  graphRemediationCommand,
+} from "./reporter.js";
 
 export async function runDoctor(config: MexConfig): Promise<void> {
   console.log(chalk.bold("mex doctor"));
   console.log(chalk.dim(`Scaffold: ${config.scaffoldRoot}`));
   console.log();
 
-  const report = await runDriftCheck(config);
+  const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
   const errors = report.issues.filter((i) => i.severity === "error").length;
   const warnings = report.issues.filter((i) => i.severity === "warning").length;
   const heartbeat = checkHeartbeat(config);
   const events = readEvents(config);
+  const graph = report.graphStatus;
 
   printLine("Drift", report.score >= 80 && errors === 0, `${report.score}/100 (${errors} errors, ${warnings} warnings)`);
+  printLine("Graph", graph.status === "fresh", graphStatusDetail(graph));
   printLine("Heartbeat", heartbeat.ok, heartbeat.ok ? "HEARTBEAT_OK" : `${heartbeat.staleFiles.length} stale files, ${heartbeat.oldDailyMemoryFiles.length} old memory files`);
   printLine("Events", true, `${events.length} logged event${events.length === 1 ? "" : "s"}`);
   const hasConfig = existsSync(resolve(config.scaffoldRoot, "config.json"));
   printLine("Config", true, hasConfig ? ".mex/config.json loaded with defaults for missing values" : "using defaults; no .mex/config.json found");
 
-  if (errors || warnings || !heartbeat.ok) {
+  const graphNeedsAttention = graph.status !== "fresh";
+  const graphRecoveryCommand = graphRemediationCommand(graph);
+  if (errors || warnings || !heartbeat.ok || graphNeedsAttention) {
     console.log();
     console.log(chalk.bold("Next steps"));
     if (errors || warnings) console.log("  Run `mex check` for drift details, then `mex sync` for targeted repair prompts.");
+    if (graphNeedsAttention && graphRecoveryCommand) {
+      console.log(`  Run \`${graphRecoveryCommand}\` to repair the graph explicitly.`);
+    } else if (graphNeedsAttention) {
+      console.log("  Review the graph diagnostics before using graph-grounded results.");
+    }
     if (!heartbeat.ok) console.log("  Run `mex heartbeat` to see stale context or memory cleanup details.");
   }
 
   if (errors) process.exitCode = 1;
+}
+
+function graphStatusDetail(graph: GraphAwareDriftReport["graphStatus"]): string {
+  const diagnostic = graphPrimaryDiagnostic(graph);
+  return `${graph.status}; ${graphChangeDetail(graph)}${diagnostic ? `; ${diagnostic}` : ""}`;
 }
 
 function printLine(label: string, ok: boolean, detail: string): void {

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -19,8 +19,13 @@ import { checkToolConfigSync } from "./checkers/tool-config-sync.js";
 import { checkTodoFixme } from "./checkers/todo-fixme.js";
 import { checkBrokenLinks } from "./checkers/broken-link.js";
 import { toPosix } from "../paths.js";
-import { loadGroundingRuntime, type GroundingRuntime } from "../graph/runtime.js";
+import {
+  loadReadOnlyGroundingRuntime,
+  type GroundingRuntime,
+  type ReadOnlyGroundingRuntimeResult,
+} from "../graph/runtime.js";
 import { findMexAnchors } from "../markdown.js";
+import type { GraphStatus } from "../team/contracts/graph.js";
 
 let graphUpgradeNudgeShown = false;
 let graphMigrationNudgeShown = false;
@@ -53,154 +58,323 @@ export interface RunDriftCheckOpts {
   /** Override the glob patterns used to discover scaffold files (relative to
    *  `config.scaffoldRoot`). Defaults to {@link DEFAULT_SCAFFOLD_PATTERNS}. */
   scaffoldPatterns?: readonly string[];
-  /** Internal seam used to verify graph-load graceful degradation. */
+  /** Backward-compatible injection seam retained for existing embedders. */
   groundingRuntimeLoader?: (config: MexConfig) => Promise<GroundingRuntime | null>;
+  /** Receive optional grounding/freshness warnings without writing to stderr. */
   graphWarning?: (message: string) => void;
 }
 
-/** Run full drift detection across all scaffold files */
+/** Internal report used by graph-aware CLI surfaces; not re-exported at package root. */
+export type GraphAwareDriftReport = DriftReport & { graphStatus: GraphStatus };
+
+/** Internal test/adapter seams; deliberately excluded from the stable package API. */
+export interface GraphAwareRunDriftCheckOpts extends RunDriftCheckOpts {
+  readOnlyGroundingRuntimeLoader?: (
+    config: MexConfig,
+    options?: { loadRuntime?: boolean },
+  ) => Promise<ReadOnlyGroundingRuntimeResult>;
+}
+
+/** Run full drift detection through the stable package API. */
 export async function runDriftCheck(
   config: MexConfig,
   opts: RunDriftCheckOpts = {}
 ): Promise<DriftReport> {
+  const { graphStatus: _graphStatus, ...report } = await runDriftCheckWithGraphStatus(config, {
+    ...opts,
+    // Preserve the historical package API warning behavior. First-party
+    // graph-aware surfaces render status themselves and default to silence.
+    graphWarning: opts.graphWarning ?? console.warn,
+  });
+  return report;
+}
+
+/**
+ * Internal graph-aware check used by first-party CLI surfaces. Keeping this
+ * richer result out of `src/index.ts` prevents provisional graph contracts
+ * from changing the package-root `DriftReport` declaration.
+ */
+export async function runDriftCheckWithGraphStatus(
+  config: MexConfig,
+  opts: GraphAwareRunDriftCheckOpts = {},
+): Promise<GraphAwareDriftReport> {
   const { projectRoot, scaffoldRoot } = config;
+  const warnGraph = opts.graphWarning ?? (() => {});
 
   // Find all markdown files in scaffold
   const scaffoldFiles = findScaffoldFiles(projectRoot, scaffoldRoot, opts.scaffoldPatterns);
   const allClaims: Claim[] = [];
   const allIssues: DriftIssue[] = [];
   const checkerIssueCounts: Array<[string, number]> = [];
+  const pendingGroundingIssues: DriftIssue[] = [];
+  const pendingGroundingIssueCounts: Array<[string, number]> = [];
+  const usesInjectedGroundingRuntime = opts.groundingRuntimeLoader !== undefined;
   const hasGroundings = scaffoldFiles.some((filePath) => {
     const groundsTo = parseFrontmatter(filePath)?.grounds_to;
     if (Array.isArray(groundsTo) && groundsTo.length > 0) return true;
     try { return findMexAnchors(readFileSync(filePath, "utf-8")).length > 0; } catch { return false; }
   });
   const needsGroundingMigration = !hasGroundings && scaffoldFiles.some(isPopulatedGroundingCandidate);
+  const groundingRelevant = hasGroundings || needsGroundingMigration;
   let groundingRuntime: GroundingRuntime | null = null;
-  if (hasGroundings || needsGroundingMigration) {
+  let graphStatus: GraphStatus | undefined;
+  try {
     try {
-      groundingRuntime = await (opts.groundingRuntimeLoader ?? loadGroundingRuntime)(config);
-      if (!groundingRuntime && !graphUpgradeNudgeShown) {
-        graphUpgradeNudgeShown = true;
-        (opts.graphWarning ?? console.warn)(
-          "A code graph unlocks sharper drift detection. Run `mex graph`, then `mex graph ground`.",
+      const loaded = await (
+        opts.readOnlyGroundingRuntimeLoader ?? loadReadOnlyGroundingRuntime
+      )(config, { loadRuntime: opts.groundingRuntimeLoader ? false : groundingRelevant });
+      graphStatus = loaded.graphStatus;
+      groundingRuntime = loaded.runtime;
+
+      if (usesInjectedGroundingRuntime) {
+        // Preserve the historical injection seam while still inspecting graph
+        // status unconditionally. An explicit injected runtime remains
+        // authoritative for checker execution; production callers do not use
+        // this seam and remain gated on a fresh read-only graph snapshot.
+        const inspectedRuntime = groundingRuntime;
+        groundingRuntime = null;
+        inspectedRuntime?.close();
+        groundingRuntime = groundingRelevant
+          ? await opts.groundingRuntimeLoader!(config)
+          : null;
+      }
+
+      if (!usesInjectedGroundingRuntime && graphStatus.status !== "fresh" && groundingRuntime) {
+        const staleRuntime = groundingRuntime;
+        groundingRuntime = null;
+        staleRuntime.close();
+      }
+
+      if (!usesInjectedGroundingRuntime && groundingRelevant && graphStatus.status !== "fresh") {
+        warnGraph(
+          graphFreshnessWarning(graphStatus, groundingRelevant, needsGroundingMigration),
         );
+      } else if (groundingRelevant && !groundingRuntime && !graphUpgradeNudgeShown) {
+        graphUpgradeNudgeShown = true;
+        warnGraph(graphStatus.status === "fresh"
+          ? "A code graph unlocks sharper drift detection. Run `mex graph`, then `mex graph ground`."
+          : graphFreshnessWarning(graphStatus, groundingRelevant, needsGroundingMigration));
       } else if (groundingRuntime && needsGroundingMigration && !graphMigrationNudgeShown) {
         graphMigrationNudgeShown = true;
-        (opts.graphWarning ?? console.warn)(
+        warnGraph(
           "Existing scaffold has no code grounding. Run `mex graph ground` to connect it.",
         );
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      (opts.graphWarning ?? console.warn)(`Code graph unavailable; grounding checks skipped: ${message}`);
+      const groundingNote = groundingRelevant ? "; grounding checks skipped" : "";
+      if (graphStatus) {
+        warnGraph(`Code graph grounding unavailable${groundingNote}: ${message}`);
+      } else {
+        graphStatus = unavailableGraphStatus(message);
+        warnGraph(`Code graph status unavailable${groundingNote}: ${message}`);
+      }
     }
-  }
 
-  // Extract claims from all files
-  for (const filePath of scaffoldFiles) {
-    const source = toPosix(relative(projectRoot, filePath));
-    const claims = extractClaims(filePath, source);
-    allClaims.push(...claims);
-  }
+    // Extract claims from all files
+    for (const filePath of scaffoldFiles) {
+      const source = toPosix(relative(projectRoot, filePath));
+      const claims = extractClaims(filePath, source);
+      allClaims.push(...claims);
+    }
 
-  // Run checkers that work on individual files
-  for (const filePath of scaffoldFiles) {
-    const source = toPosix(relative(projectRoot, filePath));
+    // Run checkers that work on individual files
+    for (const filePath of scaffoldFiles) {
+      const source = toPosix(relative(projectRoot, filePath));
 
-    // Frontmatter edge check
-    const frontmatter = parseFrontmatter(filePath);
-    const edgeIssues = checkEdges(frontmatter, filePath, source, projectRoot, scaffoldRoot);
-    allIssues.push(...edgeIssues);
+      // Frontmatter edge check
+      const frontmatter = parseFrontmatter(filePath);
+      const edgeIssues = checkEdges(frontmatter, filePath, source, projectRoot, scaffoldRoot);
+      allIssues.push(...edgeIssues);
 
-    // Frontmatter completeness check
-    const frontmatterCompletenessIssues = checkFrontmatterCompleteness(frontmatter, source);
-    allIssues.push(...frontmatterCompletenessIssues);
+      // Frontmatter completeness check
+      const frontmatterCompletenessIssues = checkFrontmatterCompleteness(frontmatter, source);
+      allIssues.push(...frontmatterCompletenessIssues);
 
-    // Staleness check
-    const stalenessIssues = await checkStaleness(
-      source,
-      source,
-      projectRoot,
-      config.stalenessThresholds,
-      { lastUpdated: typeof frontmatter?.last_updated === "string" ? frontmatter.last_updated : undefined },
-    );
-    allIssues.push(...stalenessIssues);
-
-    checkerIssueCounts.push([`edges:${source}`, edgeIssues.length]);
-    checkerIssueCounts.push([`frontmatter-completeness:${source}`, frontmatterCompletenessIssues.length]);
-    checkerIssueCounts.push([`staleness:${source}`, stalenessIssues.length]);
-
-    if (groundingRuntime) {
-      const groundingIssues = groundingRuntime.checker(
-        frontmatter, filePath, source, projectRoot, scaffoldRoot,
+      // Staleness check
+      const stalenessIssues = await checkStaleness(
+        source,
+        source,
+        projectRoot,
+        config.stalenessThresholds,
+        { lastUpdated: typeof frontmatter?.last_updated === "string" ? frontmatter.last_updated : undefined },
       );
-      allIssues.push(...groundingIssues);
-      checkerIssueCounts.push([`grounding:${source}`, groundingIssues.length]);
+      allIssues.push(...stalenessIssues);
+
+      checkerIssueCounts.push([`edges:${source}`, edgeIssues.length]);
+      checkerIssueCounts.push([`frontmatter-completeness:${source}`, frontmatterCompletenessIssues.length]);
+      checkerIssueCounts.push([`staleness:${source}`, stalenessIssues.length]);
+
+      if (groundingRuntime) {
+        const groundingIssues = groundingRuntime.checker(
+          frontmatter, filePath, source, projectRoot, scaffoldRoot,
+        );
+        // A production immutable reader is guarded for the whole check, but a
+        // later file can still observe graph replacement after an earlier file
+        // produced findings. Hold every graph-derived finding until all files
+        // have been checked, then publish the batch only if the same snapshot
+        // remained valid throughout. The explicit legacy injection seam is
+        // caller-owned and preserves its historical behavior.
+        pendingGroundingIssues.push(...groundingIssues);
+        pendingGroundingIssueCounts.push([`grounding:${source}`, groundingIssues.length]);
+      }
     }
+
+    if (usesInjectedGroundingRuntime || graphStatus?.status === "fresh") {
+      allIssues.push(...pendingGroundingIssues);
+      checkerIssueCounts.push(...pendingGroundingIssueCounts);
+    }
+
+    if (groundingRelevant
+      && graphStatus.status !== "fresh"
+      && graphStatus.diagnostics.some((entry) => entry.code === "GRAPH_INDEX_READER_DATABASE_CHANGED")) {
+      warnGraph(graphFreshnessWarning(graphStatus, groundingRelevant, needsGroundingMigration));
+    }
+
+    // Run checkers that work on claims
+    // Only check paths in ROUTER.md — other scaffold files use backticks for
+    // non-path content (config values, IPs, annotation keys) that produces
+    // false MISSING_PATH errors. See https://github.com/mex-memory/mex/issues/79
+    const routerClaims = allClaims.filter((c) => basename(c.source) === "ROUTER.md");
+    const pathIssues = checkPaths(routerClaims, projectRoot, scaffoldRoot);
+    allIssues.push(...pathIssues);
+    checkerIssueCounts.push(["paths", pathIssues.length]);
+
+    const commandIssues = checkCommands(allClaims, projectRoot);
+    allIssues.push(...commandIssues);
+    checkerIssueCounts.push(["commands", commandIssues.length]);
+
+    const dependencyIssues = checkDependencies(allClaims, projectRoot);
+    allIssues.push(...dependencyIssues);
+    checkerIssueCounts.push(["dependencies", dependencyIssues.length]);
+
+    const crossFileIssues = checkCrossFile(allClaims);
+    allIssues.push(...crossFileIssues);
+    checkerIssueCounts.push(["cross-file", crossFileIssues.length]);
+
+    // Run structural checkers
+    const indexSyncIssues = checkIndexSync(projectRoot, scaffoldRoot);
+    allIssues.push(...indexSyncIssues);
+    checkerIssueCounts.push(["index-sync", indexSyncIssues.length]);
+
+    const stalePatternIssues = checkStalePatterns(projectRoot, scaffoldRoot);
+    allIssues.push(...stalePatternIssues);
+    checkerIssueCounts.push(["stale-pattern", stalePatternIssues.length]);
+
+    // Run coverage checkers (reality → scaffold direction)
+    const scriptCoverageIssues = checkScriptCoverage(scaffoldFiles, projectRoot);
+    allIssues.push(...scriptCoverageIssues);
+    checkerIssueCounts.push(["script-coverage", scriptCoverageIssues.length]);
+
+    const toolConfigSyncIssues = checkToolConfigSync(projectRoot);
+    allIssues.push(...toolConfigSyncIssues);
+    checkerIssueCounts.push(["tool-config-sync", toolConfigSyncIssues.length]);
+
+    const todoFixmeIssues = checkTodoFixme(scaffoldFiles, projectRoot);
+    allIssues.push(...todoFixmeIssues);
+    checkerIssueCounts.push(["todo-fixme", todoFixmeIssues.length]);
+
+    const brokenLinkIssues = checkBrokenLinks(scaffoldFiles, projectRoot, scaffoldRoot);
+    allIssues.push(...brokenLinkIssues);
+    checkerIssueCounts.push(["broken-link", brokenLinkIssues.length]);
+
+    const score = computeScore(allIssues);
+    const verboseLog = opts.verbose
+      ? buildVerboseLog(scaffoldFiles.length, allClaims, checkerIssueCounts)
+      : undefined;
+
+    return {
+      score,
+      issues: allIssues,
+      filesChecked: scaffoldFiles.length,
+      timestamp: new Date().toISOString(),
+      verboseLog,
+      graphStatus: graphStatus ?? unavailableGraphStatus("Graph status inspection returned no result."),
+    };
+  } finally {
+    groundingRuntime?.close();
   }
+}
 
-  // Run checkers that work on claims
-  // Only check paths in ROUTER.md — other scaffold files use backticks for
-  // non-path content (config values, IPs, annotation keys) that produces
-  // false MISSING_PATH errors. See https://github.com/mex-memory/mex/issues/79
-  const routerClaims = allClaims.filter((c) => basename(c.source) === "ROUTER.md");
-  const pathIssues = checkPaths(routerClaims, projectRoot, scaffoldRoot);
-  allIssues.push(...pathIssues);
-  checkerIssueCounts.push(["paths", pathIssues.length]);
+function graphFreshnessWarning(
+  status: GraphStatus,
+  groundingRelevant: boolean,
+  needsGroundingMigration: boolean,
+): string {
+  const groundingNote = groundingRelevant ? "; grounding checks skipped" : "";
+  const command = graphRemediationCommand(status);
+  const primary = status.diagnostics.find((entry) =>
+    entry.code === "GRAPH_INDEX_READER_DATABASE_CHANGED"
+  )
+    ?? status.diagnostics.find((entry) => entry.severity === "error")
+    ?? status.diagnostics.find((entry) => entry.severity === "warning")
+    ?? status.diagnostics[0];
+  const diagnostic = primary
+    ? ` ${primary.code}: ${primary.message.slice(0, 300)}`
+    : " Review graph diagnostics.";
+  const remediation = command ? ` Run \`${command}\`.` : diagnostic;
+  switch (status.status) {
+    case "missing":
+      return needsGroundingMigration && command
+        ? `Code graph is missing${groundingNote}. Run \`${command}\`, then \`mex graph ground\`.`
+        : `Code graph is missing${groundingNote}.${remediation}`;
+    case "stale":
+      return `Code graph is stale${groundingNote}.${remediation}`;
+    case "degraded":
+      return `Code graph is degraded${groundingNote}.${remediation}`;
+    case "rebuild_required":
+      return `Code graph requires a rebuild${groundingNote}.${remediation}`;
+    case "corrupt":
+      return `Code graph is corrupt${groundingNote}.${remediation}`;
+    case "fresh":
+      return "";
+  }
+}
 
-  const commandIssues = checkCommands(allClaims, projectRoot);
-  allIssues.push(...commandIssues);
-  checkerIssueCounts.push(["commands", commandIssues.length]);
+function graphRemediationCommand(status: GraphStatus): string | undefined {
+  return status.diagnostics
+    .flatMap((diagnostic) => diagnostic.remediation ?? [])
+    .find((action) => action.command)?.command;
+}
 
-  const dependencyIssues = checkDependencies(allClaims, projectRoot);
-  allIssues.push(...dependencyIssues);
-  checkerIssueCounts.push(["dependencies", dependencyIssues.length]);
-
-  const crossFileIssues = checkCrossFile(allClaims);
-  allIssues.push(...crossFileIssues);
-  checkerIssueCounts.push(["cross-file", crossFileIssues.length]);
-
-  // Run structural checkers
-  const indexSyncIssues = checkIndexSync(projectRoot, scaffoldRoot);
-  allIssues.push(...indexSyncIssues);
-  checkerIssueCounts.push(["index-sync", indexSyncIssues.length]);
-
-  const stalePatternIssues = checkStalePatterns(projectRoot, scaffoldRoot);
-  allIssues.push(...stalePatternIssues);
-  checkerIssueCounts.push(["stale-pattern", stalePatternIssues.length]);
-
-  // Run coverage checkers (reality → scaffold direction)
-  const scriptCoverageIssues = checkScriptCoverage(scaffoldFiles, projectRoot);
-  allIssues.push(...scriptCoverageIssues);
-  checkerIssueCounts.push(["script-coverage", scriptCoverageIssues.length]);
-
-  const toolConfigSyncIssues = checkToolConfigSync(projectRoot);
-  allIssues.push(...toolConfigSyncIssues);
-  checkerIssueCounts.push(["tool-config-sync", toolConfigSyncIssues.length]);
-
-  const todoFixmeIssues = checkTodoFixme(scaffoldFiles, projectRoot);
-  allIssues.push(...todoFixmeIssues);
-  checkerIssueCounts.push(["todo-fixme", todoFixmeIssues.length]);
-
-  const brokenLinkIssues = checkBrokenLinks(scaffoldFiles, projectRoot, scaffoldRoot);
-  allIssues.push(...brokenLinkIssues);
-  checkerIssueCounts.push(["broken-link", brokenLinkIssues.length]);
-
-  const score = computeScore(allIssues);
-  const verboseLog = opts.verbose
-    ? buildVerboseLog(scaffoldFiles.length, allClaims, checkerIssueCounts)
-    : undefined;
-
-  const report = {
-    score,
-    issues: allIssues,
-    filesChecked: scaffoldFiles.length,
-    timestamp: new Date().toISOString(),
-    verboseLog,
+function unavailableGraphStatus(message: string): GraphStatus {
+  const observedAt = new Date().toISOString();
+  return {
+    status: "degraded",
+    observedAt,
+    currentRepo: { branch: null, head: null, dirty: false, observedAt },
+    lastSuccessfulIndexAt: null,
+    indexedAt: null,
+    indexedBranch: null,
+    indexedHead: null,
+    schemaVersion: null,
+    extractorVersion: null,
+    grammarVersion: null,
+    parseHealth: {
+      total: 0,
+      ok: 0,
+      partial: 0,
+      failed: 0,
+      failedPaths: [],
+      failedPathsTruncated: false,
+    },
+    changes: {
+      total: 0,
+      added: [],
+      modified: [],
+      deleted: [],
+      truncated: false,
+      branchChanged: false,
+      manifestChanged: false,
+      configChanged: false,
+      grammarChanged: false,
+    },
+    diagnostics: [{
+      code: "GRAPH_STATUS_UNAVAILABLE",
+      severity: "warning",
+      message,
+    }],
   };
-  groundingRuntime?.close();
-  return report;
 }
 
 function isPopulatedGroundingCandidate(filePath: string): boolean {

--- a/src/graph/__tests__/cli-agent.test.ts
+++ b/src/graph/__tests__/cli-agent.test.ts
@@ -4,7 +4,7 @@
 // meta first, source-bearing Scope by default, summary last, budget truncation,
 // directed flow records, and narrow source-on-demand via `graph get`.
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -1301,6 +1301,26 @@ describe("runGraphScope", () => {
 });
 
 describe("runGraphGet", () => {
+  it("releases default sessions when contained manifest inspection fails", () => {
+    const external = mkdtempSync(join(tmpdir(), "mex-cli-agent-config-escape-"));
+    const configPath = join(root, "package.json");
+    writeFileSync(join(external, "package.json"), "{\"name\":\"outside\"}\n");
+    symlinkSync(join(external, "package.json"), configPath);
+    try {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const emitted: string[] = [];
+        runGraphGet([idOf("run")], root, { write: (line) => emitted.push(line) });
+        expect(emitted.map((line) => JSON.parse(line))).toContainEqual(expect.objectContaining({
+          type: "error",
+          code: "GRAPH_SOURCE_STAGING_FAILED",
+        }));
+      }
+    } finally {
+      unlinkSync(configPath);
+      rmSync(external, { recursive: true, force: true });
+    }
+  });
+
   it("returns capped source for a known id and NODE_NOT_FOUND for an unknown one", () => {
     const records = capture(() => runGraphGet([idOf("run"), "function:missing"], root, deps, {}));
     expect(records.some((r) => r.type === "source" && JSON.stringify(r).includes("helper(41)"))).toBe(true);

--- a/src/graph/__tests__/cli-agent.test.ts
+++ b/src/graph/__tests__/cli-agent.test.ts
@@ -1301,7 +1301,7 @@ describe("runGraphScope", () => {
 });
 
 describe("runGraphGet", () => {
-  it("releases default sessions when contained manifest inspection fails", () => {
+  it("releases default sessions when production preflight inspection fails", async () => {
     const external = mkdtempSync(join(tmpdir(), "mex-cli-agent-config-escape-"));
     const configPath = join(root, "package.json");
     writeFileSync(join(external, "package.json"), "{\"name\":\"outside\"}\n");
@@ -1309,10 +1309,10 @@ describe("runGraphGet", () => {
     try {
       for (let attempt = 0; attempt < 2; attempt++) {
         const emitted: string[] = [];
-        runGraphGet([idOf("run")], root, { write: (line) => emitted.push(line) });
+        await runGraphGet([idOf("run")], root, { write: (line) => emitted.push(line) });
         expect(emitted.map((line) => JSON.parse(line))).toContainEqual(expect.objectContaining({
           type: "error",
-          code: "GRAPH_SOURCE_STAGING_FAILED",
+          code: "GRAPH_UNAVAILABLE",
         }));
       }
     } finally {

--- a/src/graph/__tests__/cli-graph.test.ts
+++ b/src/graph/__tests__/cli-graph.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { GraphSourceChanges } from "../../team/contracts/graph.js";
+import { formatGraphSourceChanges } from "../cli-graph.js";
+
+function changes(overrides: Partial<GraphSourceChanges> = {}): GraphSourceChanges {
+  return {
+    total: 0,
+    added: [],
+    modified: [],
+    deleted: [],
+    truncated: false,
+    branchChanged: false,
+    manifestChanged: false,
+    configChanged: false,
+    grammarChanged: false,
+    ...overrides,
+  };
+}
+
+describe("graph CLI status formatting", () => {
+  it("labels bounded path arrays as shown instead of an exact breakdown", () => {
+    const rendered = formatGraphSourceChanges(changes({
+      total: 125,
+      added: ["src/a.ts"],
+      modified: ["src/b.ts", "src/c.ts"],
+      truncated: true,
+    }));
+
+    expect(rendered).toBe(
+      "Sources: 125 changed (1 added shown, 2 modified shown, 0 deleted shown; 122 paths omitted)",
+    );
+    expect(rendered).not.toContain("1 added, 2 modified, 0 deleted");
+  });
+});

--- a/src/graph/__tests__/compiler-extraction.test.ts
+++ b/src/graph/__tests__/compiler-extraction.test.ts
@@ -316,4 +316,22 @@ describe("TypeScript compiler extraction", () => {
     expect(tokens.get(alpha.id)).not.toContain("alpha");
     expect(tokens.get(alpha.id)).not.toContain("one");
   });
+
+  it("filters source/config-policy misses across more than 1,024 module probes", () => {
+    const imports = Array.from(
+      { length: 1_100 },
+      (_, index) => `import {} from './missing-${index}';`,
+    );
+    const root = project({
+      "src/many-imports.ts": [...imports, "export const complete = true;", ""].join("\n"),
+    });
+    const result = buildTypeScriptExtraction(root, ["src/many-imports.ts"]);
+    const missing = result.semanticInputs.filter((input) => input.contentHash === null);
+
+    // Every unresolved import probes at least one supported source extension.
+    // Those future files are already covered by source-corpus freshness, so
+    // they must not consume the bounded non-corpus semantic provenance budget.
+    expect(missing).toHaveLength(0);
+    expect(result.files).toHaveLength(1);
+  }, 15_000);
 });

--- a/src/graph/__tests__/graph-v2-integrity.test.ts
+++ b/src/graph/__tests__/graph-v2-integrity.test.ts
@@ -588,6 +588,7 @@ describe("graph construction integration", () => {
     beforeDb.close();
 
     expect(await engine.sync([])).toMatchObject({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0 });
+    engine.close();
     writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
       compilerOptions: { target: "ES2022", module: "NodeNext", moduleResolution: "NodeNext" },
       include: ["src/**/*.ts"],
@@ -597,8 +598,9 @@ describe("graph construction integration", () => {
     expect(staleOutput.map((line) => JSON.parse(line))).toEqual([
       expect.objectContaining({ code: "GRAPH_REBUILD_REQUIRED", recoveryCommand: "mex graph" }),
     ]);
-    expect(await engine.sync(["tsconfig.json"])).toMatchObject({ filesIndexed: 1 });
-    engine.close();
+    const refreshEngine = createGraphEngine({ rootDir: root });
+    expect(await refreshEngine.sync(["tsconfig.json"])).toMatchObject({ filesIndexed: 1 });
+    refreshEngine.close();
 
     const afterDb = openGraphDatabase(dbPath);
     const after = new GraphStore(afterDb);

--- a/src/graph/__tests__/graph-v2-integrity.test.ts
+++ b/src/graph/__tests__/graph-v2-integrity.test.ts
@@ -1,10 +1,16 @@
+import { createHash } from "node:crypto";
 import {
-  chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync,
+  chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync,
+  unlinkSync, writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { createGraphEngine, GraphSourceStagingError } from "../engine-impl.js";
+import {
+  createGraphEngine,
+  createGraphEngineFromOpenDatabase,
+  GraphSourceStagingError,
+} from "../engine-impl.js";
 import {
   DB_SCHEMA_VERSION,
   graphRequiresRebuild,
@@ -125,6 +131,23 @@ function semanticSnapshot(path: string): Record<string, unknown[]> {
   }
 }
 
+function directorySnapshot(path: string): Array<Record<string, string>> {
+  return readdirSync(path).sort().map((name) => {
+    const filePath = join(path, name);
+    const stat = statSync(filePath, { bigint: true });
+    return {
+      name,
+      kind: stat.isFile() ? "file" : stat.isDirectory() ? "directory" : "other",
+      size: stat.size.toString(),
+      mtimeNs: stat.mtimeNs.toString(),
+      ctimeNs: stat.ctimeNs.toString(),
+      digest: stat.isFile()
+        ? createHash("sha256").update(readFileSync(filePath)).digest("hex")
+        : "",
+    };
+  });
+}
+
 describe("graph schema v2 migration and storage", () => {
   it("migrates v1 additively, preserves grounding, and requires a full rebuild", () => {
     const root = temporaryRoot("mex-schema-v2-");
@@ -203,6 +226,109 @@ describe("graph schema v2 migration and storage", () => {
     } finally {
       chmodSync(graphDir, 0o755);
       chmodSync(dbPath, 0o644);
+    }
+  });
+
+  it("serves immutable graph readers without changing any graph-directory file", async () => {
+    const root = temporaryRoot("mex-immutable-reader-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "stable.ts"),
+      "export function immutableNeedle(): number { return 1; }\n");
+    const graphDir = join(root, ".mex");
+    const dbPath = join(graphDir, "graph.db");
+    const builder = createGraphEngine({ rootDir: root });
+    await builder.build();
+    builder.close();
+    for (const suffix of ["-wal", "-shm"]) {
+      const sidecar = `${dbPath}${suffix}`;
+      if (existsSync(sidecar)) unlinkSync(sidecar);
+    }
+    writeFileSync(join(graphDir, "reader-sentinel"), "unchanged\n");
+    const before = directorySnapshot(graphDir);
+
+    const db = openGraphDatabase(dbPath, { readOnly: true, immutable: true });
+    expect(rows(db, "SELECT COUNT(*) AS count FROM nodes")).toEqual([{ count: 2 }]);
+    db.close();
+    const graphDb = openGraphDatabase(dbPath, { readOnly: true, immutable: true });
+    const graph = createGraphEngineFromOpenDatabase({ rootDir: root, dbPath }, graphDb);
+    expect(graph.searchNodes("immutableNeedle")).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: "immutableNeedle" }),
+    ]));
+    graph.close();
+
+    expect(directorySnapshot(graphDir)).toEqual(before);
+    expect(existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(existsSync(`${dbPath}-shm`)).toBe(false);
+  });
+
+  it("makes immutable mode explicit and validates snapshot compatibility", () => {
+    const root = temporaryRoot("mex-immutable-validation-");
+    const missing = join(root, "missing.db");
+    expect(() => openGraphDatabase(missing, { immutable: true })).toThrow(
+      "Immutable graph access requires readOnly: true.",
+    );
+    expect(() => createGraphEngine({
+      rootDir: root,
+      dbPath: missing,
+      immutable: true,
+    } as Parameters<typeof createGraphEngine>[0])).toThrow(
+      "Immutable graph access is internal to the validated grounding runtime.",
+    );
+
+    const legacyPath = join(root, "legacy.db");
+    createV1Database(legacyPath);
+    expect(() => openGraphDatabase(legacyPath, { readOnly: true, immutable: true }))
+      .toThrow(GraphRebuildRequiredError);
+
+    const rebuildPath = join(root, "rebuild.db");
+    const rebuild = openGraphDatabase(rebuildPath);
+    rebuild.prepare(
+      "INSERT INTO project_metadata (key, value, updated_at) VALUES ('rebuild_required', '1', ?)",
+    ).run(Date.now());
+    rebuild.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    rebuild.close();
+    expect(() => openGraphDatabase(rebuildPath, { readOnly: true, immutable: true }))
+      .toThrow(GraphRebuildRequiredError);
+  });
+
+  it("does not consume or mutate a non-empty WAL through immutable readers", async () => {
+    const root = temporaryRoot("mex-immutable-wal-");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "stable.ts"),
+      "export function immutableWalNeedle(): number { return 1; }\n");
+    const dbPath = join(root, ".mex", "graph.db");
+    const builder = createGraphEngine({ rootDir: root });
+    await builder.build();
+    builder.close();
+
+    const writer = openGraphDatabase(dbPath);
+    try {
+      writer.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+      writer.prepare(
+        "INSERT INTO project_metadata (key, value, updated_at) VALUES ('wal_only_marker', 'visible-in-wal', ?)",
+      ).run(Date.now());
+      expect(writer.prepare(
+        "SELECT value FROM project_metadata WHERE key = 'wal_only_marker'",
+      ).get()).toEqual({ value: "visible-in-wal" });
+      expect(statSync(`${dbPath}-wal`).size).toBeGreaterThan(0);
+      const before = directorySnapshot(join(root, ".mex"));
+
+      const immutable = openGraphDatabase(dbPath, { readOnly: true, immutable: true });
+      expect(immutable.prepare(
+        "SELECT value FROM project_metadata WHERE key = 'wal_only_marker'",
+      ).get()).toBeUndefined();
+      immutable.close();
+      const graphDb = openGraphDatabase(dbPath, { readOnly: true, immutable: true });
+      const graph = createGraphEngineFromOpenDatabase({ rootDir: root, dbPath }, graphDb);
+      expect(graph.searchNodes("immutableWalNeedle")).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: "immutableWalNeedle" }),
+      ]));
+      graph.close();
+
+      expect(directorySnapshot(join(root, ".mex"))).toEqual(before);
+      expect(statSync(`${dbPath}-wal`).size).toBeGreaterThan(0);
+    } finally {
+      writer.close();
     }
   });
 
@@ -364,7 +490,7 @@ describe("graph construction integration", () => {
       alias_id: oldFingerprintId, match_method: "fingerprint",
     });
     fingerprintDb.close();
-  });
+  }, 15_000);
 
   it("does not alias a deleted symbol to a newly added differently named signature match", async () => {
     const root = temporaryRoot("mex-signature-name-guard-");
@@ -491,9 +617,14 @@ describe("graph construction integration", () => {
     const prior = engine.searchNodes("stableNeedle").find((entry) => entry.name === "stableNeedle")!;
     writeFileSync(source, "}\n");
 
-    const result = await engine.sync(["src/stable.ts"]);
-    expect(result).toMatchObject({ filesIndexed: 0, nodesCreated: 0, edgesCreated: 0 });
-    expect(result.health?.failed).toBe(1);
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: [expect.objectContaining({
+        filePath: "src/stable.ts",
+        operation: "parse",
+        code: "GRAPH_SOURCE_PARSE_FAILED",
+      })],
+    });
     expect(engine.getNode(prior.id)).toMatchObject({ id: prior.id, bodyHash: prior.bodyHash });
     engine.close();
   });

--- a/src/graph/__tests__/maintenance.test.ts
+++ b/src/graph/__tests__/maintenance.test.ts
@@ -1,0 +1,641 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GraphMaintenanceOptions } from "../../team/contracts/graph.js";
+import { openSqlite } from "../db/sqlite.js";
+import { createGraphEngine } from "../engine-impl.js";
+import {
+  acquireGraphMaintenanceLease,
+  GraphMaintenanceError,
+  rebuildGraph,
+  refreshGraph,
+} from "../maintenance.js";
+import { inspectGraphStatus } from "../status.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function temporaryRoot(prefix = "mex-graph-maintenance-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function source(root: string, path: string, contents: string): void {
+  const absolute = join(root, path);
+  mkdirSync(join(absolute, ".."), { recursive: true });
+  writeFileSync(absolute, contents);
+}
+
+async function buildBaseline(root: string): Promise<string> {
+  const engine = createGraphEngine({ rootDir: root });
+  try {
+    await engine.build();
+  } finally {
+    engine.close();
+  }
+  return join(root, ".mex", "graph.db");
+}
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function ownedArtifacts(root: string): string[] {
+  const mexDir = join(root, ".mex");
+  return readdirSync(mexDir)
+    .filter((name) => name.startsWith("graph.db.candidate-")
+      || name.startsWith("graph.db.rollback-")
+      || name === "graph.db.lock"
+      || name === "graph.db.lock.gate")
+    .sort();
+}
+
+function git(root: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  }).trim();
+}
+
+describe("graph maintenance", () => {
+  it("rebuilds a missing graph through a validated candidate without leftovers", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = true;\n");
+    const phases: string[] = [];
+
+    const result = await rebuildGraph(root, {
+      onProgress: (progress) => phases.push(progress.phase),
+    });
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.filesIndexed).toBe(1);
+    expect(phases).toEqual(["discover", "stage", "validate", "publish"]);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("restores a missing index when first publication fails post-validation", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = true;\n");
+    const dbPath = join(root, ".mex", "graph.db");
+    const options = {
+      __internal: {
+        afterPublish(livePath: string) {
+          writeFileSync(livePath, "corrupt after first atomic publication");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(rebuildGraph(root, options)).rejects.toBeInstanceOf(GraphMaintenanceError);
+
+    expect(() => readFileSync(dbPath)).toThrow();
+    expect((await inspectGraphStatus({ projectRoot: root })).status).toBe("missing");
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("refreshes edited source through sync and republishes branch provenance", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    git(root, "config", "user.name", "Maintenance Test");
+    git(root, "config", "user.email", "maintenance@example.invalid");
+    source(root, ".gitignore", ".mex/graph.db*\n");
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "fixture");
+    await buildBaseline(root);
+    git(root, "switch", "-qc", "feature/refresh");
+    source(root, "src/service.ts", "export const service = 2;\n");
+
+    const result = await refreshGraph(root);
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.status.indexedBranch).toBe("feature/refresh");
+    expect(result.status.changes.total).toBe(0);
+    expect(ownedArtifacts(root)).toEqual([]);
+  }, 15_000);
+
+  it("rejects a candidate replaced after validation and leaves live bytes exact", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const before = sha256(dbPath);
+    const options = {
+      __internal: {
+        afterCandidateValidated(candidatePath: string) {
+          writeFileSync(candidatePath, "replacement candidate");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_RACE",
+    });
+
+    expect(sha256(dbPath)).toBe(before);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("does not overwrite a live graph changed at the final revalidation boundary", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const externalBytes = Buffer.from("externally replaced graph bytes\n");
+    const options = {
+      __internal: {
+        beforeLiveRevalidation() {
+          writeFileSync(dbPath, externalBytes);
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_RACE",
+    });
+
+    expect(readFileSync(dbPath)).toEqual(externalBytes);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("aborts on a nonempty candidate WAL instead of unlinking it into publication", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const before = sha256(dbPath);
+    const options = {
+      __internal: {
+        afterCandidateValidated(candidatePath: string) {
+          writeFileSync(`${candidatePath}-wal`, "authoritative candidate WAL bytes");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_LOCKED",
+    });
+
+    expect(sha256(dbPath)).toBe(before);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("preserves the prior snapshot after a failed parse or cancellation", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export function service(): number { return 1; }\n");
+    const dbPath = await buildBaseline(root);
+    const before = sha256(dbPath);
+    source(root, "src/service.ts", "}\n");
+
+    await expect(refreshGraph(root)).rejects.toMatchObject({ name: "GraphSourceStagingError" });
+    expect(sha256(dbPath)).toBe(before);
+
+    source(root, "src/service.ts", "export function service(): number { return 2; }\n");
+    const controller = new AbortController();
+    controller.abort();
+    await expect(refreshGraph(root, { signal: controller.signal })).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_CANCELLED",
+    });
+    expect(sha256(dbPath)).toBe(before);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("rolls back exact live bytes when post-publication validation fails", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    const before = sha256(dbPath);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const options = {
+      __internal: {
+        afterPublish(livePath: string) {
+          writeFileSync(livePath, "corrupt after atomic publication");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toBeInstanceOf(GraphMaintenanceError);
+
+    expect(sha256(dbPath)).toBe(before);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("retains the only exact prior copy when automatic rollback itself fails", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    const priorBytes = readFileSync(dbPath);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const options = {
+      __internal: {
+        afterPublish(livePath: string) {
+          writeFileSync(livePath, "failed published candidate");
+        },
+        beforeRollbackRestore() {
+          throw new Error("injected rollback rename failure");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    let failure: GraphMaintenanceError | null = null;
+    try {
+      await refreshGraph(root, options);
+    } catch (error) {
+      failure = error as GraphMaintenanceError;
+    }
+
+    expect(failure).toMatchObject({
+      code: "GRAPH_PUBLICATION_FAILED",
+      recoveryPath: expect.stringMatching(/^\.mex\/graph\.db\.recovery-/u),
+    });
+    expect(readFileSync(join(root, failure!.recoveryPath!))).toEqual(priorBytes);
+    expect(failure!.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_RECOVERY_RETAINED",
+      path: failure!.recoveryPath,
+    }));
+  });
+
+  it("does not overwrite a replacement live database while attempting rollback", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    const priorBytes = readFileSync(dbPath);
+    const replacementBytes = Buffer.from("independent replacement live graph\n");
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const options = {
+      __internal: {
+        afterPublish(livePath: string) {
+          const replacementPath = join(root, ".mex", "independent-replacement.tmp");
+          writeFileSync(replacementPath, replacementBytes);
+          renameSync(replacementPath, livePath);
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    let failure: GraphMaintenanceError | null = null;
+    try {
+      await refreshGraph(root, options);
+    } catch (error) {
+      failure = error as GraphMaintenanceError;
+    }
+
+    expect(failure).toMatchObject({
+      code: "GRAPH_PUBLICATION_FAILED",
+      recoveryPath: expect.stringMatching(/^\.mex\/graph\.db\.recovery-/u),
+    });
+    expect(readFileSync(dbPath)).toEqual(replacementBytes);
+    expect(readFileSync(join(root, failure!.recoveryPath!))).toEqual(priorBytes);
+  });
+
+  it("fails closed when a callback retargets the bound .mex directory", async () => {
+    const root = temporaryRoot();
+    const external = temporaryRoot("mex-graph-maintenance-external-");
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const dbPath = await buildBaseline(root);
+    const priorBytes = readFileSync(dbPath);
+    source(root, "src/service.ts", "export const service = 2;\n");
+    const displacedMex = join(root, ".mex-bound-original");
+    const externalSentinel = Buffer.from("must not be deleted by stale cleanup\n");
+    const options = {
+      __internal: {
+        afterCandidateValidated(candidatePath: string) {
+          renameSync(join(root, ".mex"), displacedMex);
+          writeFileSync(join(external, basename(candidatePath)), externalSentinel);
+          symlinkSync(external, join(root, ".mex"), "dir");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_PATH_UNSAFE",
+    });
+
+    expect(readFileSync(join(displacedMex, "graph.db"))).toEqual(priorBytes);
+    const externalEntries = readdirSync(external);
+    expect(externalEntries).toHaveLength(1);
+    expect(readFileSync(join(external, externalEntries[0]!))).toEqual(externalSentinel);
+  });
+
+  it("revalidates the bound .mex directory immediately before creating a candidate database", async () => {
+    const root = temporaryRoot();
+    const external = temporaryRoot("mex-graph-maintenance-open-external-");
+    source(root, "src/service.ts", "export const service = 1;\n");
+    const displacedMex = join(root, ".mex-bound-before-open");
+    const externalSentinel = Buffer.from("candidate path must remain untouched\n");
+    const options = {
+      __internal: {
+        beforeCandidateDatabaseOpen(candidatePath: string) {
+          renameSync(join(root, ".mex"), displacedMex);
+          writeFileSync(join(external, basename(candidatePath)), externalSentinel);
+          symlinkSync(external, join(root, ".mex"), "dir");
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(rebuildGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_PATH_UNSAFE",
+    });
+
+    const externalEntries = readdirSync(external);
+    expect(externalEntries).toHaveLength(1);
+    expect(readFileSync(join(external, externalEntries[0]!))).toEqual(externalSentinel);
+    expect(readdirSync(displacedMex)).not.toContain(expect.stringMatching(/^graph\.db\.candidate-/u));
+  });
+
+  it("retains exact corrupt bytes in ignored recovery after a successful rebuild", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const recovered = true;\n");
+    mkdirSync(join(root, ".mex"), { recursive: true });
+    const dbPath = join(root, ".mex", "graph.db");
+    const corrupt = Buffer.from("not a sqlite graph\n");
+    writeFileSync(dbPath, corrupt);
+
+    const result = await rebuildGraph(root);
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.recoveryPath).toMatch(/^\.mex\/graph\.db\.recovery-/u);
+    expect(readFileSync(join(root, result.recoveryPath!))).toEqual(corrupt);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_RECOVERY_RETAINED",
+    }));
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("clones an older readable index to preserve grounding continuity", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const migrated = true;\n");
+    const dbPath = await buildBaseline(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.prepare(
+        `INSERT INTO _mex_grounded_source
+         (scaffold_file, node_id, source, body_hash, fingerprint) VALUES (?, ?, ?, ?, ?)`,
+      ).run(".mex/context/architecture.md", "legacy-node", "legacy body", "hash", "fingerprint");
+      db.exec("DELETE FROM schema_versions");
+      db.prepare(
+        "INSERT INTO schema_versions(version, applied_at, description) VALUES(1, ?, ?)",
+      ).run(Date.now(), "legacy fixture");
+    } finally {
+      db.close();
+    }
+    const priorBytes = readFileSync(dbPath);
+
+    const result = await rebuildGraph(root);
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.recoveryPath).toMatch(/^\.mex\/graph\.db\.recovery-/u);
+    expect(readFileSync(join(root, result.recoveryPath!))).toEqual(priorBytes);
+    const rebuilt = openSqlite(dbPath, { readOnly: true, immutable: true });
+    try {
+      expect(rebuilt.prepare(
+        "SELECT source FROM _mex_grounded_source WHERE scaffold_file = ? AND node_id = ?",
+      ).get(".mex/context/architecture.md", "legacy-node")).toEqual({ source: "legacy body" });
+    } finally {
+      rebuilt.close();
+    }
+  });
+
+  it("falls back from a malformed older clone to a fresh candidate and retains recovery", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const fallbackBuilt = true;\n");
+    const dbPath = await buildBaseline(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DROP TABLE nodes");
+      db.exec("DELETE FROM schema_versions");
+      db.prepare(
+        "INSERT INTO schema_versions(version, applied_at, description) VALUES(1, ?, ?)",
+      ).run(Date.now(), "malformed legacy fixture");
+    } finally {
+      db.close();
+    }
+    const priorBytes = readFileSync(dbPath);
+
+    const result = await rebuildGraph(root);
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.recoveryPath).toMatch(/^\.mex\/graph\.db\.recovery-/u);
+    expect(readFileSync(join(root, result.recoveryPath!))).toEqual(priorBytes);
+    expect(result.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_CONTINUITY_FALLBACK",
+    }));
+  });
+
+  it("does not let an older-schema fallback hide a current source parse failure", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const previouslyValid = true;\n");
+    const dbPath = await buildBaseline(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DROP TABLE nodes");
+      db.exec("DELETE FROM schema_versions");
+      db.prepare(
+        "INSERT INTO schema_versions(version, applied_at, description) VALUES(1, ?, ?)",
+      ).run(Date.now(), "malformed legacy fixture");
+    } finally {
+      db.close();
+    }
+    const priorBytes = readFileSync(dbPath);
+    source(root, "src/service.ts", "}\n");
+
+    await expect(rebuildGraph(root)).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      code: "GRAPH_SOURCE_STAGING_FAILED",
+    });
+
+    expect(readFileSync(dbPath)).toEqual(priorBytes);
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("starts fresh for a newer index while retaining its exact recovery bytes", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const downgradedSafely = true;\n");
+    const dbPath = await buildBaseline(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.prepare(
+        `INSERT INTO _mex_grounded_source
+         (scaffold_file, node_id, source, body_hash, fingerprint) VALUES (?, ?, ?, ?, ?)`,
+      ).run(".mex/context/architecture.md", "future-node", "future body", "hash", "fingerprint");
+      db.prepare(
+        "INSERT INTO schema_versions(version, applied_at, description) VALUES(3, ?, ?)",
+      ).run(Date.now(), "future fixture");
+    } finally {
+      db.close();
+    }
+    const priorBytes = readFileSync(dbPath);
+
+    const result = await rebuildGraph(root);
+
+    expect(result.status.status).toBe("fresh");
+    expect(result.recoveryPath).toMatch(/^\.mex\/graph\.db\.recovery-/u);
+    expect(readFileSync(join(root, result.recoveryPath!))).toEqual(priorBytes);
+    const rebuilt = openSqlite(dbPath, { readOnly: true, immutable: true });
+    try {
+      expect(rebuilt.prepare("SELECT COUNT(*) AS count FROM _mex_grounded_source").get())
+        .toEqual({ count: 0 });
+    } finally {
+      rebuilt.close();
+    }
+  });
+
+  it("reclaims a well-formed owner-token lock only after its process is dead", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    await buildBaseline(root);
+    writeFileSync(join(root, ".mex", "graph.db.lock"), `${JSON.stringify({
+      pid: 2_147_483_647,
+      token: "a".repeat(48),
+      startedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`);
+    let contenderCode: string | null = null;
+    const options = {
+      __internal: {
+        beforeDeadLockReclaim() {
+          try {
+            const contender = acquireGraphMaintenanceLease(root, "refresh");
+            contender.release();
+          } catch (error) {
+            contenderCode = (error as { code?: string }).code ?? null;
+          }
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    const result = await refreshGraph(root, options);
+
+    expect(result.status.status).toBe("fresh");
+    expect(contenderCode).toBe("GRAPH_MAINTENANCE_LOCKED");
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("does not reclaim a dead main lock after losing the acquisition gate", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    await buildBaseline(root);
+    const lockPath = join(root, ".mex", "graph.db.lock");
+    const gatePath = join(root, ".mex", "graph.db.lock.gate");
+    const staleLock = `${JSON.stringify({
+      pid: 2_147_483_647,
+      token: "d".repeat(48),
+      startedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`;
+    const replacementGate = `${JSON.stringify({
+      pid: process.pid,
+      token: "e".repeat(48),
+      startedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`;
+    writeFileSync(lockPath, staleLock);
+    const options = {
+      __internal: {
+        beforeDeadLockReclaim() {
+          unlinkSync(gatePath);
+          writeFileSync(gatePath, replacementGate);
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_RACE",
+    });
+
+    expect(readFileSync(lockPath, "utf8")).toBe(staleLock);
+    expect(readFileSync(gatePath, "utf8")).toBe(replacementGate);
+  });
+
+  it("reports a crash-stale acquisition gate with an explicit recovery path", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    await buildBaseline(root);
+    const gatePath = join(root, ".mex", "graph.db.lock.gate");
+    writeFileSync(gatePath, `${JSON.stringify({
+      pid: 2_147_483_647,
+      token: "b".repeat(48),
+      startedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`);
+
+    await expect(refreshGraph(root)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_GATE_STALE",
+      diagnostics: [expect.objectContaining({
+        code: "GRAPH_MAINTENANCE_GATE_STALE",
+        path: ".mex/graph.db.lock.gate",
+      })],
+    });
+
+    // Explicit operator recovery is token-safe: maintenance never guesses and
+    // never unlinks a possibly active acquisition gate on its own.
+    unlinkSync(gatePath);
+    expect((await refreshGraph(root)).status.status).toBe("fresh");
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+
+  it("does not create the main lock after the acquisition gate loses ownership", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    await buildBaseline(root);
+    const replacement = `${JSON.stringify({
+      pid: process.pid,
+      token: "c".repeat(48),
+      startedAt: "2026-01-01T00:00:00.000Z",
+    })}\n`;
+    const options = {
+      __internal: {
+        afterLockGateAcquired(gatePath: string) {
+          unlinkSync(gatePath);
+          writeFileSync(gatePath, replacement);
+        },
+      },
+    } as GraphMaintenanceOptions;
+
+    await expect(refreshGraph(root, options)).rejects.toMatchObject({
+      code: "GRAPH_MAINTENANCE_RACE",
+    });
+
+    expect(readFileSync(join(root, ".mex", "graph.db.lock.gate"), "utf8")).toBe(replacement);
+    expect(readdirSync(join(root, ".mex"))).not.toContain("graph.db.lock");
+    unlinkSync(join(root, ".mex", "graph.db.lock.gate"));
+  });
+
+  it("holds one owner-token lease across refresh and subsequent writable work", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = 1;\n");
+    await buildBaseline(root);
+    const lease = acquireGraphMaintenanceLease(root, "refresh");
+    try {
+      await lease.refresh();
+      await expect(refreshGraph(root)).rejects.toMatchObject({
+        code: "GRAPH_MAINTENANCE_LOCKED",
+      });
+      const db = openSqlite(lease.databasePath);
+      try {
+        db.prepare(
+          "INSERT INTO project_metadata(key, value, updated_at) VALUES(?, ?, ?)",
+        ).run("lease_test", "held", Date.now());
+      } finally {
+        db.close();
+      }
+    } finally {
+      lease.release();
+    }
+
+    expect((await inspectGraphStatus({ projectRoot: root })).status).toBe("fresh");
+    expect(ownedArtifacts(root)).toEqual([]);
+  });
+});

--- a/src/graph/__tests__/snapshot.test.ts
+++ b/src/graph/__tests__/snapshot.test.ts
@@ -1,0 +1,751 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { DB_SCHEMA_VERSION } from "../db/database.js";
+import { openSqlite } from "../db/sqlite.js";
+import { createGraphEngine, GraphSourceStagingError } from "../engine-impl.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS,
+  computeSourceCorpusDigest,
+  createGraphSnapshot,
+  parseGraphSnapshot,
+  serializeGraphSnapshot,
+} from "../snapshot.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function temporaryRoot(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function metadata(dbPath: string, key: string): string | null {
+  const db = openSqlite(dbPath, { readOnly: true });
+  try {
+    const row = db.prepare("SELECT value FROM project_metadata WHERE key = ?").get(key) as
+      | { value: string }
+      | undefined;
+    return row?.value ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+function initializeGit(root: string): string {
+  const run = (args: string[]): string => execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  run(["init", "-b", "snapshot-test"]);
+  run(["config", "user.name", "Snapshot Test"]);
+  run(["config", "user.email", "snapshot@example.test"]);
+  run(["add", "src/stable.ts"]);
+  run(["commit", "-m", "fixture"]);
+  return run(["rev-parse", "HEAD"]);
+}
+
+describe("graph snapshot provenance", () => {
+  it("writes one canonical snapshot with Git and deterministic corpus provenance", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const source = "export function stableSnapshot(): number { return 7; }\n";
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, source);
+    const head = initializeGit(root);
+    const dbPath = join(root, "graph.db");
+
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    engine.close();
+
+    const raw = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    const snapshot = parseGraphSnapshot(raw);
+    expect(snapshot).not.toBeNull();
+    expect(raw).toBe(serializeGraphSnapshot(snapshot!));
+    const contentHash = createHash("sha256").update(readFileSync(sourcePath)).digest("hex");
+    expect(snapshot).toMatchObject({
+      version: 1,
+      indexedBranch: "snapshot-test",
+      indexedHead: head,
+      schemaVersion: DB_SCHEMA_VERSION,
+      compilerVersion: "5.9.3",
+      extractorVersion: expect.stringContaining("typescript-5.9"),
+      resolverVersion: "compiler-first-v2",
+      sourceCorpusDigest: computeSourceCorpusDigest([{ path: "src/stable.ts", contentHash }]),
+      sourceCount: 1,
+      parseHealth: { total: 1, ok: 1, partial: 0, failed: 0 },
+    });
+    expect(snapshot!.indexedAt).toBe(snapshot!.lastSuccessfulIndexAt);
+    expect(new Date(snapshot!.indexedAt).toISOString()).toBe(snapshot!.indexedAt);
+    expect(snapshot!.manifestHash).toBe(metadata(dbPath, "manifest_hash"));
+    expect(snapshot!.configHash).toBe(metadata(dbPath, "config_hash"));
+    expect(snapshot!.grammarHash).toBe(metadata(dbPath, "grammar_hash"));
+  }, 15_000);
+
+  it("leaves the successful snapshot unchanged after staging and changed-parse failures", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-failure-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    let failRead = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      sourceFileAccess: {
+        read: (absolutePath) => {
+          if (failRead && absolutePath === sourcePath) {
+            throw Object.assign(new Error("injected staging failure"), { code: "EACCES" });
+          }
+          return readFileSync(absolutePath, "utf8");
+        },
+      },
+    });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    expect(parseGraphSnapshot(successfulSnapshot)).toMatchObject({
+      indexedBranch: null,
+      indexedHead: null,
+    });
+
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+    failRead = true;
+    await expect(engine.sync(["src/stable.ts"])).rejects.toBeInstanceOf(GraphSourceStagingError);
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+
+    failRead = false;
+    writeFileSync(sourcePath, "}\n");
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: [expect.objectContaining({
+        filePath: "src/stable.ts",
+        operation: "parse",
+        code: "GRAPH_SOURCE_PARSE_FAILED",
+      })],
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("makes corpus identity independent of discovery order", () => {
+    const first = { path: "src/a.ts", contentHash: "a".repeat(64) };
+    const second = { path: "src/b.ts", contentHash: "b".repeat(64) };
+    expect(computeSourceCorpusDigest([first, second])).toBe(computeSourceCorpusDigest([second, first]));
+  });
+
+  it("validates canonical, bounded, unique semantic-input provenance", () => {
+    const digest = "a".repeat(64);
+    const snapshot = createGraphSnapshot({
+      indexedAt: "2026-08-22T00:00:00.000Z",
+      git: { branch: null, head: null },
+      schemaVersion: DB_SCHEMA_VERSION,
+      compilerVersion: "test",
+      extractorVersion: "test",
+      resolverVersion: "test",
+      grammarHash: digest,
+      configHash: digest,
+      manifestHash: digest,
+      sources: [{ path: "src/a.ts", contentHash: digest, parseStatus: "ok" }],
+      semanticInputs: [
+        { path: "config/z.json", contentHash: null },
+        { path: "config/a.json", contentHash: digest },
+      ],
+    });
+    expect(snapshot.semanticInputs.map((entry) => entry.path)).toEqual([
+      "config/a.json",
+      "config/z.json",
+    ]);
+    expect(parseGraphSnapshot(serializeGraphSnapshot(snapshot))).toEqual(snapshot);
+
+    const duplicate = JSON.parse(serializeGraphSnapshot(snapshot)) as Record<string, unknown>;
+    duplicate.semanticInputs = [
+      { path: "config/a.json", contentHash: digest },
+      { path: "config/a.json", contentHash: null },
+    ];
+    expect(parseGraphSnapshot(JSON.stringify(duplicate))).toBeNull();
+
+    const oversized = JSON.parse(serializeGraphSnapshot(snapshot)) as Record<string, unknown>;
+    oversized.semanticInputs = Array.from(
+      { length: GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS + 1 },
+      (_, index) => ({ path: `config/${String(index).padStart(5, "0")}.json`, contentHash: null }),
+    );
+    expect(parseGraphSnapshot(JSON.stringify(oversized))).toBeNull();
+    const overlong = JSON.parse(serializeGraphSnapshot(snapshot)) as Record<string, unknown>;
+    overlong.semanticInputs = [{ path: `${"x".repeat(4_097)}.json`, contentHash: null }];
+    expect(parseGraphSnapshot(JSON.stringify(overlong))).toBeNull();
+    expect(() => createGraphSnapshot({
+      ...snapshot,
+      git: { branch: null, head: null },
+      sources: [{ path: "src/a.ts", contentHash: digest, parseStatus: "ok" }],
+      semanticInputs: [{ path: "src/a.ts", contentHash: digest }],
+    })).toThrow("must not duplicate supported source paths");
+  });
+
+  it("binds compiler facts to staged source bytes across an A-to-B-to-A race", async () => {
+    const root = temporaryRoot("mex-graph-compiler-source-aba-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function priorCompilerFact(): number { return 1; }\n");
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+
+    const stagedA = "export function securelyStagedFact(): number { return 2; }\n";
+    const transientB = "export function transientCompilerFact(): number { return 3; }\n";
+    writeFileSync(sourcePath, stagedA);
+    let swapped = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      __internalGraphEngineHooks: {
+        afterSemanticInputsStaged: () => {
+          if (swapped) return;
+          writeFileSync(sourcePath, transientB);
+          swapped = true;
+        },
+        afterCompilerExtraction: () => writeFileSync(sourcePath, stagedA),
+      },
+    } as Parameters<typeof createGraphEngine>[0]);
+
+    await engine.sync(["src/stable.ts"]);
+    expect(swapped).toBe(true);
+    expect(engine.searchNodes("securelyStagedFact").some((node) => node.name === "securelyStagedFact")).toBe(true);
+    expect(engine.searchNodes("transientCompilerFact").some((node) => node.name === "transientCompilerFact")).toBe(false);
+    engine.close();
+  });
+
+  it("binds import resolution to the staged path set across an A-to-B-to-A race", async () => {
+    const root = temporaryRoot("mex-graph-compiler-import-aba-");
+    const sourceDir = join(root, "src");
+    const targetPath = join(sourceDir, "target.ts");
+    const savedTargetPath = join(sourceDir, "target.saved");
+    const transientTargetPath = join(sourceDir, "target.js");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(sourceDir, { recursive: true });
+    writeFileSync(targetPath, "export const targetValue = 1;\n");
+    writeFileSync(join(sourceDir, "use.ts"), [
+      "import { targetValue } from './target';",
+      "export function readTarget(): number { return targetValue; }",
+      "",
+    ].join("\n"));
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      __internalGraphEngineHooks: {
+        afterSemanticInputsStaged: () => {
+          renameSync(targetPath, savedTargetPath);
+          writeFileSync(transientTargetPath, "export const targetValue = 2;\n");
+        },
+        afterCompilerExtraction: () => {
+          rmSync(transientTargetPath);
+          renameSync(savedTargetPath, targetPath);
+        },
+      },
+    } as Parameters<typeof createGraphEngine>[0]);
+    await engine.build();
+    engine.close();
+
+    const db = openSqlite(dbPath, { readOnly: true });
+    const binding = db.prepare(
+      "SELECT resolved_file_path AS resolvedFilePath FROM import_bindings WHERE module_specifier = './target'",
+    ).get() as { resolvedFilePath: string | null } | undefined;
+    db.close();
+    expect(binding).toEqual({ resolvedFilePath: "src/target.ts" });
+  });
+
+  it("rejects an extended-config A-to-B-to-A compiler race and preserves the prior snapshot", async () => {
+    const root = temporaryRoot("mex-graph-compiler-config-aba-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const baseConfigPath = join(root, "compiler-base.json");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function priorConfigFact(): number { return 1; }\n");
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./compiler-base.json",
+      include: ["src/**/*.ts"],
+    }));
+    const configA = JSON.stringify({ compilerOptions: { strict: true, target: "ES2022" } });
+    const configB = JSON.stringify({ compilerOptions: { strict: false, target: "ES5" } });
+    writeFileSync(baseConfigPath, configA);
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    const priorNode = baseline.searchNodes("priorConfigFact")
+      .find((node) => node.name === "priorConfigFact")!;
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function priorConfigFact(): number { return 2; }\n");
+
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      __internalGraphEngineHooks: {
+        afterSemanticInputsStaged: () => writeFileSync(baseConfigPath, configB),
+        afterCompilerExtraction: () => writeFileSync(baseConfigPath, configA),
+      },
+    } as Parameters<typeof createGraphEngine>[0]);
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({
+          filePath: "compiler-base.json",
+          message: expect.stringContaining("semantic input changed"),
+        }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    expect(engine.getNode(priorNode.id)).toMatchObject({ id: priorNode.id, bodyHash: priorNode.bodyHash });
+    engine.close();
+  });
+
+  it("rejects a failed full rebuild and preserves the last trustworthy facts", async () => {
+    const root = temporaryRoot("mex-graph-full-build-parse-failure-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function fullBuildFact(): number { return 7; }\n");
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    const priorNode = engine.searchNodes("fullBuildFact").find((node) => node.name === "fullBuildFact")!;
+
+    writeFileSync(sourcePath, "}\n");
+    await expect(engine.build()).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: [expect.objectContaining({
+        filePath: "src/stable.ts",
+        operation: "parse",
+        code: "GRAPH_SOURCE_PARSE_FAILED",
+      })],
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    expect(engine.getNode(priorNode.id)).toMatchObject({ id: priorNode.id, bodyHash: priorNode.bodyHash });
+    engine.close();
+  });
+
+  it("preserves trustworthy legacy facts on a failed rebuild without snapshot metadata", async () => {
+    const root = temporaryRoot("mex-graph-legacy-full-build-parse-failure-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function legacyBuildFact(): number { return 7; }\n");
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    const priorNode = baseline.searchNodes("legacyBuildFact").find((node) => node.name === "legacyBuildFact")!;
+    baseline.close();
+    const db = openSqlite(dbPath);
+    db.prepare("DELETE FROM project_metadata WHERE key = ?").run(GRAPH_SNAPSHOT_METADATA_KEY);
+    db.close();
+
+    writeFileSync(sourcePath, "}\n");
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await expect(engine.build()).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: [expect.objectContaining({ operation: "parse" })],
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBeNull();
+    expect(engine.getNode(priorNode.id)).toMatchObject({ id: priorNode.id, bodyHash: priorNode.bodyHash });
+    engine.close();
+  });
+
+  it("rejects a direct external tsconfig extension and preserves prior provenance", async () => {
+    const root = temporaryRoot("mex-graph-config-direct-escape-");
+    const externalRoot = temporaryRoot("mex-graph-config-direct-external-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function containedConfigFact(): number { return 7; }\n");
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+
+    const externalConfig = join(externalRoot, "node_modules", "attacker", "outside.json");
+    mkdirSync(join(externalRoot, "node_modules", "attacker"), { recursive: true });
+    writeFileSync(externalConfig, JSON.stringify({ compilerOptions: { strict: false } }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: externalConfig,
+      include: ["src/**/*.ts"],
+    }));
+    await expect(engine.sync(["tsconfig.json"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: [expect.objectContaining({
+        filePath: ".",
+        code: "GRAPH_SOURCE_PATH_ESCAPE",
+      })],
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("rejects a missing compiler input below an escaped symlink ancestor", async () => {
+    const root = temporaryRoot("mex-graph-config-missing-ancestor-escape-");
+    const externalRoot = temporaryRoot("mex-graph-config-missing-ancestor-external-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function containedMissingFact(): number { return 7; }\n");
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+
+    symlinkSync(externalRoot, join(root, "probes"));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./probes/optional.json",
+      include: ["src/**/*.ts"],
+    }));
+    await expect(engine.sync(["tsconfig.json"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({
+          filePath: "probes/optional.json",
+          code: "GRAPH_SOURCE_PATH_ESCAPE",
+        }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("persists indirect compiler inputs without duplicating source provenance", async () => {
+    const root = temporaryRoot("mex-graph-semantic-input-provenance-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const baseConfigPath = join(root, "compiler-base.json");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function semanticInputFact(): number { return 7; }\n");
+    writeFileSync(baseConfigPath, JSON.stringify({ compilerOptions: { strict: true } }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./compiler-base.json",
+      include: ["src/**/*.ts"],
+    }));
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    engine.close();
+
+    const snapshot = parseGraphSnapshot(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY))!;
+    expect(snapshot.semanticInputs).toEqual(expect.arrayContaining([{
+      path: "compiler-base.json",
+      contentHash: createHash("sha256").update(readFileSync(baseConfigPath)).digest("hex"),
+    }]));
+    expect(snapshot.semanticInputs.some((input) => input.path === "src/stable.ts")).toBe(false);
+  });
+
+  it("persists a missing extended-config probe so later appearance can stale the graph", async () => {
+    const root = temporaryRoot("mex-graph-missing-semantic-input-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function missingConfigFact(): number { return 7; }\n");
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./compiler-base.json",
+      include: ["src/**/*.ts"],
+    }));
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    engine.close();
+
+    const snapshot = parseGraphSnapshot(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY))!;
+    expect(snapshot.semanticInputs).toContainEqual({ path: "compiler-base.json", contentHash: null });
+  });
+
+  it("rejects publication when Git branch provenance changes during staging", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-git-race-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    initializeGit(root);
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+
+    let switchedBranch = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      sourceFileAccess: {
+        read: (absolutePath) => {
+          const source = readFileSync(absolutePath, "utf8");
+          if (!switchedBranch && absolutePath === sourcePath) {
+            execFileSync("git", ["checkout", "-b", "snapshot-race"], {
+              cwd: root,
+              stdio: ["ignore", "ignore", "pipe"],
+            });
+            switchedBranch = true;
+          }
+          return source;
+        },
+      },
+    });
+
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({ filePath: ".git/HEAD" }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  }, 10_000);
+
+  it("rejects a checkout during final indirect semantic-input verification", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-semantic-git-race-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    writeFileSync(join(root, "compiler-base.json"), JSON.stringify({ compilerOptions: { strict: true } }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./compiler-base.json",
+      include: ["src/**/*.ts"],
+    }));
+    initializeGit(root);
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+
+    let switchedBranch = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      __internalGraphEngineHooks: {
+        afterFinalSemanticInputRead: (path: string) => {
+          if (switchedBranch || path !== "compiler-base.json") return;
+          execFileSync("git", ["checkout", "-b", "semantic-input-race"], {
+            cwd: root,
+            stdio: ["ignore", "ignore", "pipe"],
+          });
+          switchedBranch = true;
+        },
+      },
+    } as Parameters<typeof createGraphEngine>[0]);
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({ filePath: ".git/HEAD" }),
+      ]),
+    });
+    expect(switchedBranch).toBe(true);
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  }, 10_000);
+
+  it("rejects publication when graph configuration changes during staging", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-config-race-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const packagePath = join(root, "package.json");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    writeFileSync(packagePath, "{\"name\":\"before-staging\"}\n");
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+
+    let changedConfig = false;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      sourceFileAccess: {
+        read: (absolutePath) => {
+          const source = readFileSync(absolutePath, "utf8");
+          if (!changedConfig && absolutePath === sourcePath) {
+            writeFileSync(packagePath, "{\"name\":\"during-staging\"}\n");
+            changedConfig = true;
+          }
+          return source;
+        },
+      },
+    });
+
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({ filePath: ".", message: expect.stringContaining("configHash") }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("rejects publication when an exact source identity changes after staging", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-source-race-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+
+    let sourceStats = 0;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      sourceFileAccess: {
+        stat: (absolutePath) => {
+          const stats = statSync(absolutePath);
+          if (absolutePath === sourcePath) {
+            sourceStats += 1;
+            // inspectChangedSources and staging have already finished. Change
+            // the file as the post-continuity publication probe begins.
+            if (sourceStats === 3) {
+              writeFileSync(sourcePath, "export function stableSnapshot(): number { return 9; }\n");
+            }
+          }
+          return stats;
+        },
+      },
+    });
+
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({ filePath: "src/stable.ts", message: expect.stringContaining("changed") }),
+      ]),
+    });
+    expect(sourceStats).toBe(3);
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("refuses an external source symlink and preserves the prior snapshot", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-source-escape-");
+    const externalRoot = temporaryRoot("mex-graph-snapshot-source-external-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const externalSourcePath = join(externalRoot, "outside.ts");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    writeFileSync(externalSourcePath, "export const outsideSecret = 'must-not-index';\n");
+
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    rmSync(sourcePath);
+    symlinkSync(externalSourcePath, sourcePath);
+
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({
+          filePath: "src/stable.ts",
+          code: "GRAPH_SOURCE_PATH_ESCAPE",
+        }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("rejects an atomic source replacement during final verification", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-source-replace-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const replacementPath = join(root, "src", "replacement.ts.tmp");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+
+    const baseline = createGraphEngine({ rootDir: root, dbPath });
+    await baseline.build();
+    baseline.close();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 8; }\n");
+
+    let sourceReads = 0;
+    const engine = createGraphEngine({
+      rootDir: root,
+      dbPath,
+      sourceFileAccess: {
+        read: (absolutePath) => {
+          const source = readFileSync(absolutePath, "utf8");
+          if (absolutePath === sourcePath) {
+            sourceReads += 1;
+            if (sourceReads === 2) {
+              writeFileSync(replacementPath, "export function stableSnapshot(): number { return 9; }\n");
+              renameSync(replacementPath, sourcePath);
+            }
+          }
+          return source;
+        },
+      },
+    });
+
+    await expect(engine.sync(["src/stable.ts"])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({
+          filePath: "src/stable.ts",
+          code: "GRAPH_SOURCE_PATH_ESCAPE",
+        }),
+      ]),
+    });
+    expect(sourceReads).toBe(2);
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+
+  it("refuses an external config symlink and preserves the prior snapshot", async () => {
+    const root = temporaryRoot("mex-graph-snapshot-config-escape-");
+    const externalRoot = temporaryRoot("mex-graph-snapshot-config-external-");
+    const sourcePath = join(root, "src", "stable.ts");
+    const packagePath = join(root, "package.json");
+    const externalPackagePath = join(externalRoot, "package.json");
+    const dbPath = join(root, "graph.db");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, "export function stableSnapshot(): number { return 7; }\n");
+    writeFileSync(packagePath, "{\"name\":\"inside\"}\n");
+    writeFileSync(externalPackagePath, "{\"name\":\"outside-secret\"}\n");
+
+    const engine = createGraphEngine({ rootDir: root, dbPath });
+    await engine.build();
+    const successfulSnapshot = metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY);
+    rmSync(packagePath);
+    symlinkSync(externalPackagePath, packagePath);
+
+    await expect(engine.sync([])).rejects.toMatchObject({
+      name: "GraphSourceStagingError",
+      failures: expect.arrayContaining([
+        expect.objectContaining({
+          filePath: "package.json",
+          code: "GRAPH_SOURCE_PATH_ESCAPE",
+        }),
+      ]),
+    });
+    expect(metadata(dbPath, GRAPH_SNAPSHOT_METADATA_KEY)).toBe(successfulSnapshot);
+    engine.close();
+  });
+});

--- a/src/graph/__tests__/status.test.ts
+++ b/src/graph/__tests__/status.test.ts
@@ -1,0 +1,1202 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { graphRemediationCommand } from "../../reporter.js";
+import { openSqlite } from "../db/sqlite.js";
+import { BANDS } from "../config.js";
+import { createGraphEngine } from "../engine-impl.js";
+import { FingerprintStore } from "../fingerprint-store.js";
+import type { Fingerprint } from "../reconcile.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  parseGraphSnapshot,
+  serializeGraphSnapshot,
+  type GraphSnapshot,
+} from "../snapshot.js";
+import { inspectGraphSidecars, inspectGraphStatus } from "../status.js";
+
+const NOW = new Date("2026-08-22T12:00:00.000Z");
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function temporaryRoot(prefix = "mex-graph-status-"): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function source(root: string, path: string, content: string): void {
+  const absolutePath = join(root, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+async function build(root: string): Promise<string> {
+  const engine = createGraphEngine({ rootDir: root });
+  try {
+    await engine.build();
+  } finally {
+    engine.close();
+  }
+  return join(root, ".mex", "graph.db");
+}
+
+async function inspect(root: string, maxChangedPaths?: number) {
+  return inspectGraphStatus({ projectRoot: root, now: NOW, maxChangedPaths });
+}
+
+function updateSnapshot(dbPath: string, update: (snapshot: GraphSnapshot) => GraphSnapshot): void {
+  const db = openSqlite(dbPath);
+  try {
+    const row = db.prepare(
+      "SELECT value FROM project_metadata WHERE key = ?",
+    ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value: string };
+    const snapshot = parseGraphSnapshot(row.value);
+    if (!snapshot) throw new Error("test fixture has no valid graph snapshot");
+    db.prepare(
+      "UPDATE project_metadata SET value = ?, updated_at = ? WHERE key = ?",
+    ).run(serializeGraphSnapshot(update(snapshot)), NOW.getTime(), GRAPH_SNAPSHOT_METADATA_KEY);
+  } finally {
+    db.close();
+  }
+}
+
+function readSnapshot(dbPath: string): GraphSnapshot {
+  const db = openSqlite(dbPath, { readOnly: true, immutable: true });
+  try {
+    const row = db.prepare(
+      "SELECT value FROM project_metadata WHERE key = ?",
+    ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value: string };
+    const snapshot = parseGraphSnapshot(row.value);
+    if (!snapshot) throw new Error("test fixture has no valid graph snapshot");
+    return snapshot;
+  } finally {
+    db.close();
+  }
+}
+
+function executableRemediations(status: Awaited<ReturnType<typeof inspectGraphStatus>>): string[] {
+  return status.diagnostics.flatMap((diagnostic) =>
+    (diagnostic.remediation ?? []).flatMap((action) => action.command ? [action.command] : []));
+}
+
+function treeState(root: string): Array<Record<string, string | number>> {
+  const entries: Array<Record<string, string | number>> = [];
+  const visit = (directory: string) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name < right.name ? -1 : left.name > right.name ? 1 : 0)) {
+      const absolute = join(directory, entry.name);
+      const path = relative(root, absolute).replaceAll("\\", "/");
+      const stats = statSync(absolute);
+      entries.push({
+        path,
+        kind: entry.isDirectory() ? "directory" : "file",
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        ...(entry.isFile()
+          ? { sha256: createHash("sha256").update(readFileSync(absolute)).digest("hex") }
+          : {}),
+      });
+      if (entry.isDirectory()) visit(absolute);
+    }
+  };
+  visit(root);
+  return entries;
+}
+
+function git(root: string, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  }).trim();
+}
+
+describe("inspectGraphStatus", () => {
+  it("reports a missing graph without creating .mex or changing the filesystem", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export const service = true;\n");
+    const before = treeState(root);
+
+    const status = await inspect(root);
+
+    expect(status).toMatchObject({
+      status: "missing",
+      observedAt: NOW.toISOString(),
+      currentRepo: { branch: null, head: null, dirty: false, observedAt: NOW.toISOString() },
+      schemaVersion: null,
+      changes: { total: 1, added: ["src/service.ts"], modified: [], deleted: [] },
+    });
+    expect(treeState(root)).toEqual(before);
+  });
+
+  it("suppresses executable graph remediation when Git provenance is unavailable", async () => {
+    const root = temporaryRoot("mex-graph-git-unavailable-");
+    source(root, "src/service.ts", "export const service = true;\n");
+    await build(root);
+    source(root, "src/service.ts", "export const service = false;\n");
+    const unavailablePath = join(root, "no-executables");
+    mkdirSync(unavailablePath);
+    const previousPath = process.env.PATH;
+    process.env.PATH = unavailablePath;
+    try {
+      const status = await inspect(root);
+      expect(status.status).toBe("stale");
+      expect(status.diagnostics).toContainEqual(expect.objectContaining({
+        code: "GRAPH_REPO_STATE_UNAVAILABLE",
+      }));
+      expect(status.diagnostics).toContainEqual(expect.objectContaining({
+        code: "GRAPH_SOURCE_CORPUS_MISMATCH",
+      }));
+      expect(executableRemediations(status)).not.toContain("mex graph");
+    } finally {
+      if (previousPath === undefined) delete process.env.PATH;
+      else process.env.PATH = previousPath;
+    }
+  });
+
+  it("reports a fresh snapshot and leaves the database and sidecar set byte-identical", async () => {
+    const root = temporaryRoot();
+    source(root, "src/service.ts", "export function service(): number { return 1; }\n");
+    const dbPath = await build(root);
+    const before = treeState(root);
+
+    const status = await inspect(root);
+
+    expect(status.status).toBe("fresh");
+    expect(status.schemaVersion).toBe(2);
+    expect(status.parseHealth).toMatchObject({ total: 1, ok: 1, partial: 0, failed: 0 });
+    expect(status.changes).toMatchObject({
+      total: 0,
+      added: [],
+      modified: [],
+      deleted: [],
+      truncated: false,
+      branchChanged: false,
+      manifestChanged: false,
+      configChanged: false,
+      grammarChanged: false,
+    });
+    expect(status.indexedAt).not.toBeNull();
+    expect(statSync(dbPath).isFile()).toBe(true);
+    expect(treeState(root)).toEqual(before);
+  });
+
+  it("uses the engine's UTF-8 decoded-string hash for invalid byte sequences", async () => {
+    const root = temporaryRoot();
+    const path = join(root, "src", "invalid.ts");
+    mkdirSync(dirname(path), { recursive: true });
+    const bytes = Buffer.concat([
+      Buffer.from("export const valid = 1; // invalid byte: ", "utf8"),
+      Buffer.from([0xff]),
+      Buffer.from("\n", "utf8"),
+    ]);
+    writeFileSync(path, bytes);
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath, { readOnly: true, immutable: true });
+    let storedHash: string;
+    try {
+      const row = db.prepare("SELECT content_hash FROM files WHERE path = ?")
+        .get("src/invalid.ts") as { content_hash: string };
+      storedHash = row.content_hash;
+    } finally {
+      db.close();
+    }
+
+    const decodedHash = createHash("sha256").update(readFileSync(path, "utf8")).digest("hex");
+    const byteHash = createHash("sha256").update(bytes).digest("hex");
+    expect(storedHash).toBe(decodedHash);
+    expect(storedHash).not.toBe(byteHash);
+    expect((await inspect(root)).status).toBe("fresh");
+  });
+
+  it("uses exact decoded content hashes for deterministic added, modified, and deleted paths", async () => {
+    const root = temporaryRoot();
+    source(root, "src/b.ts", "export const b = 1;\n");
+    source(root, "src/c.ts", "export const c = 1;\n");
+    await build(root);
+    const prior = statSync(join(root, "src", "b.ts"));
+    writeFileSync(join(root, "src", "b.ts"), "export const b = 2;\n");
+    utimesSync(join(root, "src", "b.ts"), prior.atime, prior.mtime);
+    unlinkSync(join(root, "src", "c.ts"));
+    source(root, "src/a.ts", "export const a = 1;\n");
+
+    const full = await inspect(root);
+    expect(full.status).toBe("stale");
+    expect(full.changes).toMatchObject({
+      total: 3,
+      added: ["src/a.ts"],
+      modified: ["src/b.ts"],
+      deleted: ["src/c.ts"],
+      truncated: false,
+    });
+
+    const bounded = await inspect(root, 2);
+    expect(bounded.changes).toMatchObject({
+      total: 3,
+      added: ["src/a.ts"],
+      modified: ["src/b.ts"],
+      deleted: [],
+      truncated: true,
+    });
+  });
+
+  it("reports parser degradation with bounded failed paths", async () => {
+    const root = temporaryRoot();
+    source(root, "src/a.ts", "export const a = 1;\n");
+    source(root, "src/b.ts", "export const b = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.prepare("UPDATE files SET parse_status = 'failed' WHERE path IN (?, ?)")
+        .run("src/a.ts", "src/b.ts");
+    } finally {
+      db.close();
+    }
+    updateSnapshot(dbPath, (snapshot) => ({
+      ...snapshot,
+      parseHealth: { total: 2, ok: 0, partial: 0, failed: 2 },
+    }));
+
+    const status = await inspect(root, 1);
+    expect(status.status).toBe("degraded");
+    expect(status.parseHealth).toEqual({
+      total: 2,
+      ok: 0,
+      partial: 0,
+      failed: 2,
+      failedPaths: ["src/a.ts"],
+      failedPathsTruncated: true,
+    });
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_PARSE_DEGRADED",
+      message: expect.stringContaining("2 failed"),
+    }));
+  });
+
+  it.each([1, 3])("classifies schema %s as rebuild_required", async (schemaVersion) => {
+    const root = temporaryRoot();
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DELETE FROM schema_versions");
+      db.prepare("INSERT INTO schema_versions (version, applied_at, description) VALUES (?, ?, ?)")
+        .run(schemaVersion, NOW.getTime(), "test schema");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("rebuild_required");
+    expect(status.schemaVersion).toBe(schemaVersion);
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_REBUILD_REQUIRED");
+    expect(diagnostic).toBeDefined();
+    if (schemaVersion < 2) {
+      expect(diagnostic?.remediation).toEqual([{ label: "Rebuild graph", command: "mex graph" }]);
+    } else {
+      expect(diagnostic?.remediation).toBeUndefined();
+    }
+  });
+
+  it("treats an empty recorded schema version as commandless corruption", async () => {
+    const root = temporaryRoot("mex-graph-invalid-version-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DELETE FROM schema_versions");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
+    expect(diagnostic?.message).toContain("invalid version");
+    expect(diagnostic?.remediation).toBeUndefined();
+  });
+
+  it("distinguishes a corrupt database from an active-WAL transient state", async () => {
+    const corruptRoot = temporaryRoot("mex-graph-corrupt-");
+    mkdirSync(join(corruptRoot, ".mex"));
+    writeFileSync(join(corruptRoot, ".mex", "graph.db"), "not sqlite");
+    const corruptBefore = treeState(corruptRoot);
+    const corrupt = await inspect(corruptRoot);
+    expect(corrupt.status).toBe("corrupt");
+    expect(corrupt.changes.total).toBe(0);
+    expect(corrupt.diagnostics).toContainEqual(expect.objectContaining({ code: "GRAPH_INDEX_CORRUPT" }));
+    expect(corrupt.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(treeState(corruptRoot)).toEqual(corruptBefore);
+
+    const transientRoot = temporaryRoot("mex-graph-transient-");
+    source(transientRoot, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(transientRoot);
+    const writer = openSqlite(dbPath);
+    try {
+      writer.exec("PRAGMA wal_autocheckpoint = 0");
+      writer.prepare("UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'")
+        .run(NOW.getTime());
+      expect(statSync(`${dbPath}-wal`).size).toBeGreaterThan(0);
+      const transient = await inspect(transientRoot);
+      expect(transient.status).toBe("degraded");
+      expect(transient.changes.total).toBe(0);
+      expect(transient.diagnostics).toContainEqual(expect.objectContaining({ code: "GRAPH_INDEX_SIDECAR_ACTIVE" }));
+      expect(transient.diagnostics).not.toContainEqual(expect.objectContaining({ code: "GRAPH_INDEX_CORRUPT" }));
+    } finally {
+      writer.close();
+    }
+  });
+
+  it("reports sidecars deterministically and refuses immutable interpretation while one is active or unavailable", async () => {
+    const root = temporaryRoot("mex-graph-sidecar-probe-");
+    const dbPath = join(root, ".mex", "graph.db");
+    mkdirSync(dirname(dbPath), { recursive: true });
+    writeFileSync(dbPath, "not sqlite");
+    expect(inspectGraphSidecars(dbPath)).toEqual({ state: "clear", paths: [] });
+
+    writeFileSync(`${dbPath}-journal`, "hot rollback journal");
+    expect(inspectGraphSidecars(dbPath)).toEqual({
+      state: "active",
+      paths: ["graph.db-journal"],
+    });
+    const active = await inspect(root);
+    expect(active).toMatchObject({ status: "degraded", schemaVersion: null });
+    expect(active.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_SIDECAR_ACTIVE",
+    }));
+    expect(active.diagnostics).not.toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_CORRUPT",
+    }));
+
+    chmodSync(`${dbPath}-journal`, 0o000);
+    expect(inspectGraphSidecars(dbPath)).toEqual({
+      state: "unavailable",
+      paths: ["graph.db-journal"],
+    });
+    chmodSync(`${dbPath}-journal`, 0o600);
+    unlinkSync(`${dbPath}-journal`);
+    mkdirSync(`${dbPath}-wal`);
+    expect(inspectGraphSidecars(dbPath)).toEqual({
+      state: "unavailable",
+      paths: ["graph.db-wal"],
+    });
+    const unavailable = await inspect(root);
+    expect(unavailable).toMatchObject({ status: "degraded", schemaVersion: null });
+    expect(unavailable.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_SIDECAR_UNAVAILABLE",
+    }));
+  });
+
+  it("detects a live rollback journal before reading the database", async () => {
+    const root = temporaryRoot("mex-graph-hot-journal-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const writer = openSqlite(dbPath);
+    let transactionOpen = false;
+    try {
+      writer.exec("PRAGMA journal_mode = DELETE");
+      writer.exec("BEGIN IMMEDIATE");
+      transactionOpen = true;
+      writer.prepare("UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'")
+        .run(NOW.getTime());
+      expect(statSync(`${dbPath}-journal`).size).toBeGreaterThan(0);
+
+      const status = await inspect(root);
+      expect(status).toMatchObject({ status: "degraded", schemaVersion: null });
+      expect(status.diagnostics).toContainEqual(expect.objectContaining({
+        code: "GRAPH_INDEX_SIDECAR_ACTIVE",
+      }));
+    } finally {
+      if (transactionOpen) writer.exec("ROLLBACK");
+      writer.close();
+    }
+  });
+
+  it("never emits fresh when the database identity cannot stabilize across bounded retries", async () => {
+    const root = temporaryRoot("mex-graph-status-race-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const attempts: number[] = [];
+
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        beforeFreshValidation(attempt) {
+          attempts.push(attempt);
+          const changedAt = new Date(NOW.getTime() + (attempt + 1) * 60_000);
+          utimesSync(dbPath, changedAt, changedAt);
+        },
+      },
+    });
+
+    expect(attempts).toEqual([0, 1]);
+    expect(status.status).toBe("degraded");
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_STATUS_OBSERVATION_RACE",
+      message: expect.stringContaining("graph snapshot"),
+    }));
+  });
+
+  it("does not report durable corruption when the database changes during structural inspection", async () => {
+    const root = temporaryRoot("mex-graph-structural-race-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DROP TABLE edges");
+    } finally {
+      db.close();
+    }
+    const attempts: number[] = [];
+
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        beforeDatabaseResult(kind, attempt) {
+          if (kind !== "corrupt") return;
+          attempts.push(attempt);
+          const changedAt = new Date(NOW.getTime() + (attempt + 1) * 60_000);
+          utimesSync(dbPath, changedAt, changedAt);
+        },
+      },
+    });
+
+    expect(attempts).toEqual([0, 1]);
+    expect(status.status).toBe("degraded");
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_STATUS_OBSERVATION_RACE",
+      message: expect.stringContaining("graph database"),
+    }));
+    expect(status.diagnostics).not.toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_SCHEMA_INVALID",
+    }));
+  });
+
+  it("retries an early structural result when a contained graph symlink is retargeted", async () => {
+    const root = temporaryRoot("mex-graph-db-retarget-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const graphPath = await build(root);
+    const targetA = join(root, ".mex", "graph-a.db");
+    const targetB = join(root, ".mex", "graph-b.db");
+    renameSync(graphPath, targetA);
+    copyFileSync(targetA, targetB);
+    symlinkSync("graph-a.db", graphPath);
+    const corrupt = openSqlite(targetA);
+    try {
+      corrupt.exec("DROP TABLE edges");
+    } finally {
+      corrupt.close();
+    }
+    let retargeted = false;
+
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        beforeDatabaseResult(kind, attempt) {
+          if (retargeted || kind !== "corrupt" || attempt !== 0) return;
+          unlinkSync(graphPath);
+          symlinkSync("graph-b.db", graphPath);
+          retargeted = true;
+        },
+      },
+    });
+
+    expect(retargeted).toBe(true);
+    expect(status.status).toBe("fresh");
+    expect(status.diagnostics).not.toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_SCHEMA_INVALID",
+    }));
+  });
+
+  it("never emits fresh when an atomic save replaces a source path after it is read", async () => {
+    const root = temporaryRoot("mex-graph-source-race-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    await build(root);
+    const replacement = join(root, "src", "a.ts.next");
+    writeFileSync(replacement, "export const a = 2;\n");
+    let replaced = false;
+
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        afterSourceRead(path, pass) {
+          if (!replaced && pass === "validation" && path === "src/a.ts") {
+            replaced = true;
+            renameSync(replacement, join(root, "src", "a.ts"));
+          }
+        },
+      },
+    });
+
+    expect(replaced).toBe(true);
+    expect(status.status).toBe("stale");
+    expect(status.changes.modified).toEqual(["src/a.ts"]);
+  });
+
+  it("classifies a valid current-schema legacy graph as stale with an adoption command", async () => {
+    const root = temporaryRoot();
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.prepare("DELETE FROM project_metadata WHERE key = ?").run(GRAPH_SNAPSHOT_METADATA_KEY);
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("stale");
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SNAPSHOT_LEGACY",
+      remediation: [{ label: "Republish graph snapshot", command: "mex graph" }],
+    }));
+    expect(status.changes.total).toBe(0);
+  });
+
+  it("treats malformed, digest-inconsistent, or row-inconsistent snapshot metadata as corrupt", async () => {
+    const malformedRoot = temporaryRoot("mex-graph-snapshot-invalid-");
+    source(malformedRoot, "src/a.ts", "export const a = 1;\n");
+    const malformedPath = await build(malformedRoot);
+    const malformedDb = openSqlite(malformedPath);
+    try {
+      malformedDb.prepare("UPDATE project_metadata SET value = ? WHERE key = ?")
+        .run("{", GRAPH_SNAPSHOT_METADATA_KEY);
+    } finally {
+      malformedDb.close();
+    }
+    const malformed = await inspect(malformedRoot);
+    expect(malformed.status).toBe("corrupt");
+    expect(malformed.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+
+    const digestRoot = temporaryRoot("mex-graph-snapshot-digest-");
+    source(digestRoot, "src/a.ts", "export const a = 1;\n");
+    const digestPath = await build(digestRoot);
+    updateSnapshot(digestPath, (snapshot) => ({
+      ...snapshot,
+      sourceCorpusDigest: "0".repeat(64),
+    }));
+    const digestMismatch = await inspect(digestRoot);
+    expect(digestMismatch.status).toBe("corrupt");
+    expect(digestMismatch.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SNAPSHOT_CONTENT_MISMATCH",
+    }));
+    expect(digestMismatch.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+
+    const inconsistentRoot = temporaryRoot("mex-graph-snapshot-mismatch-");
+    source(inconsistentRoot, "src/a.ts", "export const a = 1;\n");
+    const inconsistentPath = await build(inconsistentRoot);
+    updateSnapshot(inconsistentPath, (snapshot) => ({
+      ...snapshot,
+      sourceCount: 2,
+      parseHealth: { total: 2, ok: 2, partial: 0, failed: 0 },
+    }));
+    const inconsistent = await inspect(inconsistentRoot);
+    expect(inconsistent.status).toBe("corrupt");
+    expect(inconsistent.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SNAPSHOT_CONTENT_MISMATCH",
+    }));
+    expect(inconsistent.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+  }, 10_000);
+
+  it("treats missing core tables and duplicate or dangling edges as corrupt", async () => {
+    const missingTableRoot = temporaryRoot("mex-graph-missing-table-");
+    source(missingTableRoot, "src/a.ts", "export const a = 1;\n");
+    const missingTablePath = await build(missingTableRoot);
+    const missingTableDb = openSqlite(missingTablePath);
+    try {
+      missingTableDb.exec("DROP TABLE edges");
+    } finally {
+      missingTableDb.close();
+    }
+    const missingTable = await inspect(missingTableRoot);
+    expect(missingTable.status).toBe("corrupt");
+    expect(missingTable.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_SCHEMA_INVALID",
+      message: expect.stringContaining("edges"),
+    }));
+
+    const invalidEdgesRoot = temporaryRoot("mex-graph-invalid-edges-");
+    source(invalidEdgesRoot, "src/a.ts", "export function a(): number { return 1; }\n");
+    const invalidEdgesPath = await build(invalidEdgesRoot);
+    const invalidEdgesDb = openSqlite(invalidEdgesPath);
+    try {
+      const node = invalidEdgesDb.prepare("SELECT id FROM nodes ORDER BY id LIMIT 1").get() as { id: string };
+      invalidEdgesDb.exec("PRAGMA foreign_keys = OFF");
+      invalidEdgesDb.exec("DROP INDEX idx_edges_semantic_callsite");
+      invalidEdgesDb.exec("CREATE INDEX idx_edges_semantic_callsite ON edges(source, target, kind)");
+      const insertEdge = invalidEdgesDb.prepare(
+        "INSERT INTO edges (source, target, kind, line, col) VALUES (?, ?, ?, ?, ?)",
+      );
+      insertEdge.run(node.id, node.id, "test_duplicate", 1, 1);
+      insertEdge.run(node.id, node.id, "test_duplicate", 1, 1);
+      insertEdge.run("missing-source", node.id, "test_dangling", 2, 1);
+    } finally {
+      invalidEdgesDb.close();
+    }
+    const invalidEdges = await inspect(invalidEdgesRoot);
+    expect(invalidEdges.status).toBe("corrupt");
+    const invariant = invalidEdges.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
+    expect(invariant?.message).toContain("1 duplicate edge group(s)");
+    expect(invariant?.message).toContain("1 dangling edge(s)");
+  });
+
+  it("requires retrieval triggers and current table columns", async () => {
+    const root = temporaryRoot("mex-graph-schema-structure-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DROP TRIGGER nodes_ai");
+      db.exec("ALTER TABLE files DROP COLUMN extractor_version");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
+    expect(diagnostic?.message).toContain("missing trigger nodes_ai");
+    expect(diagnostic?.message).toContain("missing column files.extractor_version");
+  });
+
+  it("requires every FTS shadow table used by retrieval and rebuild", async () => {
+    const root = temporaryRoot("mex-graph-fts-schema-");
+    source(root, "src/a.ts", "export const searchable = 1;\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DROP TABLE nodes_fts_config");
+      db.exec("DROP TABLE source_chunks_fts_config");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
+    expect(diagnostic?.message).toContain("missing table nodes_fts_config");
+    expect(diagnostic?.message).toContain("missing table source_chunks_fts_config");
+    expect(diagnostic?.remediation).toBeUndefined();
+  });
+
+  it("does not advertise in-place repair for a conflicting versionless schema", async () => {
+    const root = temporaryRoot("mex-graph-versionless-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    mkdirSync(join(root, ".mex"), { recursive: true });
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      db.exec("CREATE TABLE nodes(id TEXT)");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
+    expect(diagnostic?.message).toContain("incompatible schema objects");
+    expect(diagnostic?.remediation).toBeUndefined();
+  });
+
+  it("detects dangling ownership, alias, reference, import, and LSH records", async () => {
+    const root = temporaryRoot("mex-graph-relational-invariants-");
+    source(root, "src/a.ts", "export function a(): number { return 1; }\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("PRAGMA foreign_keys = OFF");
+      db.exec("DELETE FROM files");
+      db.prepare(
+        "INSERT INTO node_aliases (alias_id, canonical_node_id, match_method, confidence, created_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("old-node", "missing-node", "test", 1, NOW.getTime());
+      db.prepare(
+        `INSERT INTO unresolved_refs (
+          ref_key, from_node_id, reference_name, reference_kind, line, col, file_path,
+          language, status, target_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run("test-ref", "missing-from", "target", "calls", 1, 1, "src/missing.ts", "typescript", "resolved", "missing-target");
+      db.prepare(
+        `INSERT INTO import_bindings (
+          binding_key, file_path, local_name, imported_name, module_specifier, target_id
+        ) VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run("test-binding", "src/missing.ts", "local", "remote", "./missing", "missing-target");
+      db.prepare("INSERT INTO lsh_buckets (band, band_hash, node_id) VALUES (?, ?, ?)")
+        .run(0, "test-band", "missing-node");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
+    expect(diagnostic?.message).toContain("node(s) without an owning file");
+    expect(diagnostic?.message).toContain("alias(es) without a canonical node");
+    expect(diagnostic?.message).toContain("unresolved reference(s) without an owning node");
+    expect(diagnostic?.message).toContain("unresolved reference(s) with a dangling target");
+    expect(diagnostic?.message).toContain("import binding(s) without an owning file");
+    expect(diagnostic?.message).toContain("import binding(s) with a dangling target");
+    expect(diagnostic?.message).toContain("LSH bucket(s) without a node");
+    expect(diagnostic?.message).toContain("LSH bucket(s) without a fingerprint");
+  });
+
+  it("rejects malformed reachable fingerprints before the reconciler can decode them", async () => {
+    const root = temporaryRoot("mex-graph-fingerprint-shape-");
+    source(root, "src/a.ts", `
+      export function alpha(value: number): number { return value + 1; }
+      export function beta(value: number): number { return value * 2; }
+      export function gamma(value: number): number { return value - 3; }
+      export function delta(value: number): number { return value / 4; }
+    `);
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      const rows = db.prepare(
+        `SELECT node_id, minhash, neighbors, token_count
+         FROM node_fingerprints ORDER BY node_id LIMIT 4`,
+      ).all() as Array<{
+        node_id: string;
+        minhash: string;
+        neighbors: string;
+        token_count: number;
+      }>;
+      expect(rows).toHaveLength(4);
+      const reachable = rows[0]!;
+      const baseline: Fingerprint = {
+        minhash: JSON.parse(reachable.minhash) as number[],
+        neighbors: JSON.parse(reachable.neighbors) as string[],
+        tokenCount: reachable.token_count,
+      };
+      db.prepare("UPDATE node_fingerprints SET minhash = ? WHERE node_id = ?")
+        .run("{", reachable.node_id);
+      const invalidNumbers = JSON.parse(rows[1]!.minhash) as number[];
+      invalidNumbers[0] = -1;
+      db.prepare("UPDATE node_fingerprints SET minhash = ? WHERE node_id = ?")
+        .run(JSON.stringify(invalidNumbers), rows[1]!.node_id);
+      db.prepare("UPDATE node_fingerprints SET neighbors = ? WHERE node_id = ?")
+        .run("[1]", rows[2]!.node_id);
+      db.prepare("UPDATE node_fingerprints SET token_count = -1 WHERE node_id = ?")
+        .run(rows[3]!.node_id);
+
+      expect(() => new FingerprintStore(db).lookup(baseline)).toThrow();
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
+    expect(diagnostic?.message).toContain("malformed fingerprint row(s)");
+    expect(diagnostic?.remediation).toBeUndefined();
+    expect(status.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+  });
+
+  it("requires one correct LSH hash for every configured fingerprint band", async () => {
+    const root = temporaryRoot("mex-graph-fingerprint-bands-");
+    source(root, "src/a.ts", `
+      export function alpha(value: number): number { return value + 1; }
+      export function beta(value: number): number { return value * 2; }
+      export function gamma(value: number): number { return value - 3; }
+      export function delta(value: number): number { return value / 4; }
+    `);
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      const rows = db.prepare(
+        "SELECT node_id FROM node_fingerprints ORDER BY node_id LIMIT 4",
+      ).all() as Array<{ node_id: string }>;
+      expect(rows).toHaveLength(4);
+      const [missing, duplicate, outOfRange, wrongHash] = rows;
+      db.prepare("DELETE FROM lsh_buckets WHERE node_id = ?").run(missing!.node_id);
+      db.prepare(
+        `INSERT INTO lsh_buckets (band, band_hash, node_id)
+         SELECT band, band_hash, node_id FROM lsh_buckets
+         WHERE node_id = ? AND band = 0 LIMIT 1`,
+      ).run(duplicate!.node_id);
+      db.prepare(
+        `UPDATE lsh_buckets SET band = ? WHERE rowid = (
+           SELECT rowid FROM lsh_buckets WHERE node_id = ? AND band = 0 LIMIT 1
+         )`,
+      ).run(BANDS, outOfRange!.node_id);
+      db.prepare("UPDATE lsh_buckets SET band_hash = ? WHERE node_id = ?")
+        .run("0".repeat(64), wrongHash!.node_id);
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
+    expect(diagnostic?.message).toContain("missing fingerprint LSH band(s)");
+    expect(diagnostic?.message).toContain("duplicate fingerprint LSH bucket row(s)");
+    expect(diagnostic?.message).toContain("out-of-range fingerprint LSH bucket row(s)");
+    expect(diagnostic?.message).toContain("fingerprint LSH bucket hash mismatch(es)");
+    expect(diagnostic?.remediation).toBeUndefined();
+    expect(status.diagnostics.flatMap((entry) => entry.remediation ?? []))
+      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+  });
+
+  it("cross-checks node and source-chunk FTS row parity", async () => {
+    const root = temporaryRoot("mex-graph-fts-invariants-");
+    source(root, "src/a.ts", "export function searchable(): number { return 1; }\n");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.exec("DELETE FROM nodes_fts_docsize");
+      db.exec("DELETE FROM source_chunks_fts_docsize");
+    } finally {
+      db.close();
+    }
+
+    const status = await inspect(root);
+    expect(status.status).toBe("corrupt");
+    const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
+    expect(diagnostic?.message).toContain("node(s) missing from full-text search");
+    expect(diagnostic?.message).toContain("source chunk(s) missing from full-text search");
+  });
+
+  it("refuses lexical and symlink database escapes without inspecting the external database", async () => {
+    const root = temporaryRoot("mex-graph-contained-root-");
+    const externalRoot = temporaryRoot("mex-graph-external-db-");
+    source(root, "src/local.ts", "export const local = true;\n");
+    source(externalRoot, "src/external.ts", "export const external = true;\n");
+    const externalDbPath = await build(externalRoot);
+    const externalBefore = treeState(externalRoot);
+
+    const lexical = await inspectGraphStatus({
+      projectRoot: root,
+      dbPath: externalDbPath,
+      now: NOW,
+    });
+    expect(lexical.status).toBe("degraded");
+    expect(lexical.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_PATH_OUTSIDE_PROJECT",
+    }));
+    expect(treeState(externalRoot)).toEqual(externalBefore);
+
+    mkdirSync(join(root, ".mex"), { recursive: true });
+    symlinkSync(externalDbPath, join(root, ".mex", "graph.db"));
+    const symlinked = await inspect(root);
+    expect(symlinked.status).toBe("degraded");
+    expect(symlinked.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_PATH_OUTSIDE_PROJECT",
+    }));
+    expect(treeState(externalRoot)).toEqual(externalBefore);
+  });
+
+  it("refuses to hash a supported source symlink whose target escapes the project", async () => {
+    const root = temporaryRoot("mex-graph-contained-source-");
+    const externalRoot = temporaryRoot("mex-graph-external-source-");
+    source(root, "src/local.ts", "export const local = true;\n");
+    source(root, "src/escape.ts", "export const formerlyLocal = true;\n");
+    source(externalRoot, "secret.ts", "export const secret = true;\n");
+    await build(root);
+    unlinkSync(join(root, "src", "escape.ts"));
+    symlinkSync(join(externalRoot, "secret.ts"), join(root, "src", "escape.ts"));
+
+    const status = await inspect(root);
+    expect(status.status).toBe("stale");
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SOURCE_PATH_OUTSIDE_PROJECT",
+      path: "src/escape.ts",
+    }));
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SOURCE_INSPECTION_INCOMPLETE",
+    }));
+  });
+
+  it("suppresses every graph command when branch and rebuild findings coexist with an unsafe source", async () => {
+    const root = temporaryRoot("mex-graph-unsafe-remediation-");
+    const externalRoot = temporaryRoot("mex-graph-unsafe-remediation-external-");
+    source(root, "src/a.ts", "export const a = 1;\n");
+    source(externalRoot, "outside.ts", "export const outside = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    git(root, "config", "user.name", "Status Test");
+    git(root, "config", "user.email", "status@example.invalid");
+    writeFileSync(join(root, ".gitignore"), ".mex/graph.db*\n");
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "fixture");
+    const dbPath = await build(root);
+    const db = openSqlite(dbPath);
+    try {
+      db.prepare(
+        `INSERT INTO project_metadata(key, value, updated_at) VALUES(?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+      ).run("rebuild_required", "1", NOW.getTime());
+    } finally {
+      db.close();
+    }
+    git(root, "switch", "-qc", "feature/unsafe-input");
+    unlinkSync(join(root, "src", "a.ts"));
+    symlinkSync(join(externalRoot, "outside.ts"), join(root, "src", "a.ts"));
+
+    const status = await inspect(root);
+
+    expect(status.status).toBe("rebuild_required");
+    expect(status.changes.branchChanged).toBe(true);
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_REBUILD_REQUIRED",
+    }));
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_BRANCH_CHANGED",
+    }));
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SOURCE_INSPECTION_INCOMPLETE",
+    }));
+    expect(executableRemediations(status)).toEqual([]);
+    expect(graphRemediationCommand(status)).toBeUndefined();
+  });
+
+  it("tracks exact compiler semantic-input content, disappearance, and negative probes", async () => {
+    const root = temporaryRoot("mex-graph-semantic-inputs-");
+    const basePath = join(root, "config", "base.json");
+    const missingPath = join(root, "config", "optional.json");
+    const base = JSON.stringify({ compilerOptions: { strict: true } });
+    source(root, "src/a.ts", "export const a: number = 1;\n");
+    source(root, "config/base.json", base);
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./config/base.json",
+      references: [{ path: "./config/optional.json" }],
+      include: ["src/**/*.ts"],
+    }));
+    const dbPath = await build(root);
+    const snapshot = readSnapshot(dbPath);
+
+    expect(snapshot.semanticInputs).toContainEqual({
+      path: "config/base.json",
+      contentHash: createHash("sha256").update(base).digest("hex"),
+    });
+    expect(snapshot.semanticInputs).toContainEqual({
+      path: "config/optional.json",
+      contentHash: null,
+    });
+    expect((await inspect(root)).status).toBe("fresh");
+
+    const changedBase = JSON.stringify({ compilerOptions: { strict: false } });
+    writeFileSync(basePath, changedBase);
+    const changed = await inspect(root);
+    expect(changed.status).toBe("stale");
+    expect(changed.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(changed.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_CHANGED",
+      path: "config/base.json",
+      message: expect.stringContaining("changed"),
+    }));
+    expect(executableRemediations(changed)).toContain("mex graph");
+
+    writeFileSync(basePath, base);
+    expect((await inspect(root)).status).toBe("fresh");
+    unlinkSync(basePath);
+    const disappeared = await inspect(root);
+    expect(disappeared.status).toBe("stale");
+    expect(disappeared.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(disappeared.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_CHANGED",
+      path: "config/base.json",
+      message: expect.stringContaining("disappeared"),
+    }));
+    expect(executableRemediations(disappeared)).toContain("mex graph");
+
+    writeFileSync(basePath, base);
+    source(root, "config/optional.json", JSON.stringify({ compilerOptions: { noEmit: true } }));
+    const appeared = await inspect(root);
+    expect(appeared.status).toBe("stale");
+    expect(appeared.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(appeared.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_CHANGED",
+      path: "config/optional.json",
+      message: expect.stringContaining("appeared"),
+    }));
+    expect(executableRemediations(appeared)).toContain("mex graph");
+    expect(statSync(missingPath).isFile()).toBe(true);
+  });
+
+  it("refuses escaped semantic-input targets without recommending a build that must fail", async () => {
+    const root = temporaryRoot("mex-graph-contained-semantic-");
+    const externalRoot = temporaryRoot("mex-graph-external-semantic-");
+    source(root, "src/a.ts", "export const a: number = 1;\n");
+    source(root, "config/base.json", JSON.stringify({ compilerOptions: { strict: true } }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./config/base.json",
+      include: ["src/**/*.ts"],
+    }));
+    source(externalRoot, "base.json", JSON.stringify({ compilerOptions: { strict: false } }));
+    await build(root);
+    unlinkSync(join(root, "config", "base.json"));
+    symlinkSync(join(externalRoot, "base.json"), join(root, "config", "base.json"));
+
+    const readPaths: string[] = [];
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        afterSemanticInputRead(path) {
+          readPaths.push(path);
+        },
+      },
+    });
+
+    expect(status.status).toBe("stale");
+    expect(status.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_PATH_OUTSIDE_PROJECT",
+      path: "config/base.json",
+    }));
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
+    }));
+    expect(readPaths).not.toContain("config/base.json");
+    expect(executableRemediations(status)).not.toContain("mex graph");
+  });
+
+  it("does not treat a negative semantic probe below an escaped ancestor as safely absent", async () => {
+    const root = temporaryRoot("mex-graph-negative-probe-escape-");
+    const externalRoot = temporaryRoot("mex-graph-negative-probe-external-");
+    source(root, "src/a.ts", "export const a: number = 1;\n");
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      references: [{ path: "./probes/optional.json" }],
+      include: ["src/**/*.ts"],
+    }));
+    const dbPath = await build(root);
+    expect(readSnapshot(dbPath).semanticInputs).toContainEqual({
+      path: "probes/optional.json",
+      contentHash: null,
+    });
+    mkdirSync(join(externalRoot, "probes"), { recursive: true });
+    symlinkSync(join(externalRoot, "probes"), join(root, "probes"));
+
+    const status = await inspect(root);
+
+    expect(status.status).toBe("stale");
+    expect(status.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_PATH_OUTSIDE_PROJECT",
+      path: "probes/optional.json",
+    }));
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
+    }));
+    expect(executableRemediations(status)).not.toContain("mex graph");
+  });
+
+  it("never emits fresh when a semantic-input path is atomically replaced after it is read", async () => {
+    const root = temporaryRoot("mex-graph-semantic-race-");
+    const basePath = join(root, "config", "base.json");
+    source(root, "src/a.ts", "export const a: number = 1;\n");
+    source(root, "config/base.json", JSON.stringify({ compilerOptions: { strict: true } }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./config/base.json",
+      include: ["src/**/*.ts"],
+    }));
+    await build(root);
+    const replacement = join(root, "config", "base.json.next");
+    writeFileSync(replacement, JSON.stringify({ compilerOptions: { strict: false } }));
+    let replaced = false;
+
+    const status = await inspectGraphStatus({
+      projectRoot: root,
+      now: NOW,
+      internal: {
+        afterSemanticInputRead(path, pass) {
+          if (!replaced && pass === "validation" && path === "config/base.json") {
+            replaced = true;
+            renameSync(replacement, basePath);
+          }
+        },
+      },
+    });
+
+    expect(replaced).toBe(true);
+    expect(status.status).toBe("stale");
+    expect(status.changes).toMatchObject({ total: 0, configChanged: true });
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_SEMANTIC_INPUT_CHANGED",
+      path: "config/base.json",
+    }));
+  });
+
+  it("reports config/manifest drift without treating non-source HEAD movement as stale", async () => {
+    const root = temporaryRoot();
+    source(root, "src/a.ts", "export const a = 1;\n");
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fixture", type: "module" }));
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { module: "ESNext" } }));
+    git(root, "init", "-q", "-b", "main");
+    git(root, "config", "user.name", "Status Test");
+    git(root, "config", "user.email", "status@example.invalid");
+    writeFileSync(join(root, ".gitignore"), ".mex/graph.db*\n");
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "fixture");
+    await build(root);
+
+    git(root, "commit", "--allow-empty", "-qm", "non-source head movement");
+    const headOnly = await inspect(root);
+    expect(headOnly.status).toBe("fresh");
+    expect(headOnly.changes.branchChanged).toBe(false);
+    expect(headOnly.diagnostics).toContainEqual(expect.objectContaining({ code: "GRAPH_INDEX_HEAD_CHANGED" }));
+
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { module: "NodeNext" } }));
+    const configChanged = await inspect(root);
+    expect(configChanged.status).toBe("stale");
+    expect(configChanged.changes).toMatchObject({
+      total: 0,
+      configChanged: true,
+      manifestChanged: true,
+      grammarChanged: false,
+    });
+    expect(configChanged.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_BUILD_MANIFEST_CHANGED",
+      remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }],
+    }));
+  });
+
+  it("detects a branch switch even when HEAD and source bytes are unchanged", async () => {
+    const root = temporaryRoot();
+    source(root, "src/a.ts", "export const a = 1;\n");
+    git(root, "init", "-q", "-b", "main");
+    git(root, "config", "user.name", "Status Test");
+    git(root, "config", "user.email", "status@example.invalid");
+    writeFileSync(join(root, ".gitignore"), ".mex/graph.db*\n");
+    git(root, "add", ".");
+    git(root, "commit", "-qm", "fixture");
+    await build(root);
+    git(root, "switch", "-qc", "feature/status");
+
+    const status = await inspect(root);
+    expect(status.currentRepo.branch).toBe("feature/status");
+    expect(status.currentRepo.head).toBe(status.indexedHead);
+    expect(status.status).toBe("stale");
+    expect(status.changes).toMatchObject({ total: 0, branchChanged: true });
+    expect(status.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_BRANCH_CHANGED",
+      remediation: [{ label: "Republish graph for this branch", command: "mex graph" }],
+    }));
+  });
+});

--- a/src/graph/__tests__/status.test.ts
+++ b/src/graph/__tests__/status.test.ts
@@ -168,7 +168,7 @@ describe("inspectGraphStatus", () => {
       expect(status.diagnostics).toContainEqual(expect.objectContaining({
         code: "GRAPH_SOURCE_CORPUS_MISMATCH",
       }));
-      expect(executableRemediations(status)).not.toContain("mex graph");
+      expect(executableRemediations(status)).toEqual([]);
     } finally {
       if (previousPath === undefined) delete process.env.PATH;
       else process.env.PATH = previousPath;
@@ -312,14 +312,10 @@ describe("inspectGraphStatus", () => {
     expect(status.schemaVersion).toBe(schemaVersion);
     const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_REBUILD_REQUIRED");
     expect(diagnostic).toBeDefined();
-    if (schemaVersion < 2) {
-      expect(diagnostic?.remediation).toEqual([{ label: "Rebuild graph", command: "mex graph" }]);
-    } else {
-      expect(diagnostic?.remediation).toBeUndefined();
-    }
+    expect(diagnostic?.remediation).toEqual([{ label: "Rebuild graph", command: "mex graph rebuild" }]);
   });
 
-  it("treats an empty recorded schema version as commandless corruption", async () => {
+  it("offers isolated rebuild recovery for an empty recorded schema version", async () => {
     const root = temporaryRoot("mex-graph-invalid-version-");
     source(root, "src/a.ts", "export const a = 1;\n");
     const dbPath = await build(root);
@@ -335,6 +331,7 @@ describe("inspectGraphStatus", () => {
     const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
     expect(diagnostic?.message).toContain("invalid version");
     expect(diagnostic?.remediation).toBeUndefined();
+    expect(executableRemediations(status)).toContain("mex graph rebuild");
   });
 
   it("distinguishes a corrupt database from an active-WAL transient state", async () => {
@@ -346,8 +343,7 @@ describe("inspectGraphStatus", () => {
     expect(corrupt.status).toBe("corrupt");
     expect(corrupt.changes.total).toBe(0);
     expect(corrupt.diagnostics).toContainEqual(expect.objectContaining({ code: "GRAPH_INDEX_CORRUPT" }));
-    expect(corrupt.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(corrupt)).toContain("mex graph rebuild");
     expect(treeState(corruptRoot)).toEqual(corruptBefore);
 
     const transientRoot = temporaryRoot("mex-graph-transient-");
@@ -574,7 +570,7 @@ describe("inspectGraphStatus", () => {
     expect(status.status).toBe("stale");
     expect(status.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_SNAPSHOT_LEGACY",
-      remediation: [{ label: "Republish graph snapshot", command: "mex graph" }],
+      remediation: [{ label: "Republish graph snapshot", command: "mex graph refresh" }],
     }));
     expect(status.changes.total).toBe(0);
   });
@@ -592,8 +588,7 @@ describe("inspectGraphStatus", () => {
     }
     const malformed = await inspect(malformedRoot);
     expect(malformed.status).toBe("corrupt");
-    expect(malformed.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(malformed)).toContain("mex graph rebuild");
 
     const digestRoot = temporaryRoot("mex-graph-snapshot-digest-");
     source(digestRoot, "src/a.ts", "export const a = 1;\n");
@@ -607,8 +602,7 @@ describe("inspectGraphStatus", () => {
     expect(digestMismatch.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_SNAPSHOT_CONTENT_MISMATCH",
     }));
-    expect(digestMismatch.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(digestMismatch)).toContain("mex graph rebuild");
 
     const inconsistentRoot = temporaryRoot("mex-graph-snapshot-mismatch-");
     source(inconsistentRoot, "src/a.ts", "export const a = 1;\n");
@@ -623,8 +617,7 @@ describe("inspectGraphStatus", () => {
     expect(inconsistent.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_SNAPSHOT_CONTENT_MISMATCH",
     }));
-    expect(inconsistent.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(inconsistent)).toContain("mex graph rebuild");
   }, 10_000);
 
   it("treats missing core tables and duplicate or dangling edges as corrupt", async () => {
@@ -708,7 +701,7 @@ describe("inspectGraphStatus", () => {
     expect(diagnostic?.remediation).toBeUndefined();
   });
 
-  it("does not advertise in-place repair for a conflicting versionless schema", async () => {
+  it("advertises only isolated rebuild for a conflicting versionless schema", async () => {
     const root = temporaryRoot("mex-graph-versionless-");
     source(root, "src/a.ts", "export const a = 1;\n");
     mkdirSync(join(root, ".mex"), { recursive: true });
@@ -724,6 +717,7 @@ describe("inspectGraphStatus", () => {
     const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_SCHEMA_INVALID");
     expect(diagnostic?.message).toContain("incompatible schema objects");
     expect(diagnostic?.remediation).toBeUndefined();
+    expect(executableRemediations(status)).toContain("mex graph rebuild");
   });
 
   it("detects dangling ownership, alias, reference, import, and LSH records", async () => {
@@ -815,8 +809,7 @@ describe("inspectGraphStatus", () => {
     const diagnostic = status.diagnostics.find((entry) => entry.code === "GRAPH_INDEX_INVARIANT_FAILED");
     expect(diagnostic?.message).toContain("malformed fingerprint row(s)");
     expect(diagnostic?.remediation).toBeUndefined();
-    expect(status.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(status)).toContain("mex graph rebuild");
   });
 
   it("requires one correct LSH hash for every configured fingerprint band", async () => {
@@ -860,8 +853,7 @@ describe("inspectGraphStatus", () => {
     expect(diagnostic?.message).toContain("out-of-range fingerprint LSH bucket row(s)");
     expect(diagnostic?.message).toContain("fingerprint LSH bucket hash mismatch(es)");
     expect(diagnostic?.remediation).toBeUndefined();
-    expect(status.diagnostics.flatMap((entry) => entry.remediation ?? []))
-      .not.toContainEqual(expect.objectContaining({ command: expect.any(String) }));
+    expect(executableRemediations(status)).toContain("mex graph rebuild");
   });
 
   it("cross-checks node and source-chunk FTS row parity", async () => {
@@ -1010,7 +1002,7 @@ describe("inspectGraphStatus", () => {
       path: "config/base.json",
       message: expect.stringContaining("changed"),
     }));
-    expect(executableRemediations(changed)).toContain("mex graph");
+    expect(executableRemediations(changed)).toContain("mex graph refresh");
 
     writeFileSync(basePath, base);
     expect((await inspect(root)).status).toBe("fresh");
@@ -1023,7 +1015,7 @@ describe("inspectGraphStatus", () => {
       path: "config/base.json",
       message: expect.stringContaining("disappeared"),
     }));
-    expect(executableRemediations(disappeared)).toContain("mex graph");
+    expect(executableRemediations(disappeared)).toContain("mex graph refresh");
 
     writeFileSync(basePath, base);
     source(root, "config/optional.json", JSON.stringify({ compilerOptions: { noEmit: true } }));
@@ -1035,7 +1027,7 @@ describe("inspectGraphStatus", () => {
       path: "config/optional.json",
       message: expect.stringContaining("appeared"),
     }));
-    expect(executableRemediations(appeared)).toContain("mex graph");
+    expect(executableRemediations(appeared)).toContain("mex graph refresh");
     expect(statSync(missingPath).isFile()).toBe(true);
   });
 
@@ -1074,7 +1066,7 @@ describe("inspectGraphStatus", () => {
       code: "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
     }));
     expect(readPaths).not.toContain("config/base.json");
-    expect(executableRemediations(status)).not.toContain("mex graph");
+    expect(executableRemediations(status)).toEqual([]);
   });
 
   it("does not treat a negative semantic probe below an escaped ancestor as safely absent", async () => {
@@ -1104,7 +1096,7 @@ describe("inspectGraphStatus", () => {
     expect(status.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
     }));
-    expect(executableRemediations(status)).not.toContain("mex graph");
+    expect(executableRemediations(status)).toEqual([]);
   });
 
   it("never emits fresh when a semantic-input path is atomically replaced after it is read", async () => {
@@ -1173,7 +1165,7 @@ describe("inspectGraphStatus", () => {
     });
     expect(configChanged.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_BUILD_MANIFEST_CHANGED",
-      remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }],
+      remediation: [{ label: "Republish graph with current inputs", command: "mex graph refresh" }],
     }));
   });
 
@@ -1196,7 +1188,7 @@ describe("inspectGraphStatus", () => {
     expect(status.changes).toMatchObject({ total: 0, branchChanged: true });
     expect(status.diagnostics).toContainEqual(expect.objectContaining({
       code: "GRAPH_INDEX_BRANCH_CHANGED",
-      remediation: [{ label: "Republish graph for this branch", command: "mex graph" }],
+      remediation: [{ label: "Republish graph for this branch", command: "mex graph refresh" }],
     }));
   });
 });

--- a/src/graph/__tests__/sync-corpus-guard.test.ts
+++ b/src/graph/__tests__/sync-corpus-guard.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { openSqlite } from "../db/sqlite.js";
+import { createGraphEngine } from "../engine-impl.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  parseGraphSnapshot,
+  type GraphSnapshotSemanticInput,
+} from "../snapshot.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function temporaryRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-empty-sync-"));
+  roots.push(root);
+  return root;
+}
+
+function sha256(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+function semanticInputs(root: string): GraphSnapshotSemanticInput[] {
+  const db = openSqlite(join(root, ".mex", "graph.db"));
+  try {
+    const row = db.prepare("SELECT value FROM project_metadata WHERE key = ?")
+      .get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
+    const snapshot = parseGraphSnapshot(typeof row?.value === "string" ? row.value : null);
+    if (!snapshot) throw new Error("Expected a valid graph snapshot.");
+    return snapshot.semanticInputs;
+  } finally {
+    db.close();
+  }
+}
+
+describe("GraphEngine empty sync corpus guard", () => {
+  it("only no-ops when the supported paths and exact content hashes still match", async () => {
+    const root = temporaryRoot();
+    const sourcePath = join(root, "src", "entry.ts");
+    const original = "export function emptySyncAlpha(): number { return 1; }\n";
+    const replacement = "export function emptySyncBravo(): number { return 2; }\n";
+    const fixedTime = new Date("2024-01-01T00:00:00.000Z");
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(sourcePath, original);
+    utimesSync(sourcePath, fixedTime, fixedTime);
+
+    const engine = createGraphEngine({ rootDir: root });
+    try {
+      await engine.build();
+
+      expect(await engine.sync([])).toMatchObject({
+        filesIndexed: 0,
+        nodesCreated: 0,
+        edgesCreated: 0,
+      });
+
+      writeFileSync(sourcePath, replacement);
+      utimesSync(sourcePath, fixedTime, fixedTime);
+      expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+      expect(statSync(sourcePath).mtimeMs).toBe(fixedTime.getTime());
+
+      expect(await engine.sync([])).toMatchObject({ filesIndexed: 1 });
+      expect(engine.searchNodes("emptySyncAlpha").some((node) => node.name === "emptySyncAlpha")).toBe(false);
+      expect(engine.searchNodes("emptySyncBravo").some((node) => node.name === "emptySyncBravo")).toBe(true);
+      expect(engine.getIndexedFiles?.()).toEqual([
+        expect.objectContaining({ path: "src/entry.ts", contentHash: sha256(replacement) }),
+      ]);
+
+      writeFileSync(join(root, "src", "added.ts"), "export const addedDuringEmptySync = true;\n");
+      expect(await engine.sync([])).toMatchObject({ filesIndexed: 2 });
+      expect(engine.getIndexedFiles?.().map((file) => file.path)).toEqual([
+        "src/added.ts",
+        "src/entry.ts",
+      ]);
+
+      rmSync(sourcePath);
+      expect(await engine.sync([])).toMatchObject({ filesIndexed: 1 });
+      expect(engine.getIndexedFiles?.().map((file) => file.path)).toEqual(["src/added.ts"]);
+    } finally {
+      engine.close();
+    }
+  }, 20_000);
+
+  it("rebuilds when persisted positive or negative semantic inputs change", async () => {
+    const root = temporaryRoot();
+    const basePath = join(root, "config", "base.json");
+    const optionalPath = join(root, "config", "optional.json");
+    const initialBase = JSON.stringify({ compilerOptions: { strict: true } });
+    const changedBase = JSON.stringify({ compilerOptions: { strict: false } });
+    const optional = JSON.stringify({ compilerOptions: { composite: true }, files: [] });
+    mkdirSync(join(root, "src"), { recursive: true });
+    mkdirSync(join(root, "config"), { recursive: true });
+    writeFileSync(join(root, "src", "entry.ts"), "export const semanticGuardFact: number = 1;\n");
+    writeFileSync(basePath, initialBase);
+    writeFileSync(join(root, "tsconfig.json"), JSON.stringify({
+      extends: "./config/base.json",
+      references: [{ path: "./config/optional.json" }],
+      include: ["src/**/*.ts"],
+    }));
+
+    const engine = createGraphEngine({ rootDir: root });
+    try {
+      await engine.build();
+      expect(semanticInputs(root)).toEqual(expect.arrayContaining([
+        { path: "config/base.json", contentHash: sha256(initialBase) },
+        { path: "config/optional.json", contentHash: null },
+      ]));
+
+      writeFileSync(basePath, changedBase);
+      expect(await engine.sync([])).toMatchObject({ filesIndexed: 1 });
+      expect(semanticInputs(root)).toContainEqual({
+        path: "config/base.json",
+        contentHash: sha256(changedBase),
+      });
+
+      writeFileSync(optionalPath, optional);
+      expect(await engine.sync([])).toMatchObject({ filesIndexed: 1 });
+      expect(semanticInputs(root)).toContainEqual({
+        path: "config/optional.json",
+        contentHash: sha256(optional),
+      });
+    } finally {
+      engine.close();
+    }
+  });
+});

--- a/src/graph/cli-agent.ts
+++ b/src/graph/cli-agent.ts
@@ -1792,6 +1792,8 @@ function scopeEdgeKey(edge: Pick<GraphEdge, "source" | "target" | "kind" | "line
 }
 
 function openSession(rootDir: string, deps: AgentCommandDeps, write: (line: string) => void): AgentGraphSession | null {
+  let graph: GraphEngine | null = null;
+  let db: SqliteDatabase | null = null;
   try {
     if (deps.open) return deps.open(rootDir);
     const dbPath = resolve(rootDir, ".mex", "graph.db");
@@ -1799,18 +1801,22 @@ function openSession(rootDir: string, deps: AgentCommandDeps, write: (line: stri
       writeJson(write, { type: "error", code: "GRAPH_UNAVAILABLE", message: "Run `mex graph` first." });
       return null;
     }
-    const graph = createGraphEngine({ rootDir, dbPath, readOnly: true });
-    const db = openGraphDatabase(dbPath, { readOnly: true });
+    graph = createGraphEngine({ rootDir, dbPath, readOnly: true });
+    db = openGraphDatabase(dbPath, { readOnly: true });
     const storedManifest = db.prepare(
       "SELECT value FROM project_metadata WHERE key = 'manifest_hash'",
     ).get() as { value: string } | undefined;
     if (storedManifest?.value !== graphManifest(resolve(rootDir)).manifestHash) {
-      graph.close();
-      db.close();
       throw new GraphRebuildRequiredError("The code graph build manifest is stale.");
     }
-    return { graph, db, close: () => { graph.close(); db.close(); } };
+    const sessionGraph = graph;
+    const sessionDb = db;
+    graph = null;
+    db = null;
+    return { graph: sessionGraph, db: sessionDb, close: () => { sessionGraph.close(); sessionDb.close(); } };
   } catch (error) {
+    graph?.close();
+    db?.close();
     unavailable(write, error);
     return null;
   }

--- a/src/graph/cli-agent.ts
+++ b/src/graph/cli-agent.ts
@@ -1,9 +1,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { globSync } from "glob";
-import { createGraphEngine, graphManifest } from "./engine-impl.js";
+import { graphManifest } from "./engine-impl.js";
 import type { GraphEngine, GraphNeighbor, IndexedFileInfo } from "./engine.js";
-import { openGraphDatabase } from "./db/database.js";
 import type { SqliteDatabase } from "./db/sqlite.js";
 import { isSupportedSourceFile, SUPPORTED_SOURCE_GLOB } from "./extraction/index.js";
 import type { GraphEdge, GraphNode } from "./types.js";
@@ -18,12 +17,23 @@ import {
 } from "./agent-protocol.js";
 import { identifierComponents, isLowValueGraphPath, planGraphQuery } from "./retrieval/query.js";
 import { GraphRebuildRequiredError } from "./errors.js";
+import {
+  loadFreshGraphReadSession,
+  openImmutableGraphReadSessionSync,
+  type GraphFreshnessRevalidation,
+  type GraphReadValidation,
+  type LoadFreshGraphReadSessionOptions,
+} from "./read-session.js";
+import type { GraphStatus } from "../team/contracts/graph.js";
 
 type QueryRelation = "who-calls" | "what-calls" | "where-defined";
 
 interface AgentGraphSession {
   graph: GraphEngine;
   db: SqliteDatabase;
+  readIndexedSource?: (filePath: string) => string;
+  validate?: () => GraphReadValidation;
+  revalidateFreshness?: () => Promise<GraphFreshnessRevalidation>;
   close(): void;
 }
 
@@ -41,12 +51,10 @@ export function runImpact(
   rootDir = process.cwd(),
   deps: AgentCommandDeps = {},
   rawOptions: RawOptions = {},
-): void {
-  const write = deps.write ?? console.log;
+): void | Promise<void> {
+  const output = deps.write ?? console.log;
   const opts = resolveOptions(rawOptions);
-  const session = openSession(rootDir, deps, write);
-  if (!session) return;
-  try {
+  return withAgentGraphSession(rootDir, deps, output, "fresh", (session, write) => {
     const fileNodes = nodesForFile(session, rootDir, target);
     const roots = fileNodes.length > 0 ? fileNodes : resolveSymbol(session.graph, target);
     if (roots.length === 0) {
@@ -101,7 +109,7 @@ export function runImpact(
       emittedNodes.push(entry.node);
     }
 
-    const sourceRecords = planSource(ledger, emittedNodes, rootDir, opts);
+    const sourceRecords = planSource(session, ledger, emittedNodes, rootDir, opts);
 
     const affectedIds = [...new Set([...roots.map((node) => node.id), ...impacted.keys()])];
     const groundingRecords: Rec[] = [];
@@ -118,11 +126,7 @@ export function runImpact(
       truncated,
       suggestedNextCommands: emittedNodes.length > 0 ? [`mex graph get ${emittedNodes[0]!.id} --detail source`] : [],
     })));
-  } catch (error) {
-    unavailable(write, error);
-  } finally {
-    try { session.close(); } catch { /* best-effort degradation cleanup */ }
-  }
+  });
 }
 
 /** Structural graph lookup. Output is newline-delimited JSON (JSONL). */
@@ -132,16 +136,14 @@ export function runGraphQuery(
   rootDir = process.cwd(),
   deps: AgentCommandDeps = {},
   rawOptions: RawOptions = {},
-): void {
-  const write = deps.write ?? console.log;
+): void | Promise<void> {
+  const output = deps.write ?? console.log;
   if (!isRelation(relation)) {
-    writeJson(write, { type: "error", code: "INVALID_QUERY", relation, expected: ["who-calls", "what-calls", "where-defined"] });
+    writeJson(output, { type: "error", code: "INVALID_QUERY", relation, expected: ["who-calls", "what-calls", "where-defined"] });
     return;
   }
   const opts = resolveOptions(rawOptions);
-  const session = openSession(rootDir, deps, write);
-  if (!session) return;
-  try {
+  return withAgentGraphSession(rootDir, deps, output, "fresh", (session, write) => {
     const nodes = resolveSymbol(session.graph, target);
     if (nodes.length === 0) {
       writeJson(write, { type: "error", code: "TARGET_NOT_FOUND", target });
@@ -178,7 +180,7 @@ export function runGraphQuery(
       entries.push({ record, node: pair.node });
     }
 
-    const sourceRecords = planSource(ledger, entries.map((e) => e.node), rootDir, opts);
+    const sourceRecords = planSource(session, ledger, entries.map((e) => e.node), rootDir, opts);
 
     emitAll(write, meta, [...entries.map((e) => e.record), ...sourceRecords]);
     write(JSON.stringify(summaryRecord(ctx, {
@@ -188,11 +190,7 @@ export function runGraphQuery(
       truncated,
       suggestedNextCommands: entries.length > 0 && opts.detail !== "source" ? [`mex graph get ${entries[0]!.node.id} --detail source`] : [],
     })));
-  } catch (error) {
-    unavailable(write, error);
-  } finally {
-    try { session.close(); } catch { /* best-effort degradation cleanup */ }
-  }
+  });
 }
 
 /** Broad graph retrieval. One source-bearing response is the normal success path. */
@@ -202,10 +200,8 @@ export function runGraphScope(
   deps: AgentCommandDeps = {},
   rawOptions: RawOptions = {},
 ): void {
-  const write = deps.write ?? console.log;
-  const session = openSession(rootDir, deps, write);
-  if (!session) return;
-  try {
+  const output = deps.write ?? console.log;
+  return withAgentGraphSession(rootDir, deps, output, "stable", (session, write) => {
     const indexedFiles = session.graph.getIndexedFiles?.() ?? [];
     const opts = resolveScopeOptions(rawOptions, indexedFiles.length);
     const staleFiles = indexedFiles.filter((file) => {
@@ -683,11 +679,7 @@ export function runGraphScope(
       textFallbackFiles,
       warnings,
     })));
-  } catch (error) {
-    unavailable(write, error);
-  } finally {
-    try { session.close(); } catch { /* best-effort degradation cleanup */ }
-  }
+  });
 }
 
 /** Targeted source expansion by node id. Output is JSONL source records. */
@@ -696,12 +688,10 @@ export function runGraphGet(
   rootDir = process.cwd(),
   deps: AgentCommandDeps = {},
   rawOptions: RawOptions = {},
-): void {
-  const write = deps.write ?? console.log;
+): void | Promise<void> {
+  const output = deps.write ?? console.log;
   const opts = resolveOptions({ ...rawOptions, detail: "source" });
-  const session = openSession(rootDir, deps, write);
-  if (!session) return;
-  try {
+  return withAgentGraphSession(rootDir, deps, output, "fresh", (session, write) => {
     const ctx = beginResponse("graph get", { ...opts, maxNodes: ids.length, maxFlowSteps: 0 }, undefined, []);
     const { ledger, meta } = ctx;
 
@@ -717,7 +707,7 @@ export function runGraphGet(
       }
       nodes.push(node);
     }
-    const sourceRecords = planSource(ledger, nodes, rootDir, opts);
+    const sourceRecords = planSource(session, ledger, nodes, rootDir, opts);
     const sourcedIds = new Set(
       sourceRecords.flatMap((record) => (record.ranges as SourceRange[]).flatMap((range) => range.nodeIds)),
     );
@@ -730,11 +720,7 @@ export function runGraphGet(
       truncated,
       suggestedNextCommands: [],
     })));
-  } catch (error) {
-    unavailable(write, error);
-  } finally {
-    try { session.close(); } catch { /* best-effort degradation cleanup */ }
-  }
+  });
 }
 
 // ── shared helpers ──────────────────────────────────────────────────────────
@@ -923,7 +909,13 @@ function finalizedSummary(usedTokens: number, base: Rec): Rec {
  * ledger, only when detail is "source". Source ranges carry their node ids, so
  * facts do not repeat a mutable `sourceIncluded` flag.
  */
-function planSource(ledger: BudgetLedger, nodes: GraphNode[], rootDir: string, opts: AgentOptions): Rec[] {
+function planSource(
+  session: AgentGraphSession,
+  ledger: BudgetLedger,
+  nodes: GraphNode[],
+  rootDir: string,
+  opts: AgentOptions,
+): Rec[] {
   if (opts.detail !== "source") return [];
   const sourceRecords: Rec[] = [];
   const emit = (record: Rec): void => {
@@ -931,8 +923,14 @@ function planSource(ledger: BudgetLedger, nodes: GraphNode[], rootDir: string, o
     sourceRecords.push(record);
   };
   for (const [filePath, fileNodes] of groupByFile(dedupeById(nodes))) {
+    // Default production sessions bind every range for a file to one exact,
+    // hash-verified buffer. Injected fixtures keep their historical synchronous
+    // reader so protocol goldens do not gain filesystem behavior.
+    const source = session.readIndexedSource?.(filePath);
     const ranges = fileNodes
-      .map((node) => readNodeSource(node, rootDir, opts.maxSourceLines))
+      .map((node) => source === undefined
+        ? readNodeSource(node, rootDir, opts.maxSourceLines)
+        : readNodeSourceBuffer(node, source, opts.maxSourceLines))
       .filter((range): range is SourceRange => range !== null);
     if (ranges.length === 0) continue;
     const grouped: Rec = { type: "source", filePath, ranges };
@@ -942,6 +940,24 @@ function planSource(ledger: BudgetLedger, nodes: GraphNode[], rootDir: string, o
     else for (const range of ranges) emit({ type: "source", filePath, ranges: [range] });
   }
   return sourceRecords;
+}
+
+function readNodeSourceBuffer(node: GraphNode, source: string, maxLines: number): SourceRange {
+  const lines = source.split("\n");
+  const body = lines.slice(node.startLine - 1, node.endLine);
+  const truncated = maxLines > 0 && body.length > maxLines;
+  const kept = truncated ? body.slice(0, maxLines) : body;
+  const width = String(node.startLine + Math.max(0, kept.length - 1)).length;
+  return {
+    startLine: node.startLine,
+    endLine: node.startLine + Math.max(0, kept.length - 1),
+    nodeIds: [node.id],
+    content: kept.map((line, index) => (
+      `${String(node.startLine + index).padStart(width)}: ${line}`
+    )).join("\n"),
+    truncated,
+    reason: truncated ? "signature" : "complete-symbol",
+  };
 }
 
 function emitAll(write: (line: string) => void, meta: Rec, records: Rec[]): void {
@@ -1791,35 +1807,173 @@ function scopeEdgeKey(edge: Pick<GraphEdge, "source" | "target" | "kind" | "line
   return `${edge.source}\0${edge.target}\0${edge.kind}\0${edge.line ?? -1}\0${edge.column ?? -1}`;
 }
 
-function openSession(rootDir: string, deps: AgentCommandDeps, write: (line: string) => void): AgentGraphSession | null {
-  let graph: GraphEngine | null = null;
-  let db: SqliteDatabase | null = null;
+type AgentSessionMode = "stable" | "fresh";
+type AgentSessionTask = (session: AgentGraphSession, write: (line: string) => void) => void;
+
+interface AgentCommandInternalHooks {
+  freshRead?: Omit<LoadFreshGraphReadSessionOptions, "dbPath" | "loadSession">;
+  beforeFinalFreshnessValidation?: () => void | Promise<void>;
+}
+
+type AgentCommandInternalDeps = AgentCommandDeps & {
+  /** Module-private deterministic race seams; deliberately absent from declarations. */
+  __internal?: AgentCommandInternalHooks;
+};
+
+function withAgentGraphSession(
+  rootDir: string,
+  deps: AgentCommandDeps,
+  write: (line: string) => void,
+  mode: "stable",
+  task: AgentSessionTask,
+): void;
+function withAgentGraphSession(
+  rootDir: string,
+  deps: AgentCommandDeps,
+  write: (line: string) => void,
+  mode: "fresh",
+  task: AgentSessionTask,
+): void | Promise<void>;
+function withAgentGraphSession(
+  rootDir: string,
+  deps: AgentCommandDeps,
+  write: (line: string) => void,
+  mode: AgentSessionMode,
+  task: AgentSessionTask,
+): void | Promise<void> {
+  // Existing injected graph fixtures are already caller-owned snapshots. Keep
+  // them synchronous so protocol goldens and deterministic unit harnesses do
+  // not acquire filesystem/Git behavior they did not request.
+  if (deps.open) return runInjectedAgentSession(rootDir, deps.open, write, task);
+  if (mode === "stable") return runStableAgentSession(rootDir, write, task);
+  return runFreshAgentSession(rootDir, deps as AgentCommandInternalDeps, write, task);
+}
+
+function runInjectedAgentSession(
+  rootDir: string,
+  open: NonNullable<AgentCommandDeps["open"]>,
+  write: (line: string) => void,
+  task: AgentSessionTask,
+): void {
+  let session: AgentGraphSession | null = null;
+  const pending: string[] = [];
   try {
-    if (deps.open) return deps.open(rootDir);
+    session = open(rootDir);
+    task(session, (line) => pending.push(line));
+    for (const line of pending) write(line);
+  } catch (error) {
+    unavailable(write, error);
+  } finally {
+    try { session?.close(); } catch { /* best-effort degradation cleanup */ }
+  }
+}
+
+function runStableAgentSession(
+  rootDir: string,
+  write: (line: string) => void,
+  task: AgentSessionTask,
+): void {
+  let session: AgentGraphSession | null = null;
+  const pending: string[] = [];
+  try {
     const dbPath = resolve(rootDir, ".mex", "graph.db");
     if (!existsSync(dbPath)) {
       writeJson(write, { type: "error", code: "GRAPH_UNAVAILABLE", message: "Run `mex graph` first." });
-      return null;
+      return;
     }
-    graph = createGraphEngine({ rootDir, dbPath, readOnly: true });
-    db = openGraphDatabase(dbPath, { readOnly: true });
-    const storedManifest = db.prepare(
+    const opened = openImmutableGraphReadSessionSync(rootDir, dbPath);
+    session = { ...opened };
+    const storedManifest = session.db.prepare(
       "SELECT value FROM project_metadata WHERE key = 'manifest_hash'",
     ).get() as { value: string } | undefined;
     if (storedManifest?.value !== graphManifest(resolve(rootDir)).manifestHash) {
       throw new GraphRebuildRequiredError("The code graph build manifest is stale.");
     }
-    const sessionGraph = graph;
-    const sessionDb = db;
-    graph = null;
-    db = null;
-    return { graph: sessionGraph, db: sessionDb, close: () => { sessionGraph.close(); sessionDb.close(); } };
+    task(session, (line) => pending.push(line));
+    const validation = session.validate?.() ?? { valid: true };
+    if (!validation.valid) {
+      unavailable(write, Object.assign(
+        new Error(validation.message ?? "The graph changed while output was being prepared."),
+        { code: validation.code ?? "GRAPH_UNAVAILABLE" },
+      ));
+      return;
+    }
+    for (const line of pending) write(line);
   } catch (error) {
-    graph?.close();
-    db?.close();
     unavailable(write, error);
-    return null;
+  } finally {
+    try { session?.close(); } catch { /* best-effort degradation cleanup */ }
   }
+}
+
+async function runFreshAgentSession(
+  rootDir: string,
+  deps: AgentCommandInternalDeps,
+  write: (line: string) => void,
+  task: AgentSessionTask,
+): Promise<void> {
+  let session: AgentGraphSession | null = null;
+  const pending: string[] = [];
+  try {
+    const dbPath = resolve(rootDir, ".mex", "graph.db");
+    const loaded = await loadFreshGraphReadSession(rootDir, {
+      ...deps.__internal?.freshRead,
+      dbPath,
+      loadSession: true,
+    });
+    if (!loaded.session) {
+      graphStatusUnavailable(write, loaded.graphStatus);
+      return;
+    }
+    session = { ...loaded.session };
+    try {
+      task(session, (line) => pending.push(line));
+    } catch (error) {
+      const validation = session.validate?.();
+      if (validation && !validation.valid) {
+        graphStatusUnavailable(write, loaded.graphStatus, validation);
+        return;
+      }
+      throw error;
+    }
+    await deps.__internal?.beforeFinalFreshnessValidation?.();
+    const final = await session.revalidateFreshness!();
+    if (!final.valid) {
+      graphStatusUnavailable(write, final.graphStatus, final);
+      return;
+    }
+    for (const line of pending) write(line);
+  } catch (error) {
+    unavailable(write, error);
+  } finally {
+    try { session?.close(); } catch { /* best-effort degradation cleanup */ }
+  }
+}
+
+function graphStatusUnavailable(
+  write: (line: string) => void,
+  status: GraphStatus,
+  validation?: GraphReadValidation,
+): void {
+  const diagnostic = validation?.code
+    ? status.diagnostics.find((entry) => entry.code === validation.code)
+    : [...status.diagnostics].reverse().find((entry) => entry.severity !== "info")
+      ?? status.diagnostics.at(-1);
+  const graphStatus = validation && status.status === "fresh" ? "degraded" : status.status;
+  const recoveryCommand = diagnostic?.remediation?.find((entry) => entry.command)?.command
+    ?? status.diagnostics.flatMap((entry) => entry.remediation ?? [])
+      .find((entry) => entry.command)?.command;
+  writeJson(write, {
+    type: "error",
+    code: "GRAPH_UNAVAILABLE",
+    graphStatus,
+    ...(validation?.code || diagnostic?.code
+      ? { reasonCode: validation?.code ?? diagnostic?.code }
+      : {}),
+    message: validation?.message ?? diagnostic?.message
+      ?? `The graph is ${graphStatus}; no graph-derived result was returned.`,
+    ...(recoveryCommand ? { recoveryCommand } : {}),
+  });
 }
 
 function resolveSymbol(graph: GraphEngine, target: string): GraphNode[] {

--- a/src/graph/cli-graph.ts
+++ b/src/graph/cli-graph.ts
@@ -1,40 +1,107 @@
-// ============================================================================
-// mex code-graph — `mex graph` command  (A6)
-// ============================================================================
-//
-// Build/rebuild the code graph into `.mex/graph.db`. Deterministic (tree-sitter
-// → SQLite, zero LLM). Runs in `mex setup` for fresh installs and on demand.
-// Kept self-contained so `src/cli.ts` wires it with a single lazy import (like
-// every other command), never disturbing the existing surface.
-
-import { createGraphEngine } from "./index.js";
+import type { GraphSourceChanges, GraphStatus } from "../team/contracts/graph.js";
+import {
+  rebuildGraph,
+  refreshGraph,
+  type GraphMaintenanceResult,
+} from "./maintenance.js";
+import { inspectGraphStatus } from "./status.js";
 
 export interface GraphCommandOptions {
-  /** Project root to index (defaults to cwd). */
+  /** Project root to inspect or maintain (defaults to cwd). */
   root?: string;
-  /** Emit the build summary as JSON. */
+  /** Emit the complete machine-readable result. */
   json?: boolean;
 }
 
-/**
- * Run `mex graph`: build the whole graph and print a one-line (or JSON) summary.
- * Degrades loudly on failure (a clear message + non-zero exit) rather than
- * leaving a half-written DB — the caller (`cli.ts`) maps a throw to `exit(1)`.
- */
+/** Strictly read-only graph health/freshness command. */
+export async function runGraphStatus(options: GraphCommandOptions = {}): Promise<void> {
+  const rootDir = options.root ?? process.cwd();
+  const status = await inspectGraphStatus({ projectRoot: rootDir });
+  if (options.json) console.log(JSON.stringify(status, null, 2));
+  else printStatus(status);
+}
+
+/** Explicit correctness-first refresh through the existing full semantic sync path. */
+export async function runGraphRefresh(options: GraphCommandOptions = {}): Promise<void> {
+  const rootDir = options.root ?? process.cwd();
+  const result = await refreshGraph(rootDir);
+  if (options.json) console.log(JSON.stringify(result, null, 2));
+  else printMaintenance("refreshed", result);
+}
+
+/** Explicit isolated candidate rebuild with atomic publication and recovery. */
+export async function runGraphRebuild(options: GraphCommandOptions = {}): Promise<void> {
+  const rootDir = options.root ?? process.cwd();
+  const result = await rebuildGraph(rootDir);
+  if (options.json) console.log(JSON.stringify(result, null, 2));
+  else printMaintenance("rebuilt", result);
+}
+
+/** Backward-compatible `mex graph`, now implemented as a safe rebuild. */
 export async function runGraph(options: GraphCommandOptions = {}): Promise<void> {
   const rootDir = options.root ?? process.cwd();
-  const engine = createGraphEngine({ rootDir });
-  try {
-    const result = await engine.build(rootDir);
-    if (options.json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(
-        `Code graph built: ${result.nodesCreated} nodes, ${result.edgesCreated} edges ` +
-          `across ${result.filesIndexed} files in ${result.durationMs}ms → .mex/graph.db`,
-      );
-    }
-  } finally {
-    engine.close();
+  const result = await rebuildGraph(rootDir);
+  if (options.json) {
+    console.log(JSON.stringify({
+      filesIndexed: result.filesIndexed,
+      nodesCreated: result.nodesCreated,
+      edgesCreated: result.edgesCreated,
+      durationMs: result.durationMs,
+      health: {
+        ok: result.status.parseHealth.ok,
+        partial: result.status.parseHealth.partial,
+        failed: result.status.parseHealth.failed,
+      },
+    }, null, 2));
+    return;
+  }
+  console.log(
+    `Code graph built: ${result.nodesCreated} nodes, ${result.edgesCreated} edges `
+      + `across ${result.filesIndexed} files in ${result.durationMs}ms → .mex/graph.db`,
+  );
+}
+
+function printStatus(status: GraphStatus): void {
+  const branch = status.currentRepo.branch ?? "detached/no branch";
+  const head = status.currentRepo.head?.slice(0, 12) ?? "no HEAD";
+  const changes = status.changes;
+  console.log(`Graph status: ${status.status}`);
+  console.log(`Repository: ${branch} @ ${head}${status.currentRepo.dirty ? " (dirty)" : ""}`);
+  console.log(`Last successful index: ${status.lastSuccessfulIndexAt ?? "never"}`);
+  console.log(formatGraphSourceChanges(changes));
+  console.log(
+    `Parse health: ${status.parseHealth.ok} ok, ${status.parseHealth.partial} partial, `
+      + `${status.parseHealth.failed} failed`,
+  );
+  for (const diagnostic of status.diagnostics) {
+    console.log(`${diagnostic.severity.toUpperCase()} ${diagnostic.code}: ${diagnostic.message}`);
+  }
+  const command = status.diagnostics
+    .flatMap((diagnostic) => diagnostic.remediation ?? [])
+    .find((action) => action.command)?.command;
+  if (command) console.log(`Next: ${command}`);
+}
+
+/** Internal human-output formatter; JSON output retains the complete contract. */
+export function formatGraphSourceChanges(changes: GraphSourceChanges): string {
+  if (changes.truncated) {
+    const shown = changes.added.length + changes.modified.length + changes.deleted.length;
+    const omitted = Math.max(0, changes.total - shown);
+    const omission = omitted > 0 ? `${omitted} paths omitted` : "path details truncated";
+    return `Sources: ${changes.total} changed (`
+      + `${changes.added.length} added shown, ${changes.modified.length} modified shown, `
+      + `${changes.deleted.length} deleted shown; ${omission})`;
+  }
+  return `Sources: ${changes.total} changed `
+    + `(${changes.added.length} added, ${changes.modified.length} modified, ${changes.deleted.length} deleted)`;
+}
+
+function printMaintenance(verb: "refreshed" | "rebuilt", result: GraphMaintenanceResult): void {
+  console.log(
+    `Code graph ${verb}: ${result.nodesCreated} nodes, ${result.edgesCreated} edges `
+      + `across ${result.filesIndexed} files in ${result.durationMs}ms; status ${result.status.status}.`,
+  );
+  if (result.recoveryPath) {
+    console.log(`Previous index retained for local recovery: ${result.recoveryPath}`);
   }
 }

--- a/src/graph/corpus-policy.ts
+++ b/src/graph/corpus-policy.ts
@@ -1,0 +1,43 @@
+import { createHash } from "node:crypto";
+import { SUPPORTED_SOURCE_GLOB } from "./extraction/grammars.js";
+
+/** One source of truth for repository files that participate in graph identity. */
+export const GRAPH_CORPUS_IGNORE_GLOBS = Object.freeze([
+  "**/node_modules/**",
+  "**/.git/**",
+  "**/dist/**",
+  "**/build/**",
+  "**/.mex/**",
+  "**/coverage/**",
+  "**/.next/**",
+  "**/out/**",
+] as const);
+
+export const GRAPH_CONFIG_GLOBS = Object.freeze([
+  "package.json",
+  "**/package.json",
+  "tsconfig*.json",
+  "**/tsconfig*.json",
+  "jsconfig*.json",
+  "**/jsconfig*.json",
+] as const);
+
+export const GRAPH_SUPPORTED_SOURCE_GLOB = SUPPORTED_SOURCE_GLOB;
+export const GRAPH_CORPUS_GLOB_OPTIONS = Object.freeze({
+  absolute: false,
+  dot: false,
+  follow: false,
+  nodir: true,
+} as const);
+
+/**
+ * Stable identity for discovery semantics, independent of machine locale.
+ * Changing this policy invalidates the existing graph through manifestHash.
+ */
+export const GRAPH_CORPUS_POLICY_HASH = createHash("sha256").update(JSON.stringify({
+  version: 1,
+  sourceGlob: GRAPH_SUPPORTED_SOURCE_GLOB,
+  ignoreGlobs: GRAPH_CORPUS_IGNORE_GLOBS,
+  configGlobs: GRAPH_CONFIG_GLOBS,
+  globOptions: GRAPH_CORPUS_GLOB_OPTIONS,
+})).digest("hex");

--- a/src/graph/db/database.ts
+++ b/src/graph/db/database.ts
@@ -29,6 +29,11 @@ export interface OpenGraphDatabaseOptions {
   allowRebuild?: boolean;
   /** Reader-only commands must not mutate pragmas, schema, or version metadata. */
   readOnly?: boolean;
+  /**
+   * Ignore SQLite WAL state and prohibit sidecar creation. Callers must first
+   * establish that no non-empty WAL contains authoritative graph data.
+   */
+  immutable?: boolean;
 }
 
 function configureConnection(db: SqliteDatabase): void {
@@ -53,6 +58,9 @@ export function openGraphDatabase(
   dbPath: string,
   options: OpenGraphDatabaseOptions = {},
 ): SqliteDatabase {
+  if (options.immutable && !options.readOnly) {
+    throw new TypeError("Immutable graph access requires readOnly: true.");
+  }
   const dir = dirname(dbPath);
   if (!existsSync(dir)) {
     if (options.readOnly) throw new GraphRebuildRequiredError("The graph index does not exist. Run `mex graph` first.");
@@ -60,7 +68,9 @@ export function openGraphDatabase(
   }
 
   if (options.readOnly) {
-    return openReadOnlyGraphDatabase(dbPath);
+    return options.immutable
+      ? openImmutableGraphDatabase(dbPath)
+      : openReadOnlyGraphDatabase(dbPath);
   }
   const db = openSqlite(dbPath);
   configureConnection(db);
@@ -94,19 +104,29 @@ export function openGraphDatabase(
   return db;
 }
 
-function openReadOnlyGraphDatabase(dbPath: string): SqliteDatabase {
-  const validate = (db: SqliteDatabase): SqliteDatabase => {
-    configureReadOnlyConnection(db);
-    if (!tableExists(db, "schema_versions") || readSchemaVersion(db) !== DB_SCHEMA_VERSION) {
-      throw new GraphRebuildRequiredError();
-    }
-    if (graphRequiresRebuild(db)) throw new GraphRebuildRequiredError();
-    return db;
-  };
+function validateReadOnlyGraphDatabase(db: SqliteDatabase): SqliteDatabase {
+  configureReadOnlyConnection(db);
+  if (!tableExists(db, "schema_versions") || readSchemaVersion(db) !== DB_SCHEMA_VERSION) {
+    throw new GraphRebuildRequiredError();
+  }
+  if (graphRequiresRebuild(db)) throw new GraphRebuildRequiredError();
+  return db;
+}
 
+function openImmutableGraphDatabase(dbPath: string): SqliteDatabase {
+  const db = openSqlite(dbPath, { readOnly: true, immutable: true });
+  try {
+    return validateReadOnlyGraphDatabase(db);
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}
+
+function openReadOnlyGraphDatabase(dbPath: string): SqliteDatabase {
   let db = openSqlite(dbPath, { readOnly: true });
   try {
-    return validate(db);
+    return validateReadOnlyGraphDatabase(db);
   } catch (error) {
     db.close();
     const message = error instanceof Error ? error.message : String(error);
@@ -122,7 +142,7 @@ function openReadOnlyGraphDatabase(dbPath: string): SqliteDatabase {
     // first read. Immutable mode is safe only when no WAL payload exists.
     db = openSqlite(dbPath, { readOnly: true, immutable: true });
     try {
-      return validate(db);
+      return validateReadOnlyGraphDatabase(db);
     } catch (immutableError) {
       db.close();
       throw immutableError;

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -1,9 +1,25 @@
 import { createHash } from "node:crypto";
-import { readFileSync, statSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { globSync } from "glob";
 import { toPosix } from "../paths.js";
 import type { BuildResult, GraphEngine, NodeSearchOptions } from "./engine.js";
+import {
+  GRAPH_CONFIG_GLOBS,
+  GRAPH_CORPUS_GLOB_OPTIONS,
+  GRAPH_CORPUS_IGNORE_GLOBS,
+  GRAPH_CORPUS_POLICY_HASH,
+  GRAPH_SUPPORTED_SOURCE_GLOB,
+} from "./corpus-policy.js";
 import { DB_SCHEMA_VERSION, markGraphReady, openGraphDatabase } from "./db/database.js";
 import {
   GraphStore,
@@ -23,12 +39,13 @@ import {
   loadGrammars,
   normalizedAstTokens,
   normalizedCompilerTokens,
-  SUPPORTED_SOURCE_GLOB,
   TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
   TYPESCRIPT_COMPILER_VERSION,
   type CompilerExtractedNode,
   type CompilerExtractionResult,
   type CompilerFileExtraction,
+  type CompilerSemanticInput,
+  type CompilerStagedInput,
 } from "./extraction/index.js";
 import { FingerprintStore } from "./fingerprint-store.js";
 import { createFingerprintBuilder } from "./fingerprint.js";
@@ -38,13 +55,18 @@ import type { Fingerprint } from "./reconcile.js";
 import { createStagedResolutionContext } from "./resolution/context.js";
 import { FRAMEWORK_RESOLVERS } from "./resolution/frameworks/index.js";
 import { resolveReferences } from "./resolution/resolver.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS,
+  createGraphSnapshot,
+  parseGraphSnapshot,
+  readGraphGitProvenance,
+  serializeGraphSnapshot,
+  type GraphGitProvenance,
+  type GraphSnapshotSemanticInput,
+} from "./snapshot.js";
 import { getCallees, getCallers, getIncoming, getOutgoing } from "./traversal/traversal.js";
 import type { GraphEdge, GraphNode, Language, ReferenceKind } from "./types.js";
-
-const IGNORE_GLOBS = [
-  "**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**", "**/.mex/**",
-  "**/coverage/**", "**/.next/**", "**/out/**",
-];
 
 const BODY_KINDS = new Set<GraphNode["kind"]>([
   "function", "method", "class", "interface", "enum", "type_alias", "struct",
@@ -65,6 +87,18 @@ export interface GraphEngineOptions {
   sourceFileAccess?: Partial<GraphSourceFileAccess>;
 }
 
+interface GraphEngineInternalHooks {
+  afterSemanticInputsStaged?: () => void;
+  afterCompilerExtraction?: () => void;
+  afterFinalSemanticInputRead?: (path: string) => void;
+}
+
+interface GraphEngineInternalOptions {
+  /** Deliberately absent from GraphEngineOptions and generated declarations. */
+  __internalGraphEngineHooks?: GraphEngineInternalHooks;
+  immutable?: boolean;
+}
+
 export interface GraphSourceFileAccess {
   stat(absolutePath: string): { size: number; mtimeMs: number };
   read(absolutePath: string): string;
@@ -72,7 +106,7 @@ export interface GraphSourceFileAccess {
 
 export interface GraphSourceStagingFailure {
   filePath: string;
-  operation: "stat" | "read" | "discover";
+  operation: "stat" | "read" | "discover" | "parse";
   code?: string;
   message: string;
 }
@@ -112,6 +146,7 @@ interface StagedFile {
 interface StagedCorpus {
   files: StagedFile[];
   compiler: CompilerExtractionResult;
+  semanticInputs: CompilerSemanticInput[];
   fingerprints: Array<{ nodeId: string; fingerprint: Fingerprint }>;
   manifestHash: string;
   configHash: string;
@@ -128,20 +163,41 @@ class GraphEngineImpl implements GraphEngine {
   private readonly rootDir: string;
   private readonly dbPath: string;
   private readonly readOnly: boolean;
+  private readonly immutable: boolean;
   private readonly sourceFileAccess: GraphSourceFileAccess;
+  private readonly internal: GraphEngineInternalHooks;
   private db: SqliteDatabase | null = null;
   private store: GraphStore | null = null;
 
-  constructor(options: GraphEngineOptions) {
+  constructor(options: GraphEngineOptions & GraphEngineInternalOptions, database?: SqliteDatabase) {
+    if (options.immutable && options.readOnly !== true) {
+      throw new TypeError("Immutable graph access requires readOnly: true.");
+    }
+    if (database && (options.readOnly !== true || options.immutable !== true)) {
+      throw new TypeError("An adopted graph database must be an immutable read-only connection.");
+    }
     this.rootDir = resolve(options.rootDir);
     this.dbPath = options.dbPath ?? resolve(this.rootDir, ".mex", "graph.db");
     this.readOnly = options.readOnly ?? false;
-    this.sourceFileAccess = { ...NODE_SOURCE_FILE_ACCESS, ...options.sourceFileAccess };
+    this.immutable = options.immutable ?? false;
+    this.sourceFileAccess = options.sourceFileAccess
+      ? { ...NODE_SOURCE_FILE_ACCESS, ...options.sourceFileAccess }
+      : NODE_SOURCE_FILE_ACCESS;
+    this.internal = (options as GraphEngineOptions & GraphEngineInternalOptions)
+      .__internalGraphEngineHooks ?? {};
+    if (database) {
+      this.db = database;
+      this.store = new GraphStore(database);
+    }
   }
 
   private getStore(allowRebuild = false): GraphStore {
     if (!this.store) {
-      this.db = openGraphDatabase(this.dbPath, { allowRebuild, readOnly: this.readOnly });
+      this.db = openGraphDatabase(this.dbPath, {
+        allowRebuild,
+        readOnly: this.readOnly,
+        immutable: this.immutable,
+      });
       this.store = new GraphStore(this.db);
     }
     return this.store;
@@ -151,8 +207,11 @@ class GraphEngineImpl implements GraphEngine {
     if (this.readOnly) throw new Error("A read-only graph engine cannot build an index.");
     const started = Date.now();
     const root = rootDir ? resolve(rootDir) : this.rootDir;
-    const staged = await stageCorpus(root, undefined, this.sourceFileAccess);
-    const result = this.publish(staged);
+    const gitBeforeStaging = readGraphGitProvenance(root);
+    const manifest = graphManifest(root);
+    const staged = await stageCorpus(root, manifest, this.sourceFileAccess, this.internal);
+    this.assertNoNewParseFailures(staged);
+    const result = this.publish(staged, root, gitBeforeStaging);
     return { ...result, durationMs: Date.now() - started };
   }
 
@@ -164,15 +223,23 @@ class GraphEngineImpl implements GraphEngine {
     ).filter((file) => file && !file.startsWith("..")))].sort();
     const changedSources = changed.filter(isSupportedSourceFile);
     const deletedChangedSources = inspectChangedSources(this.rootDir, changedSources, this.sourceFileAccess);
+    const gitBeforeStaging = readGraphGitProvenance(this.rootDir);
     const manifest = graphManifest(this.rootDir);
-    const manifestChanged = this.getStore(true).getMetadata("manifest_hash") !== manifest.manifestHash;
+    const store = this.getStore(true);
+    const manifestChanged = store.getMetadata("manifest_hash") !== manifest.manifestHash;
     if (changedSources.length === 0 && !manifestChanged) {
-      return { filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: Date.now() - started };
+      const currentCorpus = discoverSourceFiles(this.rootDir, this.sourceFileAccess);
+      const snapshot = parseGraphSnapshot(store.getMetadata(GRAPH_SNAPSHOT_METADATA_KEY));
+      if (snapshot?.manifestHash === manifest.manifestHash
+        && sourceCorpusMatchesFileRecords(currentCorpus, store.getAllFileRecords())
+        && semanticInputsMatchSnapshot(this.rootDir, snapshot.semanticInputs)) {
+        return { filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: Date.now() - started };
+      }
     }
 
     // Re-stage the whole semantic corpus. This makes an arbitrary sync sequence
     // converge to the same graph as a clean build and re-resolves cross-file refs.
-    const staged = await stageCorpus(this.rootDir, manifest, this.sourceFileAccess);
+    const staged = await stageCorpus(this.rootDir, manifest, this.sourceFileAccess, this.internal);
     const stagedByPath = new Map(staged.files.map((file) => [file.record.path, file]));
     const unstagedExisting = changedSources.filter((file) => (
       !deletedChangedSources.has(file) && !stagedByPath.has(file)
@@ -184,21 +251,33 @@ class GraphEngineImpl implements GraphEngine {
         message: "The changed source still exists but was absent from the staged corpus.",
       })));
     }
-    const failedChanged = changedSources.filter((file) => stagedByPath.get(file)?.record.parseStatus === "failed");
-    if (failedChanged.length > 0) {
-      // Preserve the previous structural snapshot. Scope notices changed hashes
-      // and can still return the live files as explicitly text-only evidence.
-      const health = healthCounts(staged.files);
-      return {
-        filesIndexed: 0, nodesCreated: 0, edgesCreated: 0,
-        durationMs: Date.now() - started, health,
-      };
-    }
-    const result = this.publish(staged);
+    this.assertNoNewParseFailures(staged);
+    const result = this.publish(staged, this.rootDir, gitBeforeStaging);
     return { ...result, durationMs: Date.now() - started };
   }
 
-  private publish(staged: StagedCorpus): Omit<BuildResult, "durationMs"> {
+  private assertNoNewParseFailures(staged: StagedCorpus): void {
+    const store = this.getStore(true);
+    const previousFiles = store.getAllFileRecords();
+    if (previousFiles.length === 0) return;
+    const previous = new Map(previousFiles.map((file) => [file.path, file.parseStatus ?? "ok"]));
+    const newlyFailed = staged.files.filter((file) => (
+      file.record.parseStatus === "failed" && previous.get(file.record.path) !== "failed"
+    ));
+    if (newlyFailed.length === 0) return;
+    throw new GraphSourceStagingError(newlyFailed.map((file) => ({
+      filePath: file.record.path,
+      operation: "parse",
+      code: "GRAPH_SOURCE_PARSE_FAILED",
+      message: "The source no longer parses; the last trustworthy graph snapshot was preserved.",
+    })));
+  }
+
+  private publish(
+    staged: StagedCorpus,
+    root: string,
+    gitBeforeStaging: GraphGitProvenance,
+  ): Omit<BuildResult, "durationMs"> {
     const store = this.getStore(true);
     const oldNodes = store.getAllNodes();
     const oldAliases = store.getAllAliases();
@@ -208,8 +287,44 @@ class GraphEngineImpl implements GraphEngine {
       const fingerprint = priorFingerprintStore.get(node.id);
       if (fingerprint) oldFingerprints.set(node.id, fingerprint);
     }
+    // Continuity reads above may be substantial on a mature index. Re-probe
+    // only after they finish, at the final synchronous boundary before the
+    // snapshot is constructed and its publication transaction begins.
+    const git = verifyPublicationInputs(
+      root,
+      staged,
+      gitBeforeStaging,
+      this.sourceFileAccess,
+      this.internal,
+    );
     let edgeCount = 0;
     const expectedNodes = staged.files.reduce((count, file) => count + file.nodes.length, 0);
+    const semanticInputs = staged.semanticInputs
+      .map((input) => ({ path: input.filePath, contentHash: input.contentHash }));
+    if (semanticInputs.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS) {
+      throw new GraphSourceStagingError([{
+        filePath: ".",
+        operation: "discover",
+        message: `Compiler provenance exceeds the ${GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS}-path safety cap.`,
+      }]);
+    }
+    const snapshot = createGraphSnapshot({
+      indexedAt: new Date().toISOString(),
+      git,
+      schemaVersion: DB_SCHEMA_VERSION,
+      compilerVersion: staged.compiler.compilerVersion,
+      extractorVersion: CORPUS_EXTRACTOR_VERSION,
+      resolverVersion: RESOLVER_VERSION,
+      grammarHash: staged.grammarHash,
+      configHash: staged.configHash,
+      manifestHash: staged.manifestHash,
+      sources: staged.files.map((file) => ({
+        path: file.record.path,
+        contentHash: file.record.contentHash,
+        parseStatus: file.record.parseStatus ?? "ok",
+      })),
+      semanticInputs,
+    });
 
     store.transaction(() => {
       store.clearDerivedGraph();
@@ -235,6 +350,7 @@ class GraphEngineImpl implements GraphEngine {
       store.setMetadata("resolver_version", RESOLVER_VERSION);
       store.setMetadata("config_hash", staged.configHash);
       store.setMetadata("grammar_hash", staged.grammarHash);
+      store.setMetadata(GRAPH_SNAPSHOT_METADATA_KEY, serializeGraphSnapshot(snapshot));
       markGraphReady(this.db!, staged.manifestHash);
     });
 
@@ -279,18 +395,59 @@ class GraphEngineImpl implements GraphEngine {
 }
 
 export function createGraphEngine(options: GraphEngineOptions): GraphEngine {
+  if ("immutable" in (options as GraphEngineOptions & { immutable?: unknown })) {
+    throw new TypeError("Immutable graph access is internal to the validated grounding runtime.");
+  }
   return new GraphEngineImpl(options);
+}
+
+/**
+ * @internal Adopt one validated immutable connection for all grounding reads.
+ * Ownership transfers to the returned engine and `close()` releases it.
+ */
+export function createGraphEngineFromOpenDatabase(
+  options: Pick<GraphEngineOptions, "rootDir" | "dbPath">,
+  database: SqliteDatabase,
+): GraphEngine {
+  return new GraphEngineImpl({ ...options, readOnly: true, immutable: true }, database);
 }
 
 async function stageCorpus(
   root: string,
   manifest = graphManifest(root),
   sourceFileAccess: GraphSourceFileAccess = NODE_SOURCE_FILE_ACCESS,
+  internal: GraphEngineInternalHooks = {},
 ): Promise<StagedCorpus> {
   const discovered = discoverSourceFiles(root, sourceFileAccess);
+  const configSources = discoverGraphConfigSources(root);
+  const stagedConfigHash = configHashForSources(configSources);
+  if (stagedConfigHash !== manifest.configHash) {
+    throw new GraphSourceStagingError([{
+      filePath: ".",
+      operation: "discover",
+      message: "The graph configuration (configHash) changed before semantic staging began.",
+    }]);
+  }
+  const semanticSources = new Map<string, string>(configSources);
+  for (const file of discovered) semanticSources.set(file.relPath, file.source);
+  internal.afterSemanticInputsStaged?.();
   const compilerPaths = discovered.filter((file) => COMPILER_LANGUAGES.has(detectLanguage(file.relPath)))
     .map((file) => file.relPath);
-  const compiler = buildTypeScriptExtraction(root, compilerPaths);
+  const compilerInputs: CompilerStagedInput[] = [...semanticSources.entries()]
+    .map(([filePath, source]) => ({ filePath, source }))
+    .sort((left, right) => compareCodePoints(left.filePath, right.filePath));
+  let compiler: CompilerExtractionResult;
+  try {
+    compiler = buildTypeScriptExtraction(root, compilerPaths, {
+      stagedInputs: compilerInputs,
+      readProjectFile: (absolutePath) => readSecureCompilerInput(root, absolutePath),
+    });
+  } catch (error) {
+    if (error instanceof GraphSourceStagingError) throw error;
+    throw new GraphSourceStagingError([sourceStagingFailure(".", "read", error)]);
+  }
+  internal.afterCompilerExtraction?.();
+  validateCompilerInputs(discovered, compiler, semanticSources, root);
   const compilerByPath = new Map(compiler.files.map((file) => [file.filePath, file]));
   const treeLanguages = [...new Set(discovered.map((file) => detectLanguage(file.relPath))
     .filter((language) => !COMPILER_LANGUAGES.has(language)))];
@@ -300,14 +457,27 @@ async function stageCorpus(
     const compilerFile = compilerByPath.get(file.relPath);
     return compilerFile ? stageCompilerFile(file, compilerFile) : stageTreeFile(file);
   });
-  stageFrameworkAndFallbackResolution(root, files);
+  stageFrameworkAndFallbackResolution(root, files, semanticSources);
   validateStagedCorpus(files);
   const fingerprints = stageFingerprints(files);
-  return { files, compiler, fingerprints, ...manifest };
+  const coveredPaths = new Set([...discovered.map((file) => file.relPath), ...configSources.keys()]);
+  const semanticInputs = compiler.semanticInputs.filter((input) => !coveredPaths.has(input.filePath));
+  if (semanticInputs.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS) {
+    throw new GraphSourceStagingError([{
+      filePath: ".",
+      operation: "discover",
+      message: `Compiler provenance exceeds the ${GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS}-path safety cap.`,
+    }]);
+  }
+  return { files, compiler, semanticInputs, fingerprints, ...manifest };
 }
 
-function stageFrameworkAndFallbackResolution(root: string, files: StagedFile[]): void {
-  const sourceByPath = new Map(files.map((file) => [file.record.path, file.discovered.source]));
+function stageFrameworkAndFallbackResolution(
+  root: string,
+  files: StagedFile[],
+  semanticSources: ReadonlyMap<string, string>,
+): void {
+  const sourceByPath = new Map(semanticSources);
   const initialNodes = files.flatMap((file) => file.nodes);
   const detectionContext = createStagedResolutionContext(initialNodes, root, sourceByPath);
   const resolvers = FRAMEWORK_RESOLVERS.filter((resolver) => resolver.detect(detectionContext));
@@ -831,9 +1001,25 @@ function inspectChangedSources(
 ): Set<string> {
   const deleted = new Set<string>();
   const failures: GraphSourceStagingFailure[] = [];
+  let canonicalRoot: string;
+  try {
+    canonicalRoot = realpathSync(root);
+  } catch (error) {
+    throw new GraphSourceStagingError([sourceStagingFailure(".", "discover", error)]);
+  }
   for (const relPath of changedSources) {
+    let canonicalPath: string;
     try {
-      sourceFileAccess.stat(resolve(root, relPath));
+      canonicalPath = resolveContainedRepoFile(root, canonicalRoot, relPath);
+    } catch (error) {
+      if (isMissingPathError(error)) deleted.add(relPath);
+      else failures.push(sourceStagingFailure(relPath, "discover", error));
+      continue;
+    }
+    try {
+      sourceFileAccess.stat(sourceFileAccess === NODE_SOURCE_FILE_ACCESS
+        ? canonicalPath
+        : resolve(root, relPath));
     } catch (error) {
       if (isMissingPathError(error)) deleted.add(relPath);
       else failures.push(sourceStagingFailure(relPath, "stat", error));
@@ -844,24 +1030,62 @@ function inspectChangedSources(
 }
 
 function discoverSourceFiles(root: string, sourceFileAccess: GraphSourceFileAccess): DiscoveredFile[] {
-  const matches = globSync(SUPPORTED_SOURCE_GLOB, {
-    cwd: root, ignore: IGNORE_GLOBS, nodir: true, absolute: false, dot: false,
+  const matches = globSync(GRAPH_SUPPORTED_SOURCE_GLOB, {
+    ...GRAPH_CORPUS_GLOB_OPTIONS,
+    cwd: root,
+    ignore: [...GRAPH_CORPUS_IGNORE_GLOBS],
   }).map(toPosix).sort();
   const files: DiscoveredFile[] = [];
   const failures: GraphSourceStagingFailure[] = [];
+  let canonicalRoot: string;
+  try {
+    canonicalRoot = realpathSync(root);
+  } catch (error) {
+    throw new GraphSourceStagingError([sourceStagingFailure(".", "discover", error)]);
+  }
   for (const relPath of matches) {
     if (!isSupportedSourceFile(relPath)) continue;
-    let stat: { size: number; mtimeMs: number };
+    let canonicalPath: string;
     try {
-      stat = sourceFileAccess.stat(resolve(root, relPath));
+      canonicalPath = resolveContainedRepoFile(root, canonicalRoot, relPath);
+    } catch (error) {
+      failures.push(sourceStagingFailure(relPath, "discover", error));
+      continue;
+    }
+
+    if (sourceFileAccess === NODE_SOURCE_FILE_ACCESS) {
+      try {
+        const file = readStableUtf8File(canonicalPath, resolve(root, relPath));
+        files.push({ relPath, source: file.source, size: file.size, modifiedAt: file.modifiedAt });
+      } catch (error) {
+        failures.push(sourceStagingFailure(relPath, "read", error));
+      }
+      continue;
+    }
+
+    let stat: { size: number; mtimeMs: number };
+    let identityBefore: ReturnType<typeof lstatSync>;
+    const callbackPath = resolve(root, relPath);
+    try {
+      identityBefore = lstatSync(canonicalPath);
+      if (!identityBefore.isFile() || identityBefore.isSymbolicLink()) {
+        throw sourceContainmentError("Resolved source path is not a stable regular file.");
+      }
+      stat = sourceFileAccess.stat(callbackPath);
     } catch (error) {
       failures.push(sourceStagingFailure(relPath, "stat", error));
       continue;
     }
     try {
+      const source = sourceFileAccess.read(callbackPath);
+      const identityAfter = lstatSync(canonicalPath);
+      if (!sameFileIdentity(identityBefore, identityAfter)
+        || resolveContainedRepoFile(root, canonicalRoot, relPath) !== canonicalPath) {
+        throw sourceContainmentError("Source path changed while it was being read.");
+      }
       files.push({
         relPath,
-        source: sourceFileAccess.read(resolve(root, relPath)),
+        source,
         size: stat.size,
         modifiedAt: stat.mtimeMs,
       });
@@ -871,6 +1095,276 @@ function discoverSourceFiles(root: string, sourceFileAccess: GraphSourceFileAcce
   }
   if (failures.length > 0) throw new GraphSourceStagingError(failures);
   return files;
+}
+
+function sourceCorpusMatchesFileRecords(
+  currentCorpus: readonly DiscoveredFile[],
+  indexedFiles: readonly FileRecord[],
+): boolean {
+  if (currentCorpus.length !== indexedFiles.length) return false;
+  const indexedByPath = new Map(indexedFiles.map((file) => [file.path, file.contentHash]));
+  return indexedByPath.size === indexedFiles.length
+    && currentCorpus.every((file) => indexedByPath.get(file.relPath) === sha256(file.source));
+}
+
+function semanticInputsMatchSnapshot(
+  root: string,
+  semanticInputs: readonly GraphSnapshotSemanticInput[],
+): boolean {
+  return semanticInputs.every((input) => {
+    const source = readSecureCompilerInput(root, resolve(root, input.path));
+    return input.contentHash === null
+      ? source === undefined
+      : source !== undefined && sha256(source) === input.contentHash;
+  });
+}
+
+function resolveContainedRepoFile(root: string, canonicalRoot: string, relPath: string): string {
+  const lexicalRoot = resolve(root);
+  const absolutePath = resolve(lexicalRoot, relPath);
+  if (!isContainedPath(lexicalRoot, absolutePath)) {
+    throw sourceContainmentError("Source path escapes the repository root.");
+  }
+  const canonicalPath = realpathSync(absolutePath);
+  if (!isContainedPath(canonicalRoot, canonicalPath)) {
+    throw sourceContainmentError("Resolved source path escapes the repository root.");
+  }
+  return canonicalPath;
+}
+
+function readStableUtf8File(canonicalPath: string, sourcePath = canonicalPath): {
+  source: string;
+  size: number;
+  modifiedAt: number;
+} {
+  const before = lstatSync(canonicalPath);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw sourceContainmentError("Resolved source path is not a stable regular file.");
+  }
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(canonicalPath, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || !sameFileIdentity(before, opened)) {
+      throw sourceContainmentError("Source path changed before it could be opened.");
+    }
+    const source = readFileSync(fd, "utf8");
+    const after = fstatSync(fd);
+    const resolvedAfter = realpathSync(sourcePath);
+    const pathAfter = lstatSync(resolvedAfter);
+    if (!sameFileIdentity(opened, after)
+      || resolvedAfter !== canonicalPath
+      || !pathAfter.isFile()
+      || pathAfter.isSymbolicLink()
+      || !sameFileIdentity(opened, pathAfter)) {
+      throw sourceContainmentError("Source file changed while it was being read.");
+    }
+    return { source, size: opened.size, modifiedAt: opened.mtimeMs };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function sameFileIdentity(
+  left: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number },
+  right: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number },
+): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function isContainedPath(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith("../") && !path.startsWith("..\\"));
+}
+
+function sourceContainmentError(message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code: "GRAPH_SOURCE_PATH_ESCAPE" });
+}
+
+function readSecureCompilerInput(root: string, absolutePath: string): string | undefined {
+  const lexicalRoot = resolve(root);
+  const resolvedPath = resolve(absolutePath);
+  const relPath = toPosix(relative(lexicalRoot, resolvedPath));
+  if (!relPath || relPath === ".." || relPath.startsWith("../") || isAbsolute(relPath)) {
+    throw new GraphSourceStagingError([sourceStagingFailure(
+      relPath || ".",
+      "read",
+      sourceContainmentError("Compiler input escapes the repository root."),
+    )]);
+  }
+  try {
+    const canonicalRoot = realpathSync(lexicalRoot);
+    const canonicalPath = resolveContainedRepoFile(lexicalRoot, canonicalRoot, relPath);
+    return readStableUtf8File(canonicalPath, resolvedPath).source;
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      try {
+        assertContainedMissingCompilerInput(lexicalRoot, relPath);
+        return undefined;
+      } catch (containmentError) {
+        throw new GraphSourceStagingError([sourceStagingFailure(relPath, "read", containmentError)]);
+      }
+    }
+    throw new GraphSourceStagingError([sourceStagingFailure(relPath, "read", error)]);
+  }
+}
+
+function assertContainedMissingCompilerInput(root: string, relPath: string): void {
+  const canonicalRoot = realpathSync(root);
+  const absolutePath = resolve(root, relPath);
+  try {
+    if (lstatSync(absolutePath).isSymbolicLink()) {
+      throw sourceContainmentError("A missing compiler input is represented by an unresolved symlink.");
+    }
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
+  }
+  let ancestor = dirname(absolutePath);
+  for (;;) {
+    try {
+      const canonicalAncestor = realpathSync(ancestor);
+      if (!isContainedPath(canonicalRoot, canonicalAncestor)) {
+        throw sourceContainmentError("A missing compiler input's resolved ancestor escapes the repository root.");
+      }
+      return;
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      try {
+        if (lstatSync(ancestor).isSymbolicLink()) {
+          throw sourceContainmentError("A missing compiler input has an unresolved symlink ancestor.");
+        }
+      } catch (lstatError) {
+        if (!isMissingPathError(lstatError)) throw lstatError;
+      }
+      const parent = dirname(ancestor);
+      if (parent === ancestor) {
+        throw sourceContainmentError("No stable repository ancestor exists for the missing compiler input.");
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+function validateCompilerInputs(
+  discovered: readonly DiscoveredFile[],
+  compiler: CompilerExtractionResult,
+  stagedInputs: ReadonlyMap<string, string>,
+  root: string,
+): void {
+  const observed = new Map(compiler.semanticInputs.map((input) => [input.filePath, input.contentHash]));
+  const failures: GraphSourceStagingFailure[] = [];
+  for (const file of discovered) {
+    if (!COMPILER_LANGUAGES.has(detectLanguage(file.relPath))) continue;
+    const compilerHash = observed.get(file.relPath);
+    if (compilerHash === sha256(file.source)) continue;
+    failures.push({
+      filePath: file.relPath,
+      operation: "read",
+      message: compilerHash === undefined
+        ? "The TypeScript compiler did not consume the securely staged source."
+        : "The TypeScript compiler consumed source bytes that differ from the staged corpus.",
+    });
+  }
+  for (const input of compiler.semanticInputs) {
+    const staged = stagedInputs.get(input.filePath);
+    if (staged !== undefined) {
+      if (input.contentHash === null || sha256(staged) !== input.contentHash) failures.push({
+        filePath: input.filePath,
+        operation: "read",
+        message: "The compiler semantic input differs from the immutable staged bytes.",
+      });
+      continue;
+    }
+    const current = readSecureCompilerInput(root, resolve(root, input.filePath));
+    const matches = input.contentHash === null
+      ? current === undefined
+      : current !== undefined && sha256(current) === input.contentHash;
+    if (!matches) failures.push({
+      filePath: input.filePath,
+      operation: "read",
+      message: "A compiler semantic input changed while extraction was running.",
+    });
+  }
+  if (failures.length > 0) throw new GraphSourceStagingError(failures);
+}
+
+/**
+ * Publication is allowed only when the staged semantic corpus still describes
+ * the checkout. The final Git read intentionally happens after source and
+ * manifest verification so a checkout operation during either read is also
+ * observed before the transaction begins.
+ */
+function verifyPublicationInputs(
+  root: string,
+  staged: StagedCorpus,
+  gitBeforeStaging: GraphGitProvenance,
+  sourceFileAccess: GraphSourceFileAccess,
+  internal: GraphEngineInternalHooks = {},
+): GraphGitProvenance {
+  const currentFiles = discoverSourceFiles(root, sourceFileAccess);
+  const currentManifest = graphManifest(root);
+  const failures: GraphSourceStagingFailure[] = [];
+
+  const changedManifestParts = (["manifestHash", "configHash", "grammarHash"] as const)
+    .filter((key) => staged[key] !== currentManifest[key]);
+  if (changedManifestParts.length > 0) {
+    failures.push({
+      filePath: ".",
+      operation: "discover",
+      message: `The graph build manifest changed while the corpus was being staged (${changedManifestParts.join(", ")}).`,
+    });
+  }
+
+  const stagedSources = new Map(staged.files.map((file) => [file.record.path, file.record.contentHash]));
+  const currentSources = new Map(currentFiles.map((file) => [file.relPath, sha256(file.source)]));
+  const paths = [...new Set([...stagedSources.keys(), ...currentSources.keys()])]
+    .sort(compareCodePoints);
+  for (const filePath of paths) {
+    const stagedHash = stagedSources.get(filePath);
+    const currentHash = currentSources.get(filePath);
+    if (stagedHash === currentHash) continue;
+    const change = stagedHash === undefined ? "appeared"
+      : currentHash === undefined ? "disappeared"
+        : "changed";
+    failures.push({
+      filePath,
+      operation: "discover",
+      message: `The supported source ${change} while the graph corpus was being staged.`,
+    });
+  }
+
+  for (const input of staged.compiler.semanticInputs) {
+    if (stagedSources.has(input.filePath)) continue;
+    const source = readSecureCompilerInput(root, resolve(root, input.filePath));
+    internal.afterFinalSemanticInputRead?.(input.filePath);
+    if (input.contentHash === null ? source === undefined : source !== undefined && sha256(source) === input.contentHash) {
+      continue;
+    }
+    failures.push({
+      filePath: input.filePath,
+      operation: "read",
+      message: "A compiler semantic input changed before graph publication.",
+    });
+  }
+
+  // Git is deliberately the last checkout observation. A checkout during any
+  // source, manifest, or indirect semantic-input verification is therefore
+  // caught before snapshot construction and the publication transaction.
+  const currentGit = readGraphGitProvenance(root);
+  if (gitBeforeStaging.branch !== currentGit.branch || gitBeforeStaging.head !== currentGit.head) {
+    failures.push({
+      filePath: ".git/HEAD",
+      operation: "discover",
+      message: "Git branch or HEAD changed while the graph corpus was being staged.",
+    });
+  }
+
+  if (failures.length > 0) throw new GraphSourceStagingError(failures);
+  return currentGit;
 }
 
 function sourceStagingFailure(
@@ -896,27 +1390,49 @@ function isMissingPathError(error: unknown): boolean {
 }
 
 export function graphManifest(root: string): GraphManifest {
-  const configPaths = [...new Set(globSync([
-    "package.json", "**/package.json", "tsconfig*.json", "**/tsconfig*.json",
-    "jsconfig*.json", "**/jsconfig*.json",
-  ], {
-    cwd: root, ignore: IGNORE_GLOBS, nodir: true,
-  }).map(toPosix))].sort();
-  const configs = configPaths.map((path) => {
-    try { return [path, sha256(readFileSync(resolve(root, path), "utf-8"))]; }
-    catch { return [path, "unreadable"]; }
-  });
-  const configHash = sha256(JSON.stringify(configs));
+  const configSources = discoverGraphConfigSources(root);
+  const configHash = configHashForSources(configSources);
   const grammarHash = grammarManifestHash();
   const manifestHash = sha256(JSON.stringify({
     db: DB_SCHEMA_VERSION,
     compiler: TYPESCRIPT_COMPILER_VERSION,
     extractor: CORPUS_EXTRACTOR_VERSION,
     resolver: RESOLVER_VERSION,
+    corpusPolicyHash: GRAPH_CORPUS_POLICY_HASH,
     grammarHash,
     configHash,
   }));
   return { manifestHash, configHash, grammarHash };
+}
+
+function discoverGraphConfigSources(root: string): Map<string, string> {
+  let canonicalRoot: string;
+  let configPaths: string[];
+  try {
+    canonicalRoot = realpathSync(root);
+    configPaths = [...new Set(globSync([...GRAPH_CONFIG_GLOBS], {
+      ...GRAPH_CORPUS_GLOB_OPTIONS,
+      cwd: root,
+      ignore: [...GRAPH_CORPUS_IGNORE_GLOBS],
+    }).map(toPosix))].sort();
+  } catch (error) {
+    throw new GraphSourceStagingError([sourceStagingFailure(".", "discover", error)]);
+  }
+  const configs = configPaths.map((path) => {
+    try {
+      const canonicalPath = resolveContainedRepoFile(root, canonicalRoot, path);
+      return [path, readStableUtf8File(canonicalPath, resolve(root, path)).source] as const;
+    } catch (error) {
+      throw new GraphSourceStagingError([sourceStagingFailure(path, "read", error)]);
+    }
+  });
+  return new Map(configs);
+}
+
+function configHashForSources(configSources: ReadonlyMap<string, string>): string {
+  return sha256(JSON.stringify([...configSources.entries()]
+    .map(([path, source]) => [path, sha256(source)])
+    .sort(([left], [right]) => compareCodePoints(left!, right!))));
 }
 
 function healthCounts(files: StagedFile[]): { ok: number; partial: number; failed: number } {
@@ -929,6 +1445,10 @@ function healthCounts(files: StagedFile[]): { ok: number; partial: number; faile
 
 function sha256(text: string | Buffer): string {
   return createHash("sha256").update(text).digest("hex");
+}
+
+function compareCodePoints(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function bodyHash(sourceLines: string[], startLine: number, endLine: number): string {

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -91,6 +91,10 @@ interface GraphEngineInternalHooks {
   afterSemanticInputsStaged?: () => void;
   afterCompilerExtraction?: () => void;
   afterFinalSemanticInputRead?: (path: string) => void;
+  /** Final path/cancellation seam immediately before SQLite opens or creates the database. */
+  beforeDatabaseOpen?: () => void;
+  /** Final cancellation/fault seam before any publication continuity reads. */
+  beforePublication?: () => void;
 }
 
 interface GraphEngineInternalOptions {
@@ -193,6 +197,7 @@ class GraphEngineImpl implements GraphEngine {
 
   private getStore(allowRebuild = false): GraphStore {
     if (!this.store) {
+      this.internal.beforeDatabaseOpen?.();
       this.db = openGraphDatabase(this.dbPath, {
         allowRebuild,
         readOnly: this.readOnly,
@@ -231,6 +236,7 @@ class GraphEngineImpl implements GraphEngine {
       const currentCorpus = discoverSourceFiles(this.rootDir, this.sourceFileAccess);
       const snapshot = parseGraphSnapshot(store.getMetadata(GRAPH_SNAPSHOT_METADATA_KEY));
       if (snapshot?.manifestHash === manifest.manifestHash
+        && snapshot.indexedBranch === gitBeforeStaging.branch
         && sourceCorpusMatchesFileRecords(currentCorpus, store.getAllFileRecords())
         && semanticInputsMatchSnapshot(this.rootDir, snapshot.semanticInputs)) {
         return { filesIndexed: 0, nodesCreated: 0, edgesCreated: 0, durationMs: Date.now() - started };
@@ -278,6 +284,7 @@ class GraphEngineImpl implements GraphEngine {
     root: string,
     gitBeforeStaging: GraphGitProvenance,
   ): Omit<BuildResult, "durationMs"> {
+    this.internal.beforePublication?.();
     const store = this.getStore(true);
     const oldNodes = store.getAllNodes();
     const oldAliases = store.getAllAliases();

--- a/src/graph/extraction/compiler.ts
+++ b/src/graph/extraction/compiler.ts
@@ -12,6 +12,7 @@ import {
   statSync,
 } from "node:fs";
 import {
+  basename,
   dirname,
   extname,
   isAbsolute,
@@ -179,11 +180,36 @@ export interface CompilerExtractionResult {
   extractorVersion: string;
   projects: DiscoveredTypeScriptProject[];
   files: CompilerFileExtraction[];
+  /** Repository inputs whose exact bytes influenced config parsing or compiler facts. */
+  semanticInputs: CompilerSemanticInput[];
+}
+
+export interface CompilerStagedInput {
+  filePath: string;
+  source: string;
+}
+
+export interface CompilerSemanticInput {
+  filePath: string;
+  /** Exact UTF-8 hash, or null when a resolution/config probe observed absence. */
+  contentHash: string | null;
 }
 
 export interface CompilerExtractionOptions {
   /** Additional options used only by the inferred program. */
   inferredCompilerOptions?: ts.CompilerOptions;
+  /**
+   * Immutable repository inputs supplied by the graph staging layer. The
+   * compiler host always prefers these bytes to the live filesystem.
+   * @internal
+   */
+  stagedInputs?: readonly CompilerStagedInput[];
+  /**
+   * Secure reader for repository inputs discovered indirectly (for example an
+   * extended tsconfig). Results are cached for the complete extraction.
+   * @internal
+   */
+  readProjectFile?: (absolutePath: string) => string | undefined;
 }
 
 interface ParsedProject {
@@ -309,13 +335,20 @@ export function buildTypeScriptExtraction(
   options: CompilerExtractionOptions = {},
 ): CompilerExtractionResult {
   const root = resolve(rootDir);
-  const candidates = collectCandidates(root, candidateFiles);
-  const parsedProjects = parseProjects(root, new Set(candidates));
+  const inputs = new CompilerInputLedger(root, options);
+  const candidates = collectCandidates(root, candidateFiles, inputs);
+  inputs.setCandidateFiles(candidates);
+  const candidateSet = new Set(candidates);
+  const parsedProjects = parseProjects(root, candidateSet, inputs);
   const runtimeProjects: RuntimeProject[] = parsedProjects.map((project) => {
+    const rootNames = project.parsed.fileNames
+      .map(normalizedAbsolute)
+      .filter((file) => candidateSet.has(file));
     const program = ts.createProgram({
-      rootNames: project.parsed.fileNames,
+      rootNames,
       options: project.parsed.options,
       projectReferences: project.parsed.projectReferences,
+      host: inputs.compilerHost(project.parsed.options),
     });
     return { ...project, program, checker: program.getTypeChecker() };
   });
@@ -345,7 +378,11 @@ export function buildTypeScriptExtraction(
       target: ts.ScriptTarget.ES2022,
       ...options.inferredCompilerOptions,
     };
-    const program = ts.createProgram({ rootNames: uncovered, options: inferredOptions });
+    const program = ts.createProgram({
+      rootNames: uncovered,
+      options: inferredOptions,
+      host: inputs.compilerHost(inferredOptions),
+    });
     inferred = {
       id: "inferred",
       configPath: "",
@@ -411,7 +448,7 @@ export function buildTypeScriptExtraction(
   }
 
   const files = contexts.map((context) => {
-    const importBindings = extractImportBindings(root, context, locationIds);
+    const importBindings = extractImportBindings(root, context, locationIds, inputs);
     const references = extractReferences(context, contexts, locationIds, nodeById, importBindings);
     return {
       filePath: context.filePath,
@@ -442,6 +479,7 @@ export function buildTypeScriptExtraction(
     extractorVersion: TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
     projects: projectSummaries,
     files,
+    semanticInputs: inputs.semanticInputs(),
   };
 }
 
@@ -505,8 +543,298 @@ export function normalizedCompilerTokens(
   }));
 }
 
-function parseProjects(root: string, candidates?: ReadonlySet<string>): ParsedProject[] {
-  const queue = findConfigFiles(root);
+type MatchFiles = (
+  path: string,
+  extensions: readonly string[] | undefined,
+  excludes: readonly string[] | undefined,
+  includes: readonly string[] | undefined,
+  useCaseSensitiveFileNames: boolean,
+  currentDirectory: string,
+  depth: number | undefined,
+  getFileSystemEntries: (path: string) => { files: string[]; directories: string[] },
+  realpath: (path: string) => string,
+) => string[];
+
+/**
+ * One immutable view of repository inputs for the complete compiler pass.
+ * Project files are read at most once; explicitly staged bytes always win.
+ * TypeScript libraries and ignored dependency/build directories retain the
+ * compiler's normal filesystem behavior and do not become graph provenance.
+ */
+class CompilerInputLedger {
+  private readonly root: string;
+  private readonly staged = new Map<string, string>();
+  private readonly cache = new Map<string, string | undefined>();
+  private readonly observed = new Map<string, string | null>();
+  private readonly knownPaths = new Set<string>();
+  private readonly knownDirectories = new Set<string>();
+  private readonly directoryFiles = new Map<string, Set<string>>();
+  private readonly directoryChildren = new Map<string, Set<string>>();
+  private candidates: string[] = [];
+
+  constructor(root: string, private readonly options: CompilerExtractionOptions) {
+    this.root = resolve(root);
+    for (const input of options.stagedInputs ?? []) {
+      const absolute = absoluteCandidate(this.root, input.filePath);
+      if (!withinRoot(this.root, absolute)) {
+        throw new Error(`Compiler staged input escapes the project root: ${input.filePath}`);
+      }
+      const previous = this.staged.get(absolute);
+      if (previous !== undefined && previous !== input.source) {
+        throw new Error(`Compiler staged input has conflicting bytes: ${input.filePath}`);
+      }
+      this.staged.set(absolute, input.source);
+      this.indexKnownFile(absolute);
+    }
+    this.knownDirectories.add(normalizedAbsolute(this.root));
+  }
+
+  hasStagedInput(fileName: string): boolean {
+    return this.staged.has(absoluteCandidate(this.root, fileName));
+  }
+
+  setCandidateFiles(files: readonly string[]): void {
+    this.candidates = [...files].map(normalizedAbsolute).sort(compareCodePoints);
+    for (const file of this.candidates) this.indexKnownFile(file);
+  }
+
+  configFiles(): string[] {
+    if (this.options.stagedInputs === undefined) return findConfigFiles(this.root);
+    return [...this.staged.keys()]
+      .filter((file) => /^tsconfig(?:\.[^.]+)?\.json$/u.test(file.split("/").at(-1) ?? ""))
+      .sort(compareCodePoints);
+  }
+
+  readFile(fileName: string): string | undefined {
+    const absolute = absoluteCandidate(this.root, fileName);
+    const staged = this.staged.get(absolute);
+    if (staged !== undefined) {
+      this.observe(absolute, staged);
+      return staged;
+    }
+    if (!withinRoot(this.root, absolute)) {
+      return isAllowedCompilerDependency(absolute) ? ts.sys.readFile(fileName) : undefined;
+    }
+    if (!this.isProjectInput(absolute)) {
+      return isAllowedCompilerDependency(absolute) ? ts.sys.readFile(fileName) : undefined;
+    }
+    if (this.cache.has(absolute)) return this.cache.get(absolute);
+    const source = this.options.readProjectFile
+      ? this.options.readProjectFile(absolute)
+      : ts.sys.readFile(fileName);
+    this.cache.set(absolute, source);
+    if (source !== undefined) {
+      this.indexKnownFile(absolute);
+      this.observe(absolute, source);
+    }
+    else this.observeMissing(absolute);
+    return source;
+  }
+
+  readConfigFile(fileName: string): string | undefined {
+    const absolute = absoluteCandidate(this.root, fileName);
+    if (!withinRoot(this.root, absolute)) {
+      throw compilerInputContainmentError(`TypeScript config escapes the project root: ${fileName}`);
+    }
+    if (!this.isProjectInput(absolute) && !isAllowedCompilerDependency(absolute)) {
+      throw compilerInputContainmentError(`TypeScript config is outside the supported project corpus: ${fileName}`);
+    }
+    return this.readFile(absolute);
+  }
+
+  configFileExists(fileName: string): boolean {
+    const absolute = absoluteCandidate(this.root, fileName);
+    if (!withinRoot(this.root, absolute)) {
+      throw compilerInputContainmentError(`TypeScript config escapes the project root: ${fileName}`);
+    }
+    if (!this.isProjectInput(absolute) && !isAllowedCompilerDependency(absolute)) {
+      throw compilerInputContainmentError(`TypeScript config is outside the supported project corpus: ${fileName}`);
+    }
+    return this.fileExists(absolute);
+  }
+
+  fileExists(fileName: string): boolean {
+    const absolute = absoluteCandidate(this.root, fileName);
+    if (this.staged.has(absolute)) return true;
+    if (!withinRoot(this.root, absolute)) {
+      return isAllowedCompilerDependency(absolute) && ts.sys.fileExists(fileName);
+    }
+    if (!this.isProjectInput(absolute)) {
+      return isAllowedCompilerDependency(absolute) && ts.sys.fileExists(fileName);
+    }
+    return this.readFile(absolute) !== undefined;
+  }
+
+  directoryExists(directoryName: string): boolean {
+    const absolute = absoluteCandidate(this.root, directoryName);
+    if (!withinRoot(this.root, absolute)) {
+      return isAllowedCompilerDependency(absolute) && ts.sys.directoryExists(absolute);
+    }
+    if (!this.isProjectInput(absolute)) {
+      return isAllowedCompilerDependency(absolute) && ts.sys.directoryExists(absolute);
+    }
+    return this.knownDirectories.has(absolute);
+  }
+
+  getDirectories(directoryName: string): string[] {
+    const absolute = absoluteCandidate(this.root, directoryName);
+    if (!withinRoot(this.root, absolute)) {
+      return isAllowedCompilerDependency(absolute) ? ts.sys.getDirectories(absolute) : [];
+    }
+    if (!this.isProjectInput(absolute)) {
+      return isAllowedCompilerDependency(absolute) ? ts.sys.getDirectories(absolute) : [];
+    }
+    return [...(this.directoryChildren.get(absolute) ?? [])]
+      .map((name) => resolve(absolute, name))
+      .sort(compareCodePoints);
+  }
+
+  readDirectory(
+    rootDir: string,
+    extensions: readonly string[],
+    excludes: readonly string[] | undefined,
+    includes: readonly string[],
+    depth?: number,
+  ): string[] {
+    if (!withinRoot(this.root, absoluteCandidate(this.root, rootDir))) {
+      throw compilerInputContainmentError(`TypeScript config include escapes the project root: ${rootDir}`);
+    }
+    // TypeScript's matcher is intentionally used with a virtual directory tree
+    // built only from the immutable candidate list. This preserves exact
+    // tsconfig include/exclude semantics without consulting a racing checkout.
+    const matchFiles = (ts as unknown as { matchFiles?: MatchFiles }).matchFiles;
+    if (!matchFiles) {
+      throw new Error("The pinned TypeScript compiler does not expose its deterministic file matcher.");
+    }
+    return matchFiles(
+      rootDir,
+      extensions,
+      excludes,
+      includes,
+      ts.sys.useCaseSensitiveFileNames,
+      this.root,
+      depth,
+      (directory) => this.virtualDirectoryEntries(directory),
+      (path) => normalizedAbsolute(path),
+    );
+  }
+
+  compilerHost(options: ts.CompilerOptions): ts.CompilerHost {
+    const base = ts.createCompilerHost(options, true);
+    const getSourceFile: ts.CompilerHost["getSourceFile"] = (
+      fileName,
+      languageVersionOrOptions,
+      onError,
+    ) => {
+      const source = this.readFile(fileName);
+      if (source === undefined) {
+        onError?.(`Could not read compiler input ${fileName}.`);
+        return undefined;
+      }
+      return ts.createSourceFile(
+        fileName,
+        source,
+        languageVersionOrOptions,
+        true,
+        scriptKindForFile(fileName),
+      );
+    };
+    return {
+      ...base,
+      fileExists: (fileName) => this.fileExists(fileName),
+      directoryExists: (directoryName) => this.directoryExists(directoryName),
+      getDirectories: (directoryName) => this.getDirectories(directoryName),
+      readFile: (fileName) => this.readFile(fileName),
+      readDirectory: (rootDir, extensions, excludes, includes, depth) =>
+        this.readDirectory(rootDir, extensions, excludes, includes, depth),
+      getSourceFile,
+      getSourceFileByPath: (fileName, _path, languageVersionOrOptions, onError) =>
+        getSourceFile(fileName, languageVersionOrOptions, onError),
+      realpath: (path) => this.isProjectInput(absoluteCandidate(this.root, path))
+        ? absoluteCandidate(this.root, path)
+        : (base.realpath?.(path) ?? path),
+    };
+  }
+
+  moduleResolutionHost(): ts.ModuleResolutionHost {
+    return {
+      fileExists: (fileName) => this.fileExists(fileName),
+      readFile: (fileName) => this.readFile(fileName),
+      directoryExists: (directoryName) => this.directoryExists(directoryName),
+      getDirectories: (directoryName) => this.getDirectories(directoryName),
+      realpath: (path) => this.isProjectInput(absoluteCandidate(this.root, path))
+        ? absoluteCandidate(this.root, path)
+        : (ts.sys.realpath?.(path) ?? path),
+      useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
+    };
+  }
+
+  semanticInputs(): CompilerSemanticInput[] {
+    return [...this.observed.entries()]
+      .map(([file, contentHash]) => ({ filePath: relativePath(this.root, file), contentHash }))
+      .sort((left, right) => compareCodePoints(left.filePath, right.filePath));
+  }
+
+  private observe(absolute: string, source: string): void {
+    const contentHash = sha256(source);
+    const previous = this.observed.get(absolute);
+    if (previous !== undefined && previous !== contentHash) {
+      throw new Error(`Compiler input changed during extraction: ${relativePath(this.root, absolute)}`);
+    }
+    this.observed.set(absolute, contentHash);
+  }
+
+  private observeMissing(absolute: string): void {
+    if (negativeProbeCoveredByCorpusPolicy(absolute)) return;
+    if (!this.observed.has(absolute)) {
+      this.observed.set(absolute, null);
+      return;
+    }
+    if (this.observed.get(absolute) !== null) {
+      throw new Error(`Compiler input changed during extraction: ${relativePath(this.root, absolute)}`);
+    }
+  }
+
+  private isProjectInput(absolute: string): boolean {
+    if (!withinRoot(this.root, absolute)) return false;
+    const parts = relativePath(this.root, absolute).split("/");
+    return !parts.some((part) => IGNORED_DIRECTORIES.has(part));
+  }
+
+  private virtualDirectoryEntries(directory: string): { files: string[]; directories: string[] } {
+    const absoluteDirectory = normalizedAbsolute(directory);
+    return {
+      files: [...(this.directoryFiles.get(absoluteDirectory) ?? [])].sort(compareCodePoints),
+      directories: [...(this.directoryChildren.get(absoluteDirectory) ?? [])].sort(compareCodePoints),
+    };
+  }
+
+  private indexKnownFile(file: string): void {
+    const absolute = normalizedAbsolute(file);
+    if (this.knownPaths.has(absolute)) return;
+    this.knownPaths.add(absolute);
+    let directory = normalizedAbsolute(dirname(absolute));
+    const fileNames = this.directoryFiles.get(directory) ?? new Set<string>();
+    fileNames.add(basename(absolute));
+    this.directoryFiles.set(directory, fileNames);
+    while (withinRoot(this.root, directory)) {
+      this.knownDirectories.add(directory);
+      const parent = normalizedAbsolute(dirname(directory));
+      if (parent === directory || !withinRoot(this.root, parent)) break;
+      const children = this.directoryChildren.get(parent) ?? new Set<string>();
+      children.add(basename(directory));
+      this.directoryChildren.set(parent, children);
+      directory = parent;
+    }
+  }
+}
+
+function parseProjects(
+  root: string,
+  candidates?: ReadonlySet<string>,
+  inputs?: CompilerInputLedger,
+): ParsedProject[] {
+  const queue = inputs?.configFiles() ?? findConfigFiles(root);
   const seen = new Set<string>();
   const projects: ParsedProject[] = [];
   while (queue.length > 0) {
@@ -517,9 +845,12 @@ function parseProjects(root: string, candidates?: ReadonlySet<string>): ParsedPr
     const host: ts.ParseConfigFileHost = {
       useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
       getCurrentDirectory: () => root,
-      fileExists: ts.sys.fileExists,
-      readDirectory: ts.sys.readDirectory,
-      readFile: ts.sys.readFile,
+      fileExists: inputs ? (fileName) => inputs.configFileExists(fileName) : ts.sys.fileExists,
+      readDirectory: inputs
+        ? (rootDir, extensions, excludes, includes, depth) =>
+          inputs.readDirectory(rootDir, extensions, excludes, includes, depth)
+        : ts.sys.readDirectory,
+      readFile: inputs ? (fileName) => inputs.readConfigFile(fileName) : ts.sys.readFile,
       onUnRecoverableConfigFileDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
     };
     const parsed = ts.getParsedCommandLineOfConfigFile(configPath, {}, host);
@@ -527,7 +858,10 @@ function parseProjects(root: string, candidates?: ReadonlySet<string>): ParsedPr
     diagnostics.push(...parsed.errors);
     for (const reference of parsed.projectReferences ?? []) {
       const referencePath = normalizedAbsolute(ts.resolveProjectReferencePath(reference));
-      if (withinRoot(root, referencePath) && !seen.has(referencePath)) queue.push(referencePath);
+      if (!withinRoot(root, referencePath)) {
+        throw compilerInputContainmentError(`TypeScript project reference escapes the project root: ${referencePath}`);
+      }
+      if (!seen.has(referencePath)) queue.push(referencePath);
     }
     const includesCandidate = !candidates || parsed.fileNames.some((file) => candidates.has(normalizedAbsolute(file)));
     const isReferenced = projects.some((project) =>
@@ -570,12 +904,16 @@ function findConfigFiles(root: string): string[] {
   return configs.sort();
 }
 
-function collectCandidates(root: string, supplied?: readonly string[]): string[] {
+function collectCandidates(
+  root: string,
+  supplied?: readonly string[],
+  inputs?: CompilerInputLedger,
+): string[] {
   if (supplied) {
     return [...new Set(supplied
       .map((file) => absoluteCandidate(root, file))
       .filter(isCompilerSourceFile)
-      .filter((file) => existsSync(file) && statSync(file).isFile()))]
+      .filter((file) => inputs?.hasStagedInput(file) || (existsSync(file) && statSync(file).isFile())))]
       .sort();
   }
   const files: string[] = [];
@@ -835,6 +1173,7 @@ function extractImportBindings(
   root: string,
   context: FileContext,
   locationIds: ReadonlyMap<string, string>,
+  inputs: CompilerInputLedger,
 ): CompilerImportBinding[] {
   const bindings: CompilerImportBinding[] = [];
   const checker = context.project.checker;
@@ -843,7 +1182,12 @@ function extractImportBindings(
     if (!ts.isImportDeclaration(statement) || !ts.isStringLiteralLike(statement.moduleSpecifier)) continue;
     if (!referenceSyntaxIsTrusted(statement, context)) continue;
     const moduleSpecifier = statement.moduleSpecifier.text;
-    const resolution = ts.resolveModuleName(moduleSpecifier, context.sourceFile.fileName, options, ts.sys).resolvedModule;
+    const resolution = ts.resolveModuleName(
+      moduleSpecifier,
+      context.sourceFile.fileName,
+      options,
+      inputs.moduleResolutionHost(),
+    ).resolvedModule;
     const resolvedFilePath = resolution && withinRoot(root, resolution.resolvedFileName)
       ? relativePath(root, resolution.resolvedFileName)
       : undefined;
@@ -1568,6 +1912,15 @@ function languageForFile(filePath: string): CompilerSourceLanguage {
   return "typescript";
 }
 
+function scriptKindForFile(filePath: string): ts.ScriptKind {
+  const extension = extname(filePath).toLowerCase();
+  if (extension === ".js" || extension === ".mjs" || extension === ".cjs") return ts.ScriptKind.JS;
+  if (extension === ".jsx") return ts.ScriptKind.JSX;
+  if (extension === ".tsx") return ts.ScriptKind.TSX;
+  if (extension === ".json") return ts.ScriptKind.JSON;
+  return ts.ScriptKind.TS;
+}
+
 function isCompilerSourceFile(filePath: string): boolean {
   return SOURCE_EXTENSIONS.has(extname(filePath).toLowerCase());
 }
@@ -1603,4 +1956,25 @@ function withinRoot(root: string, file: string): boolean {
 
 function sha256(value: string): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function compareCodePoints(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compilerInputContainmentError(message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code: "GRAPH_SOURCE_PATH_ESCAPE" });
+}
+
+function isAllowedCompilerDependency(absolutePath: string): boolean {
+  return normalizeRelative(absolutePath).split("/").includes("node_modules");
+}
+
+/** Future appearance of these paths is already detected by corpus/config status. */
+function negativeProbeCoveredByCorpusPolicy(absolutePath: string): boolean {
+  if (isCompilerSourceFile(absolutePath)) return true;
+  const name = basename(absolutePath).toLowerCase();
+  return name === "package.json"
+    || /^tsconfig(?:\.[^.]+)?\.json$/u.test(name)
+    || /^jsconfig(?:\.[^.]+)?\.json$/u.test(name);
 }

--- a/src/graph/extraction/index.ts
+++ b/src/graph/extraction/index.ts
@@ -44,8 +44,10 @@ export type {
   CompilerReference,
   CompilerReferenceKind,
   CompilerResolutionStatus,
+  CompilerSemanticInput,
   CompilerSourceHealth,
   CompilerSourceLanguage,
+  CompilerStagedInput,
   DiscoveredTypeScriptProject,
 } from "./compiler.js";
 

--- a/src/graph/maintenance.ts
+++ b/src/graph/maintenance.ts
@@ -1,0 +1,1475 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import type {
+  Diagnostic,
+} from "../team/contracts/shared.js";
+import type {
+  GraphMaintenanceOptions,
+  GraphMaintenanceProgress,
+  GraphRefreshResult,
+  GraphStatus,
+} from "../team/contracts/graph.js";
+import { DB_SCHEMA_VERSION } from "./db/database.js";
+import { openSqlite } from "./db/sqlite.js";
+import { createGraphEngine, GraphSourceStagingError } from "./engine-impl.js";
+import type { BuildResult, GraphEngine } from "./engine.js";
+import {
+  inspectGraphSidecars,
+  inspectGraphStatus,
+} from "./status.js";
+import { GRAPH_SNAPSHOT_METADATA_KEY } from "./snapshot.js";
+
+const LOCK_FILE = "graph.db.lock";
+const LOCK_GATE_FILE = "graph.db.lock.gate";
+const MAX_LOCK_BYTES = 4 * 1024;
+const HASH_CHUNK_BYTES = 1024 * 1024;
+const OWNED_DATABASE_PREFIXES = [
+  "graph.db.candidate-",
+  "graph.db.rollback-",
+  "graph.db.recovery-",
+] as const;
+
+export type GraphMaintenanceErrorCode =
+  | "GRAPH_INDEX_MISSING"
+  | "GRAPH_INDEX_NOT_REFRESHABLE"
+  | "GRAPH_MAINTENANCE_LOCKED"
+  | "GRAPH_MAINTENANCE_GATE_STALE"
+  | "GRAPH_MAINTENANCE_CANCELLED"
+  | "GRAPH_MAINTENANCE_PATH_UNSAFE"
+  | "GRAPH_MAINTENANCE_RACE"
+  | "GRAPH_CANDIDATE_INVALID"
+  | "GRAPH_PUBLICATION_FAILED";
+
+/** Internal typed failure used by the CLI and the future GraphPort adapter. */
+export class GraphMaintenanceError extends Error {
+  override readonly name = "GraphMaintenanceError";
+
+  constructor(
+    readonly code: GraphMaintenanceErrorCode,
+    message: string,
+    readonly diagnostics: readonly Diagnostic[] = [],
+    readonly recoveryPath?: string,
+  ) {
+    super(message);
+  }
+}
+
+export interface GraphMaintenanceResult extends GraphRefreshResult {
+  /** Retained only when an unsafe prior database was replaced successfully. */
+  recoveryPath?: string;
+  durationMs: number;
+}
+
+interface MaintenancePaths {
+  projectRoot: string;
+  projectRootReal: string;
+  mexDir: string;
+  mexDirReal: string;
+  mexDirDev: number;
+  mexDirIno: number;
+  database: string;
+  lock: string;
+  lockGate: string;
+}
+
+interface DatabaseIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  digest: string;
+}
+
+interface StatIdentity {
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+interface ValidatedCandidate {
+  status: GraphStatus;
+  identity: DatabaseIdentity;
+  snapshotRaw: string;
+  snapshotHash: string;
+}
+
+interface LockOwner {
+  pid: number;
+  token: string;
+  startedAt: string;
+}
+
+interface MaintenanceLock {
+  owner: LockOwner;
+  identity: StatIdentity;
+  release(): void;
+}
+
+interface GraphMaintenanceInternalHooks {
+  token?: () => string;
+  now?: () => Date;
+  inspectStatus?: typeof inspectGraphStatus;
+  afterLockAcquired?: () => void | Promise<void>;
+  afterCandidateBuilt?: (candidatePath: string) => void | Promise<void>;
+  afterCandidateValidated?: (candidatePath: string, status: GraphStatus) => void | Promise<void>;
+  beforeLiveRevalidation?: () => void | Promise<void>;
+  afterRollbackCreated?: (rollbackPath: string) => void | Promise<void>;
+  afterPublish?: (databasePath: string) => void | Promise<void>;
+  beforeRollbackRestore?: (rollbackPath: string, databasePath: string) => void | Promise<void>;
+  beforeCandidateDatabaseOpen?: (candidatePath: string) => void;
+  beforeDeadLockReclaim?: (lockPath: string) => void;
+  afterLockGateAcquired?: (gatePath: string) => void;
+}
+
+type InternalMaintenanceOptions = GraphMaintenanceOptions & {
+  /** Deterministic fault/race seams. Deliberately absent from public declarations. */
+  __internal?: GraphMaintenanceInternalHooks;
+};
+
+interface CandidatePublicationInput {
+  paths: MaintenancePaths;
+  candidatePath: string;
+  candidate: ValidatedCandidate;
+  priorStatus: GraphStatus;
+  priorIdentity: DatabaseIdentity | null;
+  retainRecovery: boolean;
+  options: InternalMaintenanceOptions;
+}
+
+interface CandidatePublicationResult {
+  status: GraphStatus;
+  recoveryPath?: string;
+  diagnostics: readonly Diagnostic[];
+}
+
+export type GraphMaintenanceLeaseMode = "refresh" | "rebuild";
+
+/**
+ * Internal programmatic lease for workflows that must keep graph writes and
+ * subsequent grounding-baseline writes under one cross-process owner token.
+ * The lease is intentionally not exported from the package root.
+ */
+export interface GraphMaintenanceLease {
+  readonly projectRoot: string;
+  readonly databasePath: string;
+  refresh(options?: GraphMaintenanceOptions): Promise<GraphMaintenanceResult>;
+  rebuild(options?: GraphMaintenanceOptions): Promise<GraphMaintenanceResult>;
+  release(): void;
+}
+
+export function acquireGraphMaintenanceLease(
+  projectRoot: string,
+  mode: GraphMaintenanceLeaseMode = "refresh",
+  options: GraphMaintenanceOptions = {},
+): GraphMaintenanceLease {
+  const internalOptions = options as InternalMaintenanceOptions;
+  const paths = resolveMaintenancePaths(projectRoot, mode === "rebuild");
+  assertMaintenanceDirectoryUnchanged(paths);
+  if (mode === "refresh" && !existsSync(paths.database)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_INDEX_MISSING",
+      "The graph index does not exist. Run `mex graph rebuild` first.",
+    );
+  }
+  const lock = acquireMaintenanceLock(paths, internalOptions);
+  let released = false;
+  let active = false;
+  const run = async (
+    operation: "refresh" | "rebuild",
+    operationOptions: GraphMaintenanceOptions,
+  ): Promise<GraphMaintenanceResult> => {
+    if (released) throw new Error("The graph maintenance lease has already been released.");
+    if (active) {
+      throw new GraphMaintenanceError(
+        "GRAPH_MAINTENANCE_LOCKED",
+        "This graph maintenance lease already has an active operation.",
+      );
+    }
+    active = true;
+    try {
+      const resolved = operationOptions as InternalMaintenanceOptions;
+      // Wrapper callers pass the same options to acquisition and execution.
+      // A manual lease may supply operation-local progress/cancellation while
+      // retaining acquisition-time deterministic hooks.
+      const merged = {
+        ...operationOptions,
+        __internal: resolved.__internal ?? internalOptions.__internal,
+      } as InternalMaintenanceOptions;
+      await merged.__internal?.afterLockAcquired?.();
+      assertMaintenanceDirectoryUnchanged(paths);
+      return operation === "refresh"
+        ? await refreshGraphWithLease(paths, merged)
+        : await rebuildGraphWithLease(paths, merged);
+    } finally {
+      active = false;
+    }
+  };
+  return {
+    projectRoot: paths.projectRoot,
+    databasePath: paths.database,
+    refresh: (operationOptions = {}) => run("refresh", operationOptions),
+    rebuild: (operationOptions = {}) => run("rebuild", operationOptions),
+    release: () => {
+      if (released) return;
+      if (active) throw new Error("Cannot release an active graph maintenance lease.");
+      released = true;
+      lock.release();
+    },
+  };
+}
+
+/** Explicit correctness-first refresh. Reads never call this function. */
+export async function refreshGraph(
+  projectRoot: string,
+  options: GraphMaintenanceOptions = {},
+): Promise<GraphMaintenanceResult> {
+  const lease = acquireGraphMaintenanceLease(projectRoot, "refresh", options);
+  try {
+    return await lease.refresh(options);
+  } finally {
+    lease.release();
+  }
+}
+
+async function refreshGraphWithLease(
+  paths: MaintenancePaths,
+  options: InternalMaintenanceOptions,
+): Promise<GraphMaintenanceResult> {
+  const started = currentDate(options);
+  let candidatePath: string | null = null;
+  try {
+    assertNotAborted(options.signal);
+    const priorStatus = await inspect(options, paths.projectRoot, paths.database);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertRefreshable(priorStatus);
+    assertClearSidecars(paths.database);
+    const priorIdentity = captureDatabaseIdentity(paths.database);
+    progress(options, "discover", "Inspecting the current graph snapshot and source corpus.");
+
+    candidatePath = ownedPath(paths, "candidate", createToken(options));
+    copyExactDatabase(paths, paths.database, candidatePath, priorIdentity);
+    const buildResult = await refreshCandidate(paths, candidatePath, options);
+    await options.__internal?.afterCandidateBuilt?.(candidatePath);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertNotAborted(options.signal);
+
+    progress(options, "validate", "Validating the refreshed graph candidate.");
+    const candidate = await validateCandidate(options, paths, candidatePath);
+    await options.__internal?.afterCandidateValidated?.(candidatePath, candidate.status);
+    assertMaintenanceDirectoryUnchanged(paths);
+
+    const published = await publishCandidate({
+      paths,
+      candidatePath,
+      candidate,
+      priorStatus,
+      priorIdentity,
+      retainRecovery: false,
+      options,
+    });
+    candidatePath = null;
+    const finished = currentDate(options);
+    return maintenanceResult(started, finished, buildResult, published);
+  } finally {
+    if (candidatePath) cleanupOwnedDatabase(paths, candidatePath);
+  }
+}
+
+/** Explicit isolated rebuild for missing, incompatible, or corrupt indexes. */
+export async function rebuildGraph(
+  projectRoot: string,
+  options: GraphMaintenanceOptions = {},
+): Promise<GraphMaintenanceResult> {
+  const lease = acquireGraphMaintenanceLease(projectRoot, "rebuild", options);
+  try {
+    return await lease.rebuild(options);
+  } finally {
+    lease.release();
+  }
+}
+
+async function rebuildGraphWithLease(
+  paths: MaintenancePaths,
+  options: InternalMaintenanceOptions,
+): Promise<GraphMaintenanceResult> {
+  const started = currentDate(options);
+  let candidatePath: string | null = null;
+  try {
+    assertNotAborted(options.signal);
+    progress(options, "discover", "Inspecting graph recovery prerequisites.");
+    const priorStatus = await inspect(options, paths.projectRoot, paths.database);
+    assertMaintenanceDirectoryUnchanged(paths);
+    const databaseExists = existsSync(paths.database);
+    if (databaseExists) assertClearSidecars(paths.database);
+    const priorIdentity = databaseExists ? captureDatabaseIdentity(paths.database) : null;
+
+    const cloneForContinuity = Boolean(priorIdentity && shouldCloneForContinuity(priorStatus));
+    let continuityFallback = false;
+    candidatePath = ownedPath(paths, "candidate", createToken(options));
+    if (priorIdentity && cloneForContinuity) {
+      copyExactDatabase(paths, paths.database, candidatePath, priorIdentity);
+    }
+    let buildResult: BuildResult;
+    try {
+      buildResult = await rebuildCandidate(paths, candidatePath, options);
+    } catch (error) {
+      if (!cloneForContinuity || !isContinuityCloneCompatibilityFailure(error)) throw error;
+      // An older database may be readable enough to identify its version yet
+      // structurally unsafe to migrate. Discard only the isolated clone and
+      // retry from an empty candidate; the exact live bytes remain untouched
+      // and will be retained as recovery if publication succeeds.
+      cleanupOwnedDatabase(paths, candidatePath);
+      candidatePath = ownedPath(paths, "candidate", createToken(options));
+      continuityFallback = true;
+      buildResult = await rebuildCandidate(paths, candidatePath, options);
+      if ((buildResult.health?.failed ?? 0) > 0) {
+        cleanupOwnedDatabase(paths, candidatePath);
+        candidatePath = null;
+        throw new GraphSourceStagingError([{
+          filePath: ".",
+          operation: "parse",
+          code: "GRAPH_SOURCE_PARSE_FAILED",
+          message: "A fresh compatibility fallback encountered failed source parsing and was not published.",
+        }]);
+      }
+    }
+    await options.__internal?.afterCandidateBuilt?.(candidatePath);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertNotAborted(options.signal);
+
+    progress(options, "validate", "Validating the isolated graph rebuild candidate.");
+    const candidate = await validateCandidate(options, paths, candidatePath);
+    await options.__internal?.afterCandidateValidated?.(candidatePath, candidate.status);
+    assertMaintenanceDirectoryUnchanged(paths);
+
+    const retainRecovery = priorStatus.status === "corrupt"
+      || priorStatus.status === "rebuild_required";
+    const publication = await publishCandidate({
+      paths,
+      candidatePath,
+      candidate,
+      priorStatus,
+      priorIdentity,
+      retainRecovery,
+      options,
+    });
+    const published = continuityFallback
+      ? {
+          ...publication,
+          diagnostics: [
+            ...publication.diagnostics,
+            {
+              code: "GRAPH_INDEX_CONTINUITY_FALLBACK",
+              severity: "info" as const,
+              message: "The older graph index could not be migrated safely; mex rebuilt from a fresh candidate and retained the prior bytes for recovery.",
+            },
+          ],
+        }
+      : publication;
+    candidatePath = null;
+    const finished = currentDate(options);
+    return maintenanceResult(started, finished, buildResult, published);
+  } finally {
+    if (candidatePath) cleanupOwnedDatabase(paths, candidatePath);
+  }
+}
+
+async function refreshCandidate(
+  paths: MaintenancePaths,
+  candidatePath: string,
+  options: InternalMaintenanceOptions,
+): Promise<BuildResult> {
+  progress(options, "stage", "Checking exact graph provenance and restaging the corpus when required.");
+  const engine = maintenanceEngine(paths, candidatePath, options);
+  try {
+    // The empty-hint sync path performs the exact corpus, semantic-input,
+    // manifest, and branch handshake. It no-ops only when all provenance still
+    // matches; otherwise it securely restages the whole semantic corpus.
+    return await engine.sync([]);
+  } finally {
+    engine.close();
+  }
+}
+
+async function rebuildCandidate(
+  paths: MaintenancePaths,
+  candidatePath: string,
+  options: InternalMaintenanceOptions,
+): Promise<BuildResult> {
+  progress(options, "stage", "Building the graph in an isolated same-directory candidate.");
+  const engine = maintenanceEngine(paths, candidatePath, options);
+  try {
+    return await engine.build(paths.projectRoot);
+  } finally {
+    engine.close();
+  }
+}
+
+function maintenanceEngine(
+  paths: MaintenancePaths,
+  candidatePath: string,
+  options: InternalMaintenanceOptions,
+): GraphEngine {
+  assertMaintenanceDirectoryUnchanged(paths);
+  const check = () => {
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertNotAborted(options.signal);
+  };
+  return createGraphEngine({
+    rootDir: paths.projectRoot,
+    dbPath: candidatePath,
+    __internalGraphEngineHooks: {
+      beforeDatabaseOpen: () => {
+        options.__internal?.beforeCandidateDatabaseOpen?.(candidatePath);
+        check();
+      },
+      afterSemanticInputsStaged: check,
+      afterCompilerExtraction: check,
+      beforePublication: check,
+    },
+  } as Parameters<typeof createGraphEngine>[0]);
+}
+
+async function publishCandidate(input: CandidatePublicationInput): Promise<CandidatePublicationResult> {
+  const { paths, options } = input;
+  let rollbackPath: string | null = null;
+  let rollbackIdentity: DatabaseIdentity | null = null;
+  let published = false;
+  try {
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertNotAborted(options.signal);
+    await options.__internal?.beforeLiveRevalidation?.();
+    assertMaintenanceDirectoryUnchanged(paths);
+    revalidateLiveDatabase(paths.database, input.priorIdentity);
+    assertClearSidecarsIfPresent(paths.database);
+    assertCandidateUnchanged(input.candidatePath, input.candidate);
+
+    if (input.priorIdentity) {
+      rollbackPath = ownedPath(
+        paths,
+        "recovery",
+        createToken(options),
+      );
+      rollbackIdentity = copyExactDatabase(paths, paths.database, rollbackPath, input.priorIdentity);
+      await options.__internal?.afterRollbackCreated?.(rollbackPath);
+      assertMaintenanceDirectoryUnchanged(paths);
+      revalidateLiveDatabase(paths.database, input.priorIdentity);
+      assertClearSidecars(paths.database);
+      assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+    }
+    assertNotAborted(options.signal);
+    assertCandidateUnchanged(input.candidatePath, input.candidate);
+    cleanupCheckpointedOwnedSidecars(paths, input.candidatePath);
+    assertMaintenanceDirectoryUnchanged(paths);
+    fsyncFile(input.candidatePath);
+    fsyncMaintenanceDirectory(paths);
+    progress(options, "publish", "Publishing the validated graph candidate atomically.");
+    // Progress callbacks are caller code and may take arbitrary time. Bind both
+    // sides again at the final synchronous publication boundary.
+    revalidateLiveDatabase(paths.database, input.priorIdentity);
+    assertClearSidecarsIfPresent(paths.database);
+    assertCandidateUnchanged(input.candidatePath, input.candidate);
+    if (rollbackPath && rollbackIdentity) assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+    assertMaintenanceDirectoryUnchanged(paths);
+    renameSync(input.candidatePath, paths.database);
+    published = true;
+    fsyncMaintenanceDirectory(paths);
+    await options.__internal?.afterPublish?.(paths.database);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertNotAborted(options.signal);
+
+    const status = await inspect(options, paths.projectRoot, paths.database);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertPublishableCandidate(status);
+    const diagnostics: Diagnostic[] = [...status.diagnostics];
+    let recoveryPath: string | undefined;
+    if (rollbackPath && input.retainRecovery) {
+      if (rollbackIdentity) assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+      recoveryPath = toRepoRelative(paths.projectRoot, rollbackPath);
+      diagnostics.push(recoveryRetainedDiagnostic(
+        recoveryPath,
+        "The replaced incompatible or corrupt graph database was retained as ignored local recovery data.",
+      ));
+      rollbackPath = null;
+      rollbackIdentity = null;
+    } else if (rollbackPath) {
+      cleanupOwnedDatabase(paths, rollbackPath);
+      rollbackPath = null;
+      rollbackIdentity = null;
+    }
+    return { status, recoveryPath, diagnostics };
+  } catch (error) {
+    if (published && rollbackPath) {
+      try {
+        assertMaintenanceDirectoryUnchanged(paths);
+        if (!existsSync(rollbackPath)) throw new Error("The rollback copy disappeared.");
+        if (!rollbackIdentity) throw new Error("The rollback copy has no bound identity.");
+        assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+        assertPublishedCandidateOwnsLivePath(paths, input.candidate);
+        await options.__internal?.beforeRollbackRestore?.(rollbackPath, paths.database);
+        assertMaintenanceDirectoryUnchanged(paths);
+        assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+        assertPublishedCandidateOwnsLivePath(paths, input.candidate);
+        renameSync(rollbackPath, paths.database);
+        rollbackPath = null;
+        rollbackIdentity = null;
+        fsyncMaintenanceDirectory(paths);
+      } catch (rollbackError) {
+        const retainedPath = rollbackPath && rollbackIdentity
+          ? retainBoundRollbackCopy(paths, rollbackPath, rollbackIdentity)
+          : undefined;
+        // Never let the outer finally delete the only prior snapshot after a
+        // restore failure. Even when directory safety prevents a trustworthy
+        // path projection, leaving the copy untouched is safer than deletion.
+        rollbackPath = null;
+        rollbackIdentity = null;
+        const diagnostics = retainedPath
+          ? [
+              ...input.candidate.status.diagnostics,
+              recoveryRetainedDiagnostic(retainedPath, "Automatic rollback failed; the exact prior graph bytes were retained for manual recovery."),
+            ]
+          : input.candidate.status.diagnostics;
+        throw new GraphMaintenanceError(
+          "GRAPH_PUBLICATION_FAILED",
+          `The graph candidate failed validation and automatic rollback also failed: ${errorMessage(rollbackError)}`
+            + (retainedPath ? ` Exact prior bytes remain at ${retainedPath}.` : ""),
+          diagnostics,
+          retainedPath,
+        );
+      }
+    } else if (published && input.priorIdentity === null) {
+      // A failed first build has no prior file to rename back. Restore the
+      // exact prior `missing` state, but only while the live path is still the
+      // same file object that we published. If another writer replaced it, it
+      // is safer to leave that path alone and report the failed rollback.
+      try {
+        restoreMissingDatabaseState(input);
+      } catch (rollbackError) {
+        throw new GraphMaintenanceError(
+          "GRAPH_PUBLICATION_FAILED",
+          `The first graph candidate failed validation and the prior missing state could not be restored safely: ${errorMessage(rollbackError)}`,
+          input.candidate.status.diagnostics,
+        );
+      }
+    }
+    if (error instanceof GraphMaintenanceError) throw error;
+    throw new GraphMaintenanceError(
+      published ? "GRAPH_PUBLICATION_FAILED" : "GRAPH_MAINTENANCE_RACE",
+      published
+        ? `The graph candidate could not be published safely: ${errorMessage(error)}`
+        : `The live graph changed before candidate publication: ${errorMessage(error)}`,
+      input.priorStatus.diagnostics,
+    );
+  } finally {
+    if (rollbackPath) cleanupOwnedDatabase(paths, rollbackPath);
+  }
+}
+
+function retainBoundRollbackCopy(
+  paths: MaintenancePaths,
+  rollbackPath: string,
+  rollbackIdentity: DatabaseIdentity,
+): string | undefined {
+  try {
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertOwnedCopyUnchanged(rollbackPath, rollbackIdentity);
+    return toRepoRelative(paths.projectRoot, rollbackPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function recoveryRetainedDiagnostic(path: string, message: string): Diagnostic {
+  return {
+    code: "GRAPH_INDEX_RECOVERY_RETAINED",
+    severity: "info",
+    message,
+    path,
+  };
+}
+
+function assertPublishedCandidateOwnsLivePath(
+  paths: MaintenancePaths,
+  candidate: ValidatedCandidate,
+): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  const active = safeLstat(paths.database);
+  if (!active
+    || !active.isFile()
+    || active.isSymbolicLink()
+    || active.dev !== candidate.identity.dev
+    || active.ino !== candidate.identity.ino) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      "The published candidate was replaced before rollback; the replacement live path was not overwritten.",
+    );
+  }
+  assertClearSidecars(paths.database);
+}
+
+function restoreMissingDatabaseState(input: CandidatePublicationInput): void {
+  const { paths, candidatePath, candidate } = input;
+  assertMaintenanceDirectoryUnchanged(paths);
+  if (!existsSync(paths.database)) {
+    fsyncMaintenanceDirectory(paths);
+    return;
+  }
+  const active = lstatSync(paths.database);
+  if (!active.isFile()
+    || active.isSymbolicLink()
+    || active.dev !== candidate.identity.dev
+    || active.ino !== candidate.identity.ino) {
+    throw new GraphMaintenanceError(
+      "GRAPH_PUBLICATION_FAILED",
+      "The published graph path was replaced before the prior missing state could be restored.",
+    );
+  }
+  assertClearSidecars(paths.database);
+  if (existsSync(candidatePath)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_PUBLICATION_FAILED",
+      "The owned candidate path was unexpectedly occupied during missing-state restoration.",
+    );
+  }
+  assertMaintenanceDirectoryUnchanged(paths);
+  renameSync(paths.database, candidatePath);
+  fsyncMaintenanceDirectory(paths);
+}
+
+function maintenanceResult(
+  started: Date,
+  finished: Date,
+  build: BuildResult,
+  published: CandidatePublicationResult,
+): GraphMaintenanceResult {
+  return {
+    state: "succeeded",
+    startedAt: started.toISOString(),
+    finishedAt: finished.toISOString(),
+    durationMs: Math.max(0, finished.getTime() - started.getTime()),
+    diagnostics: published.diagnostics,
+    status: published.status,
+    filesIndexed: build.filesIndexed,
+    nodesCreated: build.nodesCreated,
+    edgesCreated: build.edgesCreated,
+    ...(published.recoveryPath ? { recoveryPath: published.recoveryPath } : {}),
+  };
+}
+
+function resolveMaintenancePaths(projectRoot: string, createMexDir: boolean): MaintenancePaths {
+  const root = resolve(projectRoot);
+  let rootReal: string;
+  try {
+    rootReal = realpathSync(root);
+  } catch {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "The project root could not be resolved safely.",
+    );
+  }
+  const mexDir = join(root, ".mex");
+  if (!existsSync(mexDir)) {
+    if (!createMexDir) {
+      throw new GraphMaintenanceError(
+        "GRAPH_INDEX_MISSING",
+        "The graph index does not exist. Run `mex graph rebuild` first.",
+      );
+    }
+    mkdirSync(mexDir, { recursive: true, mode: 0o700 });
+  }
+  const mexStats = lstatSync(mexDir);
+  if (!mexStats.isDirectory() || mexStats.isSymbolicLink()) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "The .mex maintenance directory must be a contained, non-symlink directory.",
+    );
+  }
+  const mexReal = realpathSync(mexDir);
+  if (!isContained(rootReal, mexReal)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "The .mex maintenance directory resolves outside the project root.",
+    );
+  }
+  const database = join(mexDir, "graph.db");
+  if (existsSync(database)) assertRegularNonSymlink(database, "graph database");
+  return {
+    projectRoot: root,
+    projectRootReal: rootReal,
+    mexDir,
+    mexDirReal: mexReal,
+    mexDirDev: mexStats.dev,
+    mexDirIno: mexStats.ino,
+    database,
+    lock: join(mexDir, LOCK_FILE),
+    lockGate: join(mexDir, LOCK_GATE_FILE),
+  };
+}
+
+function acquireMaintenanceLock(
+  paths: MaintenancePaths,
+  options: InternalMaintenanceOptions,
+): MaintenanceLock {
+  const owner: LockOwner = {
+    pid: process.pid,
+    token: createToken(options),
+    startedAt: currentDate(options).toISOString(),
+  };
+  const gate = acquireLockGate(paths, owner);
+  try {
+    options.__internal?.afterLockGateAcquired?.(paths.lockGate);
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertLockOwned(paths.lockGate, gate.owner, gate.identity);
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      let fd: number | null = null;
+      try {
+        assertMaintenanceDirectoryUnchanged(paths);
+        assertLockOwned(paths.lockGate, gate.owner, gate.identity);
+        const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+        fd = openSync(
+          paths.lock,
+          constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | noFollow,
+          0o600,
+        );
+        writeFileSync(fd, `${JSON.stringify(owner)}\n`, "utf8");
+        fsyncSync(fd);
+        closeSync(fd);
+        fd = null;
+        const identity = captureLockIdentity(paths.lock);
+        assertLockOwned(paths.lockGate, gate.owner, gate.identity);
+        fsyncMaintenanceDirectory(paths);
+        return {
+          owner,
+          identity,
+          release: () => releaseMaintenanceLock(paths, owner, identity),
+        };
+      } catch (error) {
+        if (fd !== null) closeSync(fd);
+        if (errorCode(error) !== "EEXIST") throw error;
+        if (attempt === 0 && reclaimDeadLock(paths, paths.lock, gate, options)) continue;
+        throw new GraphMaintenanceError(
+          "GRAPH_MAINTENANCE_LOCKED",
+          "Another graph maintenance operation is already active for this project.",
+        );
+      }
+    }
+  } finally {
+    gate.release();
+  }
+  throw new GraphMaintenanceError(
+    "GRAPH_MAINTENANCE_LOCKED",
+    "Another graph maintenance operation is already active for this project.",
+  );
+}
+
+function acquireLockGate(paths: MaintenancePaths, owner: LockOwner): MaintenanceLock {
+  assertMaintenanceDirectoryUnchanged(paths);
+  let fd: number | null = null;
+  try {
+    const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+    fd = openSync(
+      paths.lockGate,
+      constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | noFollow,
+      0o600,
+    );
+    writeFileSync(fd, `${JSON.stringify(owner)}\n`, "utf8");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    const identity = captureLockIdentity(paths.lockGate);
+    fsyncMaintenanceDirectory(paths);
+    return {
+      owner,
+      identity,
+      release: () => releaseLockGate(paths, owner, identity),
+    };
+  } catch (error) {
+    if (fd !== null) closeSync(fd);
+    if (errorCode(error) === "EEXIST") {
+      const existing = readLockOwner(paths.lockGate);
+      if (!existing || !processIsAlive(existing.pid)) {
+        const path = toRepoRelative(paths.projectRoot, paths.lockGate);
+        const message = "A prior graph lock acquisition was interrupted and left its acquisition gate behind. Verify no mex process is running, remove the reported gate path, and retry.";
+        throw new GraphMaintenanceError(
+          "GRAPH_MAINTENANCE_GATE_STALE",
+          `${message} Gate: ${path}.`,
+          [{
+            code: "GRAPH_MAINTENANCE_GATE_STALE",
+            severity: "error",
+            message,
+            path,
+          }],
+        );
+      }
+      throw new GraphMaintenanceError(
+        "GRAPH_MAINTENANCE_LOCKED",
+        "Another graph maintenance lock acquisition is already in progress for this project.",
+      );
+    }
+    throw error;
+  }
+}
+
+function releaseLockGate(
+  paths: MaintenancePaths,
+  owner: LockOwner,
+  identity: StatIdentity,
+): void {
+  try {
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertLockOwned(paths.lockGate, owner, identity);
+    unlinkSync(paths.lockGate);
+    fsyncMaintenanceDirectory(paths);
+  } catch {
+    // A replaced directory or gate is never deleted through a stale owner.
+  }
+}
+
+function reclaimDeadLock(
+  paths: MaintenancePaths,
+  lockPath: string,
+  gate: MaintenanceLock,
+  options: InternalMaintenanceOptions,
+): boolean {
+  assertMaintenanceDirectoryUnchanged(paths);
+  const owner = readLockOwner(lockPath);
+  if (!owner || processIsAlive(owner.pid)) return false;
+  options.__internal?.beforeDeadLockReclaim?.(lockPath);
+  assertMaintenanceDirectoryUnchanged(paths);
+  const before = safeLstat(lockPath);
+  if (!before || !before.isFile() || before.isSymbolicLink()) return false;
+  const current = readLockOwner(lockPath);
+  const after = safeLstat(lockPath);
+  if (!current || current.token !== owner.token || !after || !sameStatIdentity(before, after)) return false;
+  try {
+    // Every cooperating creator holds lockGate from its O_EXCL lock creation
+    // through this reclaim decision. The final token/inode check is therefore
+    // a compare-and-delete with respect to concurrent MEX reclaimers/creators.
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertLockOwned(paths.lockGate, gate.owner, gate.identity);
+    unlinkSync(lockPath);
+    fsyncMaintenanceDirectory(paths);
+    return true;
+  } catch (error) {
+    if (error instanceof GraphMaintenanceError) throw error;
+    return false;
+  }
+}
+
+function releaseMaintenanceLock(
+  paths: MaintenancePaths,
+  owner: LockOwner,
+  identity: StatIdentity,
+): void {
+  try {
+    assertMaintenanceDirectoryUnchanged(paths);
+    assertLockOwned(paths.lock, owner, identity);
+    unlinkSync(paths.lock);
+    fsyncMaintenanceDirectory(paths);
+  } catch {
+    // A lost or replaced owner token is safer to leave for explicit diagnosis.
+  }
+}
+
+function readLockOwner(lockPath: string): LockOwner | null {
+  let fd: number | null = null;
+  try {
+    const before = lstatSync(lockPath);
+    if (!before.isFile() || before.isSymbolicLink() || before.size > MAX_LOCK_BYTES) return null;
+    const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+    fd = openSync(lockPath, constants.O_RDONLY | noFollow);
+    const opened = fstatSync(fd);
+    if (!sameStatIdentity(before, opened)) return null;
+    const raw = readFileSync(fd, "utf8");
+    const after = fstatSync(fd);
+    if (!sameStatIdentity(opened, after)) return null;
+    const parsed = JSON.parse(raw) as Partial<LockOwner>;
+    if (!Number.isInteger(parsed.pid) || Number(parsed.pid) <= 0
+      || typeof parsed.token !== "string" || !/^[a-f0-9]{32,128}$/u.test(parsed.token)
+      || typeof parsed.startedAt !== "string" || !Number.isFinite(Date.parse(parsed.startedAt))) return null;
+    return { pid: Number(parsed.pid), token: parsed.token, startedAt: parsed.startedAt };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+function captureLockIdentity(lockPath: string): StatIdentity {
+  const stats = lstatSync(lockPath);
+  if (!stats.isFile() || stats.isSymbolicLink() || stats.size > MAX_LOCK_BYTES) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      `The maintenance lock ${basename(lockPath)} is not a bounded regular file.`,
+    );
+  }
+  return stats;
+}
+
+function assertLockOwned(
+  lockPath: string,
+  owner: LockOwner,
+  identity: StatIdentity,
+): void {
+  const current = readLockOwner(lockPath);
+  const stats = safeLstat(lockPath);
+  if (!current
+    || current.pid !== owner.pid
+    || current.token !== owner.token
+    || !stats
+    || !sameStatIdentity(stats, identity)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      `The maintenance lock ${basename(lockPath)} changed ownership unexpectedly.`,
+    );
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+function captureDatabaseIdentity(path: string): DatabaseIdentity {
+  assertRegularNonSymlink(path, "graph database");
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_RDONLY | noFollow);
+  try {
+    const before = fstatSync(fd);
+    const hash = createHash("sha256");
+    const chunk = Buffer.allocUnsafe(HASH_CHUNK_BYTES);
+    let offset = 0;
+    for (;;) {
+      const count = readSync(fd, chunk, 0, chunk.length, offset);
+      if (count === 0) break;
+      hash.update(chunk.subarray(0, count));
+      offset += count;
+    }
+    const after = fstatSync(fd);
+    const pathAfter = lstatSync(path);
+    if (!sameStatIdentity(before, after)
+      || !sameStatIdentity(after, pathAfter)
+      || pathAfter.isSymbolicLink()) {
+      throw new GraphMaintenanceError(
+        "GRAPH_MAINTENANCE_RACE",
+        "The graph database changed while its exact identity was captured.",
+      );
+    }
+    return {
+      dev: after.dev,
+      ino: after.ino,
+      size: after.size,
+      mtimeMs: after.mtimeMs,
+      ctimeMs: after.ctimeMs,
+      digest: hash.digest("hex"),
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function copyExactDatabase(
+  paths: MaintenancePaths,
+  sourcePath: string,
+  destinationPath: string,
+  expected: DatabaseIdentity,
+): DatabaseIdentity {
+  assertMaintenanceDirectoryUnchanged(paths);
+  assertOwnedDatabasePath(destinationPath);
+  if (existsSync(destinationPath)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      `Refusing to overwrite an existing owned maintenance path (${basename(destinationPath)}).`,
+    );
+  }
+  const before = captureDatabaseIdentity(sourcePath);
+  if (!sameDatabaseIdentity(before, expected)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      "The live graph changed before it could be copied safely.",
+    );
+  }
+  assertMaintenanceDirectoryUnchanged(paths);
+  copyFileSync(sourcePath, destinationPath, constants.COPYFILE_EXCL);
+  const copied = captureDatabaseIdentity(destinationPath);
+  const after = captureDatabaseIdentity(sourcePath);
+  if (copied.digest !== expected.digest || copied.size !== expected.size
+    || !sameDatabaseIdentity(after, expected)) {
+    cleanupOwnedDatabasePath(paths, destinationPath);
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      "The graph database changed while an exact maintenance copy was being created.",
+    );
+  }
+  assertMaintenanceDirectoryUnchanged(paths);
+  fsyncFile(destinationPath);
+  return copied;
+}
+
+function assertOwnedCopyUnchanged(path: string, expected: DatabaseIdentity): void {
+  assertOwnedDatabasePath(path);
+  if (!existsSync(path) || !sameDatabaseIdentity(captureDatabaseIdentity(path), expected)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      `The owned maintenance copy ${basename(path)} changed after its exact bytes were bound.`,
+    );
+  }
+}
+
+function revalidateLiveDatabase(path: string, expected: DatabaseIdentity | null): void {
+  if (expected === null) {
+    if (existsSync(path)) {
+      throw new GraphMaintenanceError(
+        "GRAPH_MAINTENANCE_RACE",
+        "A graph database appeared while an isolated rebuild was in progress.",
+      );
+    }
+    return;
+  }
+  if (!existsSync(path) || !sameDatabaseIdentity(captureDatabaseIdentity(path), expected)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      "The live graph changed while an isolated candidate was being built.",
+    );
+  }
+}
+
+async function validateCandidate(
+  options: InternalMaintenanceOptions,
+  paths: MaintenancePaths,
+  candidatePath: string,
+): Promise<ValidatedCandidate> {
+  assertMaintenanceDirectoryUnchanged(paths);
+  assertClearSidecars(candidatePath);
+  const identityBefore = captureDatabaseIdentity(candidatePath);
+  const status = await inspect(options, paths.projectRoot, candidatePath);
+  assertMaintenanceDirectoryUnchanged(paths);
+  assertPublishableCandidate(status);
+  assertClearSidecars(candidatePath);
+  const snapshot = readExactSnapshot(candidatePath);
+  const identityAfter = captureDatabaseIdentity(candidatePath);
+  if (!sameDatabaseIdentity(identityBefore, identityAfter)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_CANDIDATE_INVALID",
+      "The graph candidate changed while it was being validated.",
+      status.diagnostics,
+    );
+  }
+  return {
+    status,
+    identity: identityAfter,
+    snapshotRaw: snapshot.raw,
+    snapshotHash: snapshot.hash,
+  };
+}
+
+function assertCandidateUnchanged(candidatePath: string, candidate: ValidatedCandidate): void {
+  if (!existsSync(candidatePath)) {
+    throw new GraphMaintenanceError("GRAPH_MAINTENANCE_RACE", "The graph candidate disappeared before publication.");
+  }
+  assertClearSidecars(candidatePath);
+  const identity = captureDatabaseIdentity(candidatePath);
+  const snapshot = readExactSnapshot(candidatePath);
+  if (!sameDatabaseIdentity(identity, candidate.identity)
+    || snapshot.raw !== candidate.snapshotRaw
+    || snapshot.hash !== candidate.snapshotHash) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_RACE",
+      "The graph candidate changed after validation and was not published.",
+      candidate.status.diagnostics,
+    );
+  }
+}
+
+function readExactSnapshot(path: string): { raw: string; hash: string } {
+  assertClearSidecars(path);
+  const before = captureDatabaseIdentity(path);
+  const db = openSqlite(path, { readOnly: true, immutable: true });
+  let raw: string;
+  try {
+    const row = db.prepare(
+      "SELECT value FROM project_metadata WHERE key = ?",
+    ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
+    if (typeof row?.value !== "string") {
+      throw new GraphMaintenanceError(
+        "GRAPH_CANDIDATE_INVALID",
+        "The graph candidate is missing exact graph_snapshot_v1 provenance.",
+      );
+    }
+    raw = row.value;
+  } finally {
+    db.close();
+  }
+  const after = captureDatabaseIdentity(path);
+  if (!sameDatabaseIdentity(before, after)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_CANDIDATE_INVALID",
+      "The graph candidate changed while its snapshot token was being read.",
+    );
+  }
+  return { raw, hash: createHash("sha256").update(raw).digest("hex") };
+}
+
+function shouldCloneForContinuity(status: GraphStatus): boolean {
+  if (status.status === "fresh" || status.status === "stale" || status.status === "degraded") {
+    return status.schemaVersion === DB_SCHEMA_VERSION;
+  }
+  return status.status === "rebuild_required"
+    && status.schemaVersion !== null
+    && status.schemaVersion <= DB_SCHEMA_VERSION;
+}
+
+function isContinuityCloneCompatibilityFailure(error: unknown): boolean {
+  if (error instanceof GraphSourceStagingError || error instanceof GraphMaintenanceError) return false;
+  const code = errorCode(error).toUpperCase();
+  const name = error instanceof Error ? error.name : "";
+  const message = errorMessage(error);
+  return name === "GraphRebuildRequiredError"
+    || ["ERR_SQLITE_CORRUPT", "ERR_SQLITE_NOTADB", "ERR_SQLITE_SCHEMA",
+      "SQLITE_CORRUPT", "SQLITE_NOTADB", "SQLITE_SCHEMA"].includes(code)
+    || /(?:database disk image is malformed|file is not a database|malformed database schema|no such (?:table|column)|duplicate column name|unsupported graph schema)/iu.test(message);
+}
+
+function assertRefreshable(status: GraphStatus): void {
+  if (status.status === "missing") {
+    throw new GraphMaintenanceError(
+      "GRAPH_INDEX_MISSING",
+      "The graph index does not exist. Run `mex graph rebuild` first.",
+      status.diagnostics,
+    );
+  }
+  const blockedCodes = new Set([
+    "GRAPH_INDEX_CORRUPT",
+    "GRAPH_INDEX_SCHEMA_INVALID",
+    "GRAPH_INDEX_INVARIANT_FAILED",
+    "GRAPH_INDEX_REBUILD_REQUIRED",
+    "GRAPH_INDEX_SIDECAR_ACTIVE",
+    "GRAPH_INDEX_SIDECAR_UNAVAILABLE",
+    "GRAPH_INDEX_LOCKED",
+    "GRAPH_INDEX_UNAVAILABLE",
+    "GRAPH_INDEX_PATH_OUTSIDE_PROJECT",
+    "GRAPH_INDEX_PATH_UNAVAILABLE",
+    "GRAPH_SOURCE_INSPECTION_INCOMPLETE",
+    "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
+    "GRAPH_REPO_INSPECTION_INCOMPLETE",
+    "GRAPH_MANIFEST_INSPECTION_FAILED",
+    "GRAPH_STATUS_OBSERVATION_RACE",
+  ]);
+  if (status.schemaVersion !== DB_SCHEMA_VERSION
+    || status.status === "corrupt"
+    || status.status === "rebuild_required"
+    || status.diagnostics.some((diagnostic) => blockedCodes.has(diagnostic.code))) {
+    throw new GraphMaintenanceError(
+      "GRAPH_INDEX_NOT_REFRESHABLE",
+      "The current graph cannot be refreshed safely. Run `mex graph rebuild` after resolving its diagnostics.",
+      status.diagnostics,
+    );
+  }
+}
+
+function assertPublishableCandidate(status: GraphStatus): void {
+  if (status.status === "fresh") return;
+  const degradedOnlyByParse = status.status === "degraded"
+    && status.changes.total === 0
+    && !status.changes.branchChanged
+    && !status.changes.manifestChanged
+    && !status.changes.configChanged
+    && !status.changes.grammarChanged
+    && status.diagnostics.every((diagnostic) => (
+      diagnostic.severity !== "error"
+      && (diagnostic.code === "GRAPH_PARSE_DEGRADED" || diagnostic.code === "GRAPH_INDEX_HEAD_CHANGED")
+    ));
+  if (degradedOnlyByParse) return;
+  throw new GraphMaintenanceError(
+    "GRAPH_CANDIDATE_INVALID",
+    `The isolated graph candidate validated as ${status.status}; the live graph was not replaced.`,
+    status.diagnostics,
+  );
+}
+
+function assertClearSidecarsIfPresent(path: string): void {
+  if (existsSync(path)) assertClearSidecars(path);
+}
+
+function assertClearSidecars(path: string): void {
+  const probe = inspectGraphSidecars(path);
+  if (probe.state === "clear") return;
+  throw new GraphMaintenanceError(
+    "GRAPH_MAINTENANCE_LOCKED",
+    probe.state === "active"
+      ? `SQLite recovery activity is active (${probe.paths.join(", ")}); graph maintenance was not started.`
+      : `SQLite recovery state could not be verified (${probe.paths.join(", ")}); graph maintenance was not started.`,
+  );
+}
+
+function progress(
+  options: GraphMaintenanceOptions,
+  phase: GraphMaintenanceProgress["phase"],
+  message: string,
+): void {
+  assertNotAborted(options.signal);
+  options.onProgress?.({ phase, message });
+}
+
+function assertNotAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) return;
+  throw new GraphMaintenanceError(
+    "GRAPH_MAINTENANCE_CANCELLED",
+    "Graph maintenance was cancelled before publication completed.",
+  );
+}
+
+async function inspect(
+  options: InternalMaintenanceOptions,
+  projectRoot: string,
+  database: string,
+): Promise<GraphStatus> {
+  return (options.__internal?.inspectStatus ?? inspectGraphStatus)({ projectRoot, dbPath: database });
+}
+
+function currentDate(options: InternalMaintenanceOptions): Date {
+  const date = options.__internal?.now?.() ?? new Date();
+  if (Number.isNaN(date.getTime())) throw new TypeError("Graph maintenance requires a valid clock value.");
+  return date;
+}
+
+function createToken(options: InternalMaintenanceOptions): string {
+  const value = options.__internal?.token?.() ?? randomBytes(24).toString("hex");
+  if (!/^[a-f0-9]{32,128}$/u.test(value)) {
+    throw new TypeError("Graph maintenance tokens must be 32-128 lowercase hexadecimal characters.");
+  }
+  return value;
+}
+
+function ownedPath(paths: MaintenancePaths, kind: "candidate" | "rollback" | "recovery", token: string): string {
+  assertMaintenanceDirectoryUnchanged(paths);
+  const path = join(paths.mexDir, `graph.db.${kind}-${token}`);
+  assertOwnedDatabasePath(path);
+  return path;
+}
+
+function cleanupOwnedDatabase(paths: MaintenancePaths, path: string): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  if (dirname(path) !== paths.mexDir) return;
+  cleanupOwnedDatabasePath(paths, path);
+  cleanupDiscardedOwnedSidecars(paths, path);
+}
+
+function cleanupOwnedDatabasePath(paths: MaintenancePaths, path: string): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  assertOwnedDatabasePath(path);
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+}
+
+function cleanupCheckpointedOwnedSidecars(paths: MaintenancePaths, databasePath: string): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  if (dirname(databasePath) !== paths.mexDir) return;
+  assertOwnedDatabasePath(databasePath);
+  // Re-probe immediately before unlinking. A non-empty WAL/journal can contain
+  // authoritative candidate data and must never be silently discarded or
+  // separated from the main file selected for publication.
+  const probe = inspectGraphSidecars(databasePath);
+  if (probe.state !== "clear") {
+    throw new GraphMaintenanceError(
+      "GRAPH_CANDIDATE_INVALID",
+      "The validated graph candidate acquired SQLite recovery state before publication.",
+    );
+  }
+  for (const suffix of ["-wal", "-journal"] as const) {
+    const path = `${databasePath}${suffix}`;
+    try {
+      const stats = lstatSync(path);
+      if (!stats.isFile() || stats.isSymbolicLink() || stats.size !== 0) {
+        throw new GraphMaintenanceError(
+          "GRAPH_CANDIDATE_INVALID",
+          `The candidate sidecar ${basename(path)} was not a checkpointed empty regular file.`,
+        );
+      }
+      assertMaintenanceDirectoryUnchanged(paths);
+      unlinkSync(path);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+  }
+  // A shared-memory file contains no authoritative pages without a WAL. It is
+  // still removed only after the WAL/journal probe above proved the closed
+  // candidate checkpointed.
+  const shmPath = `${databasePath}-shm`;
+  try {
+    const stats = lstatSync(shmPath);
+    if (!stats.isFile() || stats.isSymbolicLink()) {
+      throw new GraphMaintenanceError(
+        "GRAPH_CANDIDATE_INVALID",
+        `The candidate sidecar ${basename(shmPath)} is not a regular file.`,
+      );
+    }
+    assertMaintenanceDirectoryUnchanged(paths);
+    unlinkSync(shmPath);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") throw error;
+  }
+}
+
+/** Cleanup only after the owned candidate main file has been discarded. */
+function cleanupDiscardedOwnedSidecars(paths: MaintenancePaths, databasePath: string): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  if (dirname(databasePath) !== paths.mexDir) return;
+  assertOwnedDatabasePath(databasePath);
+  for (const suffix of ["-wal", "-shm", "-journal"] as const) {
+    try {
+      assertMaintenanceDirectoryUnchanged(paths);
+      unlinkSync(`${databasePath}${suffix}`);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+  }
+}
+
+function assertOwnedDatabasePath(path: string): void {
+  if (!OWNED_DATABASE_PREFIXES.some((prefix) => basename(path).startsWith(prefix))) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "Refusing to modify a path not owned by graph maintenance.",
+    );
+  }
+}
+
+function assertRegularNonSymlink(path: string, label: string): void {
+  const stats = lstatSync(path);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      `The ${label} must be a contained, non-symlink regular file.`,
+    );
+  }
+}
+
+function assertMaintenanceDirectoryUnchanged(paths: MaintenancePaths): void {
+  let stats: Stats;
+  let real: string;
+  try {
+    stats = lstatSync(paths.mexDir);
+    real = realpathSync(paths.mexDir);
+  } catch {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "The bound .mex maintenance directory became unavailable.",
+    );
+  }
+  if (!stats.isDirectory()
+    || stats.isSymbolicLink()
+    || stats.dev !== paths.mexDirDev
+    || stats.ino !== paths.mexDirIno
+    || real !== paths.mexDirReal
+    || !isContained(paths.projectRootReal, real)) {
+    throw new GraphMaintenanceError(
+      "GRAPH_MAINTENANCE_PATH_UNSAFE",
+      "The bound .mex maintenance directory changed or escaped the project; no further filesystem mutation was attempted.",
+    );
+  }
+}
+
+function fsyncMaintenanceDirectory(paths: MaintenancePaths): void {
+  assertMaintenanceDirectoryUnchanged(paths);
+  fsyncDirectory(paths.mexDir);
+}
+
+function fsyncFile(path: string): void {
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(path, constants.O_RDONLY | noFollow);
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function fsyncDirectory(path: string): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(path, constants.O_RDONLY);
+    fsyncSync(fd);
+  } catch (error) {
+    // Directory fsync is unsupported on some Node/OS combinations. File fsync
+    // and atomic same-directory rename still provide the publication boundary.
+    if (!["EINVAL", "ENOTSUP", "EISDIR", "EPERM"].includes(errorCode(error))) throw error;
+  } finally {
+    if (fd !== null) closeSync(fd);
+  }
+}
+
+function safeLstat(path: string): Stats | null {
+  try {
+    return lstatSync(path);
+  } catch {
+    return null;
+  }
+}
+
+function sameStatIdentity(
+  left: StatIdentity,
+  right: StatIdentity,
+): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function sameDatabaseIdentity(left: DatabaseIdentity, right: DatabaseIdentity): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs
+    && left.digest === right.digest;
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith("../") && !path.startsWith("..\\"));
+}
+
+function toRepoRelative(root: string, path: string): string {
+  return relative(root, path).replaceAll("\\", "/");
+}
+
+function errorCode(error: unknown): string {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code?: unknown }).code ?? "")
+    : "";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/graph/read-session.ts
+++ b/src/graph/read-session.ts
@@ -1,0 +1,748 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import type { GraphStatus } from "../team/contracts/graph.js";
+import { openGraphDatabase } from "./db/database.js";
+import type { SqliteDatabase } from "./db/sqlite.js";
+import { createGraphEngineFromOpenDatabase } from "./engine-impl.js";
+import type { GraphEngine, IndexedFileInfo } from "./engine.js";
+import {
+  inspectGraphSidecars,
+  inspectGraphStatusWithFreshObservation,
+  resolveContainedGraphDatabasePath,
+  type GraphSidecarProbe,
+  type InternalGraphFreshObservationToken,
+  type InternalGraphStatusInspection,
+} from "./status.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  computeSourceCorpusDigest,
+  parseGraphSnapshot,
+  type GraphSnapshot,
+} from "./snapshot.js";
+
+export interface GraphReadValidation {
+  valid: boolean;
+  code?: string;
+  message?: string;
+}
+
+/** @internal One immutable SQLite snapshot shared by every graph facade in a read. */
+export interface InternalGraphReadSession {
+  graph: GraphEngine;
+  db: SqliteDatabase;
+  /** Read one indexed source file from a stable fd and prove its exact bytes match SQLite. */
+  readIndexedSource(filePath: string): string;
+  validate(): GraphReadValidation;
+  close(): void;
+}
+
+export interface GraphFreshnessRevalidation extends GraphReadValidation {
+  graphStatus: GraphStatus;
+}
+
+/** @internal A stable database session bound to one successful freshness observation. */
+export interface InternalFreshGraphReadSession extends InternalGraphReadSession {
+  graphStatus: GraphStatus;
+  revalidateFreshness(): Promise<GraphFreshnessRevalidation>;
+}
+
+export interface InternalFreshGraphReadResult {
+  graphStatus: GraphStatus;
+  session: InternalFreshGraphReadSession | null;
+}
+
+interface ImmutableGraphReadHooks {
+  afterDatabaseIdentityRead?: () => void | Promise<void>;
+  afterDatabaseOpen?: (database: SqliteDatabase) => void | Promise<void>;
+  afterDatabaseDescriptorClose?: () => void;
+  beforeIndexedSourceRead?: (filePath: string) => void;
+  afterIndexedSourceRead?: (filePath: string) => void;
+}
+
+export interface LoadFreshGraphReadSessionOptions {
+  dbPath?: string;
+  loadSession?: boolean;
+  inspectObservation?: typeof inspectGraphStatusWithFreshObservation;
+  inspectSidecars?: typeof inspectGraphSidecars;
+  afterStatusInspection?: (
+    inspection: InternalGraphStatusInspection,
+  ) => void | Promise<void>;
+  hooks?: ImmutableGraphReadHooks;
+}
+
+export interface OpenImmutableGraphReadSessionOptions extends ImmutableGraphReadHooks {
+  inspectSidecars?: typeof inspectGraphSidecars;
+  expectedObservation?: InternalGraphFreshObservationToken;
+  /** Fresh loaders verify the adopted snapshot before performing the final path probe. */
+  deferPostOpenValidation?: boolean;
+}
+
+export interface OpenImmutableGraphReadSessionSyncOptions {
+  inspectSidecars?: typeof inspectGraphSidecars;
+  afterDatabaseDescriptorClose?: () => void;
+}
+
+interface BoundDatabaseFile {
+  readonly databasePath: string;
+  readonly identity: string;
+  close(): void;
+}
+
+class GraphReadSessionError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+    this.name = "GraphReadSessionError";
+  }
+}
+
+/** Synchronous form used by the existing synchronous Scope command surface. */
+export function openImmutableGraphReadSessionSync(
+  projectRoot: string,
+  dbPath = resolve(projectRoot, ".mex", "graph.db"),
+  options: OpenImmutableGraphReadSessionSyncOptions = {},
+): InternalGraphReadSession {
+  const canonicalDbPath = resolveContainedGraphDatabasePath(projectRoot, dbPath);
+  if (!canonicalDbPath) {
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database path changed or escaped the project while immutable readers were opening.",
+    );
+  }
+  let boundFile: BoundDatabaseFile | null = null;
+  let databaseIdentityBefore: string;
+  try {
+    boundFile = bindDatabaseFile(canonicalDbPath, options.afterDatabaseDescriptorClose);
+    databaseIdentityBefore = boundFile.identity;
+  } catch {
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database became unavailable while immutable readers were opening.",
+    );
+  }
+  const inspectSidecars = options.inspectSidecars ?? inspectGraphSidecars;
+
+  let graph: GraphEngine | null = null;
+  let pendingDb: SqliteDatabase | null = null;
+  try {
+    const sidecarsBeforeOpen = inspectSidecars(canonicalDbPath);
+    if (sidecarsBeforeOpen.state !== "clear") {
+      throw new GraphReadSessionError(
+        "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+        sidecarMessage("before immutable readers opened", sidecarsBeforeOpen),
+      );
+    }
+    pendingDb = openGraphDatabase(boundFile.databasePath, { readOnly: true, immutable: true });
+    const sharedDb = pendingDb;
+    graph = createGraphEngineFromOpenDatabase({ rootDir: projectRoot, dbPath: canonicalDbPath }, sharedDb);
+    pendingDb = null;
+    const validation = validateReadPath(
+      projectRoot,
+      dbPath,
+      canonicalDbPath,
+      databaseIdentityBefore,
+      inspectSidecars,
+    );
+    if (!validation.valid) throw new GraphReadSessionError(validation.code!, validation.message!);
+
+    const ownedGraph = graph;
+    const ownedBoundFile = boundFile;
+    graph = null;
+    boundFile = null;
+    let open = true;
+    let sourceValidation: GraphReadValidation | null = null;
+    const readIndexedSource = createIndexedSourceReader(
+      projectRoot,
+      sharedDb,
+      {},
+      (code, message) => {
+        sourceValidation = { valid: false, code, message };
+      },
+    );
+    return {
+      graph: ownedGraph,
+      db: sharedDb,
+      readIndexedSource,
+      validate: () => open
+        ? sourceValidation
+          ?? validateReadPath(projectRoot, dbPath, canonicalDbPath, databaseIdentityBefore, inspectSidecars)
+        : {
+            valid: false,
+            code: "GRAPH_INDEX_READER_OPEN_FAILED",
+            message: "The immutable graph reader is already closed.",
+          },
+      close: () => {
+        if (!open) return;
+        open = false;
+        try {
+          ownedGraph.close();
+        } finally {
+          ownedBoundFile.close();
+        }
+      },
+    };
+  } catch (error) {
+    try {
+      graph?.close();
+      pendingDb?.close();
+    } finally {
+      boundFile?.close();
+    }
+    if (error instanceof GraphReadSessionError) throw error;
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_OPEN_FAILED",
+      "The graph changed or became unavailable while immutable readers were opening.",
+    );
+  }
+}
+
+/**
+ * Open one stable immutable database snapshot without asserting source freshness.
+ * Scope uses this so its deliberate stale-file text fallback stays available.
+ */
+export async function openImmutableGraphReadSession(
+  projectRoot: string,
+  dbPath = resolve(projectRoot, ".mex", "graph.db"),
+  options: OpenImmutableGraphReadSessionOptions = {},
+): Promise<InternalGraphReadSession> {
+  const expected = options.expectedObservation;
+  const canonicalDbPath = resolveContainedGraphDatabasePath(projectRoot, dbPath);
+  if (!canonicalDbPath || (expected && canonicalDbPath !== expected.canonicalDbPath)) {
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database path changed or escaped the project while immutable readers were opening.",
+    );
+  }
+
+  let boundFile: BoundDatabaseFile | null = null;
+  let databaseIdentityBefore: string;
+  try {
+    boundFile = bindDatabaseFile(canonicalDbPath, options.afterDatabaseDescriptorClose);
+    databaseIdentityBefore = boundFile.identity;
+  } catch {
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database became unavailable while immutable readers were opening.",
+    );
+  }
+  const inspectSidecars = options.inspectSidecars ?? inspectGraphSidecars;
+
+  let graph: GraphEngine | null = null;
+  let pendingDb: SqliteDatabase | null = null;
+  try {
+    if (expected && databaseIdentityBefore !== expected.databaseIdentity) {
+      throw new GraphReadSessionError(
+        "GRAPH_INDEX_READER_DATABASE_CHANGED",
+        "The graph database changed after freshness inspection.",
+      );
+    }
+    await options.afterDatabaseIdentityRead?.();
+    const sidecarsBeforeOpen = inspectSidecars(canonicalDbPath);
+    if (sidecarsBeforeOpen.state !== "clear") {
+      throw new GraphReadSessionError(
+        "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+        sidecarMessage("before immutable readers opened", sidecarsBeforeOpen),
+      );
+    }
+    pendingDb = openGraphDatabase(boundFile.databasePath, { readOnly: true, immutable: true });
+    await options.afterDatabaseOpen?.(pendingDb);
+    const sharedDb = pendingDb;
+    graph = createGraphEngineFromOpenDatabase({ rootDir: projectRoot, dbPath: canonicalDbPath }, sharedDb);
+    pendingDb = null;
+
+    if (!options.deferPostOpenValidation) {
+      const validation = validateReadPath(
+        projectRoot,
+        dbPath,
+        canonicalDbPath,
+        databaseIdentityBefore,
+        inspectSidecars,
+      );
+      if (!validation.valid) throw new GraphReadSessionError(validation.code!, validation.message!);
+    }
+
+    const ownedGraph = graph;
+    const ownedBoundFile = boundFile;
+    graph = null;
+    boundFile = null;
+    let open = true;
+    let sourceValidation: GraphReadValidation | null = null;
+    const readIndexedSource = createIndexedSourceReader(
+      projectRoot,
+      sharedDb,
+      options,
+      (code, message) => {
+        sourceValidation = { valid: false, code, message };
+      },
+    );
+    return {
+      graph: ownedGraph,
+      db: sharedDb,
+      readIndexedSource,
+      validate: () => open
+        ? sourceValidation
+          ?? validateReadPath(projectRoot, dbPath, canonicalDbPath, databaseIdentityBefore, inspectSidecars)
+        : {
+            valid: false,
+            code: "GRAPH_INDEX_READER_OPEN_FAILED",
+            message: "The immutable graph reader is already closed.",
+          },
+      close: () => {
+        if (!open) return;
+        open = false;
+        try {
+          ownedGraph.close();
+        } finally {
+          ownedBoundFile.close();
+        }
+      },
+    };
+  } catch (error) {
+    try {
+      graph?.close();
+      pendingDb?.close();
+    } finally {
+      boundFile?.close();
+    }
+    if (error instanceof GraphReadSessionError) throw error;
+    throw new GraphReadSessionError(
+      "GRAPH_INDEX_READER_OPEN_FAILED",
+      "The graph changed or became unavailable while immutable readers were opening.",
+    );
+  }
+}
+
+/**
+ * Inspect freshness, bind readers to that exact observation, and expose a final
+ * revalidation step for callers that buffer graph-derived output until commit.
+ */
+export async function loadFreshGraphReadSession(
+  projectRoot: string,
+  options: LoadFreshGraphReadSessionOptions = {},
+): Promise<InternalFreshGraphReadResult> {
+  const dbPath = options.dbPath ?? resolve(projectRoot, ".mex", "graph.db");
+  const inspectObservation = options.inspectObservation ?? inspectGraphStatusWithFreshObservation;
+  const inspection = await inspectObservation({ projectRoot, dbPath });
+  await options.afterStatusInspection?.(inspection);
+  const { graphStatus, freshObservation } = inspection;
+  if (graphStatus.status !== "fresh" || options.loadSession === false) {
+    return { graphStatus, session: null };
+  }
+  if (!freshObservation || sha256(freshObservation.snapshotRaw) !== freshObservation.snapshotHash) {
+    return unavailableFreshGraphReadResult(
+      graphStatus,
+      "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+      "The fresh graph observation could not be bound to an exact snapshot; graph reads were skipped.",
+    );
+  }
+
+  let base: InternalGraphReadSession | null = null;
+  try {
+    base = await openImmutableGraphReadSession(projectRoot, dbPath, {
+      expectedObservation: freshObservation,
+      inspectSidecars: options.inspectSidecars,
+      deferPostOpenValidation: true,
+      ...options.hooks,
+    });
+    const snapshotIdentity = readSessionSnapshotIdentity(base.db);
+    const snapshot = snapshotIdentity.snapshot;
+    const indexedFiles = base.graph.getIndexedFiles?.();
+    if (snapshotIdentity.snapshotRaw !== freshObservation.snapshotRaw
+      || snapshotIdentity.snapshotHash !== freshObservation.snapshotHash
+      || !snapshot
+      || !snapshotMatchesStatus(snapshot, graphStatus)
+      || !indexedFiles
+      || !snapshotMatchesIndexedFiles(snapshot, indexedFiles)) {
+      base.close();
+      return unavailableFreshGraphReadResult(
+        graphStatus,
+        "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+        "The graph snapshot changed while immutable readers were opening; graph reads were skipped.",
+      );
+    }
+    const openedValidation = base.validate();
+    if (!openedValidation.valid) {
+      base.close();
+      return unavailableFreshGraphReadResult(
+        graphStatus,
+        openedValidation.code ?? "GRAPH_INDEX_READER_OPEN_FAILED",
+        openedValidation.message
+          ?? "The graph changed or became unavailable while immutable readers were opening.",
+      );
+    }
+
+    const guardedStatus: GraphStatus = { ...graphStatus, diagnostics: [...graphStatus.diagnostics] };
+    const ownedBase = base;
+    base = null;
+    const session: InternalFreshGraphReadSession = {
+      ...ownedBase,
+      graphStatus: guardedStatus,
+      validate: () => ownedBase.validate(),
+      revalidateFreshness: async () => {
+        const before = session.validate();
+        const finalInspection = await inspectObservation({ projectRoot, dbPath });
+        if (finalInspection.graphStatus.status !== "fresh" || !finalInspection.freshObservation) {
+          return { valid: false, graphStatus: finalInspection.graphStatus };
+        }
+        if (!sameObservation(freshObservation, finalInspection.freshObservation)) {
+          const changed = unavailableStatus(
+            finalInspection.graphStatus,
+            "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+            "Graph freshness changed while graph-derived output was being prepared; the output was discarded.",
+          );
+          return {
+            valid: false,
+            code: "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+            message: changed.diagnostics.at(-1)?.message,
+            graphStatus: changed,
+          };
+        }
+        if (!before.valid) return { ...before, graphStatus: finalInspection.graphStatus };
+        const after = session.validate();
+        return after.valid
+          ? { valid: true, graphStatus: finalInspection.graphStatus }
+          : { ...after, graphStatus: guardedStatus };
+      },
+    };
+    return { graphStatus: guardedStatus, session };
+  } catch (error) {
+    base?.close();
+    const coded = graphReadError(error);
+    return unavailableFreshGraphReadResult(graphStatus, coded.code, coded.message);
+  }
+}
+
+function createIndexedSourceReader(
+  projectRoot: string,
+  db: SqliteDatabase,
+  hooks: Pick<ImmutableGraphReadHooks, "beforeIndexedSourceRead" | "afterIndexedSourceRead">,
+  invalidate: (code: string, message: string) => void,
+): (filePath: string) => string {
+  const cache = new Map<string, string>();
+  return (filePath: string): string => {
+    const cached = cache.get(filePath);
+    if (cached !== undefined) return cached;
+    try {
+      const indexed = db.prepare(
+        "SELECT content_hash FROM files WHERE path = ?",
+      ).get(filePath) as { content_hash?: unknown } | undefined;
+      if (typeof indexed?.content_hash !== "string" || !/^[0-9a-f]{64}$/.test(indexed.content_hash)) {
+        const code = "GRAPH_INDEX_READER_SOURCE_READ_FAILED";
+        const message = "An indexed source record could not be verified; graph-derived source output was discarded.";
+        invalidate(code, message);
+        throw new GraphReadSessionError(
+          code,
+          message,
+        );
+      }
+      hooks.beforeIndexedSourceRead?.(filePath);
+      const bytes = readStableContainedSource(projectRoot, filePath);
+      hooks.afterIndexedSourceRead?.(filePath);
+      // Indexing and status both hash the once-decoded UTF-8 source string.
+      // Keep that parity for invalid byte sequences while still binding the
+      // returned text to this one exact, fd-stable buffer.
+      const source = bytes.toString("utf8");
+      if (sha256(source) !== indexed.content_hash) {
+        invalidate(
+          "GRAPH_SOURCE_CORPUS_MISMATCH",
+          "Source bytes no longer match the graph snapshot; graph-derived source output was discarded.",
+        );
+      }
+      cache.set(filePath, source);
+      return source;
+    } catch (error) {
+      if (error instanceof GraphReadSessionError) throw error;
+      const code = "GRAPH_INDEX_READER_SOURCE_READ_FAILED";
+      const message = "An indexed source file could not be read from a stable contained path; graph-derived source output was discarded.";
+      invalidate(code, message);
+      throw new GraphReadSessionError(
+        code,
+        message,
+      );
+    }
+  };
+}
+
+/** Read one exact byte buffer through a contained, identity-stable file descriptor. */
+function readStableContainedSource(projectRoot: string, filePath: string): Buffer {
+  const lexicalRoot = resolve(projectRoot);
+  const canonicalRoot = realpathSync(lexicalRoot);
+  const absolutePath = resolve(lexicalRoot, filePath);
+  if (!isContainedPath(lexicalRoot, absolutePath)) {
+    throw new Error("Indexed source path escapes the project root.");
+  }
+  const canonicalPath = realpathSync(absolutePath);
+  if (!isContainedPath(canonicalRoot, canonicalPath)) {
+    throw new Error("Indexed source target escapes the project root.");
+  }
+  const before = lstatSync(canonicalPath);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error("Indexed source target is not a stable regular file.");
+  }
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(canonicalPath, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || !sameFileIdentity(before, opened)) {
+      throw new Error("Indexed source changed before it could be opened.");
+    }
+    const bytes = readFileSync(fd);
+    const after = fstatSync(fd);
+    const resolvedAfter = realpathSync(absolutePath);
+    const pathAfter = lstatSync(resolvedAfter);
+    if (!sameFileIdentity(opened, after)
+      || resolvedAfter !== canonicalPath
+      || !pathAfter.isFile()
+      || pathAfter.isSymbolicLink()
+      || !sameFileIdentity(opened, pathAfter)) {
+      throw new Error("Indexed source changed while it was being read.");
+    }
+    return bytes;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function isContainedPath(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function sameFileIdentity(
+  left: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number },
+  right: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number },
+): boolean {
+  return left.dev === right.dev
+    && left.ino === right.ino
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs;
+}
+
+function validateReadPath(
+  projectRoot: string,
+  requestedDbPath: string,
+  canonicalDbPath: string,
+  expectedIdentity: string,
+  inspectSidecars: typeof inspectGraphSidecars,
+): GraphReadValidation {
+  try {
+    if (resolveContainedGraphDatabasePath(projectRoot, requestedDbPath) !== canonicalDbPath) {
+      return {
+        valid: false,
+        code: "GRAPH_INDEX_READER_PATH_CHANGED",
+        message: "The graph database path changed while graph-derived output was being prepared.",
+      };
+    }
+    const sidecars = inspectSidecars(canonicalDbPath);
+    if (sidecars.state !== "clear") {
+      return {
+        valid: false,
+        code: "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+        message: sidecarMessage("while graph-derived output was being prepared", sidecars),
+      };
+    }
+    if (readDatabaseIdentity(canonicalDbPath) !== expectedIdentity) {
+      return {
+        valid: false,
+        code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+        message: "The graph database changed while graph-derived output was being prepared.",
+      };
+    }
+    return { valid: true };
+  } catch {
+    return {
+      valid: false,
+      code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+      message: "The graph database changed or became unavailable while graph-derived output was being prepared.",
+    };
+  }
+}
+
+function graphReadError(error: unknown): { code: string; message: string } {
+  if (error instanceof GraphReadSessionError) return error;
+  return {
+    code: "GRAPH_INDEX_READER_OPEN_FAILED",
+    message: "The graph changed or became unavailable while immutable readers were opening.",
+  };
+}
+
+function readDatabaseIdentity(dbPath: string): string {
+  const stats = statSync(dbPath);
+  return databaseFileIdentity(stats);
+}
+
+/**
+ * Bind SQLite to the exact inode that was inspected, not merely its pathname.
+ * On POSIX, opening `/dev/fd/<n>` (or `/proc/self/fd/<n>`) gives SQLite another
+ * handle to that same file even if `graph.db` is atomically replaced in the
+ * meantime. Windows does not expose descriptor paths, but its open handles
+ * prevent the rename-away/restore ABA that this binding closes on POSIX.
+ */
+function bindDatabaseFile(dbPath: string, afterClose?: () => void): BoundDatabaseFile {
+  const before = lstatSync(dbPath);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw new Error("Graph database is not a stable regular file.");
+  }
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(dbPath, constants.O_RDONLY | noFollow);
+  let open = true;
+  const close = (): void => {
+    if (!open) return;
+    open = false;
+    try {
+      closeSync(fd);
+    } finally {
+      try {
+        afterClose?.();
+      } catch {
+        // Test-only observation must never compromise descriptor cleanup.
+      }
+    }
+  };
+  try {
+    const opened = fstatSync(fd);
+    const resolvedAfter = realpathSync(dbPath);
+    const pathAfter = lstatSync(resolvedAfter);
+    if (!opened.isFile()
+      || resolvedAfter !== dbPath
+      || !pathAfter.isFile()
+      || pathAfter.isSymbolicLink()
+      || !sameFileIdentity(before, opened)
+      || !sameFileIdentity(opened, pathAfter)) {
+      throw new Error("Graph database changed before it could be bound.");
+    }
+    return {
+      databasePath: descriptorDatabasePath(fd, dbPath),
+      identity: databaseFileIdentity(opened),
+      close,
+    };
+  } catch (error) {
+    close();
+    throw error;
+  }
+}
+
+function descriptorDatabasePath(fd: number, fallbackPath: string): string {
+  if (process.platform === "win32") return fallbackPath;
+  for (const prefix of ["/dev/fd", "/proc/self/fd"]) {
+    const candidate = `${prefix}/${fd}`;
+    try {
+      statSync(candidate);
+      return candidate;
+    } catch {
+      // Try the next platform descriptor namespace.
+    }
+  }
+  throw new Error("This platform cannot bind SQLite to an inspected file descriptor.");
+}
+
+function databaseFileIdentity(
+  stats: { dev: number; ino: number; size: number; mtimeMs: number; ctimeMs: number },
+): string {
+  return JSON.stringify([stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs]);
+}
+
+function readSessionSnapshotIdentity(db: SqliteDatabase): {
+  snapshotRaw: string | null;
+  snapshotHash: string | null;
+  snapshot: GraphSnapshot | null;
+} {
+  const row = db.prepare(
+    "SELECT value FROM project_metadata WHERE key = ?",
+  ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
+  const snapshotRaw = typeof row?.value === "string" ? row.value : null;
+  return {
+    snapshotRaw,
+    snapshotHash: snapshotRaw === null ? null : sha256(snapshotRaw),
+    snapshot: parseGraphSnapshot(snapshotRaw),
+  };
+}
+
+function snapshotMatchesStatus(snapshot: GraphSnapshot, status: GraphStatus): boolean {
+  return snapshot.indexedAt === status.indexedAt
+    && snapshot.lastSuccessfulIndexAt === status.lastSuccessfulIndexAt
+    && snapshot.indexedBranch === status.indexedBranch
+    && snapshot.indexedHead === status.indexedHead
+    && snapshot.schemaVersion === status.schemaVersion
+    && snapshot.extractorVersion === status.extractorVersion
+    && snapshot.grammarHash === status.grammarVersion
+    && snapshot.parseHealth.total === status.parseHealth.total
+    && snapshot.parseHealth.ok === status.parseHealth.ok
+    && snapshot.parseHealth.partial === status.parseHealth.partial
+    && snapshot.parseHealth.failed === status.parseHealth.failed;
+}
+
+function snapshotMatchesIndexedFiles(
+  snapshot: GraphSnapshot,
+  files: readonly IndexedFileInfo[],
+): boolean {
+  if (snapshot.sourceCount !== files.length
+    || snapshot.sourceCorpusDigest !== computeSourceCorpusDigest(files)) return false;
+  let ok = 0;
+  let partial = 0;
+  let failed = 0;
+  for (const file of files) {
+    if (file.parseStatus === "ok") ok += 1;
+    else if (file.parseStatus === "partial") partial += 1;
+    else failed += 1;
+  }
+  return snapshot.parseHealth.total === files.length
+    && snapshot.parseHealth.ok === ok
+    && snapshot.parseHealth.partial === partial
+    && snapshot.parseHealth.failed === failed;
+}
+
+function sameObservation(
+  left: InternalGraphFreshObservationToken,
+  right: InternalGraphFreshObservationToken,
+): boolean {
+  return left.canonicalDbPath === right.canonicalDbPath
+    && left.databaseIdentity === right.databaseIdentity
+    && left.snapshotRaw === right.snapshotRaw
+    && left.snapshotHash === right.snapshotHash;
+}
+
+function unavailableFreshGraphReadResult(
+  status: GraphStatus,
+  code: string,
+  message: string,
+): InternalFreshGraphReadResult {
+  return { graphStatus: unavailableStatus(status, code, message), session: null };
+}
+
+function unavailableStatus(status: GraphStatus, code: string, message: string): GraphStatus {
+  return {
+    ...status,
+    status: "degraded",
+    diagnostics: [
+      ...status.diagnostics,
+      {
+        code,
+        severity: "warning",
+        message,
+        remediation: [{ label: "Retry after graph maintenance finishes" }],
+      },
+    ],
+  };
+}
+
+function sidecarMessage(when: string, probe: GraphSidecarProbe): string {
+  const paths = probe.paths.length > 0 ? ` (${probe.paths.join(", ")})` : "";
+  return probe.state === "active"
+    ? `SQLite recovery activity was detected ${when}${paths}; graph reads were skipped.`
+    : `SQLite recovery state could not be verified ${when}${paths}; graph reads were skipped.`;
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/src/graph/resolution/context.ts
+++ b/src/graph/resolution/context.ts
@@ -75,9 +75,8 @@ export function createStagedResolutionContext(
     getNodesByQualifiedName: (name) => byQualifiedName.get(name) ?? [],
     getNodesByKind: (kind) => byKind.get(kind) ?? [],
     getNodeById: (id) => byId.get(id) ?? null,
-    fileExists: (path) => stagedSources.has(path) || existsSync(resolve(projectRoot, path)),
-    readFile: (path) => stagedSources.get(path)
-      ?? (() => { try { return readFileSync(resolve(projectRoot, path), "utf-8"); } catch { return null; } })(),
+    fileExists: (path) => stagedSources.has(path),
+    readFile: (path) => stagedSources.get(path) ?? null,
     getProjectRoot: () => projectRoot,
     getAllFiles: () => [...new Set([...stagedSources.keys(), ...nodes.map((node) => node.filePath)])].sort(),
   };

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -1,12 +1,11 @@
-import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { globSync } from "glob";
 import type { MexConfig, Grounding } from "../types.js";
 import { extractGroundings, findMexAnchors, rewriteMexAnchor, writeGroundings } from "../markdown.js";
 import { createGroundingChecker, type GroundingChecker, type GroundedSource } from "./grounding.js";
-import { createGraphEngine, createGraphEngineFromOpenDatabase } from "./engine-impl.js";
-import type { GraphEngine, IndexedFileInfo } from "./engine.js";
+import { createGraphEngine } from "./engine-impl.js";
+import type { GraphEngine } from "./engine.js";
 import {
   GRAPH_CORPUS_GLOB_OPTIONS,
   GRAPH_CORPUS_IGNORE_GLOBS,
@@ -16,22 +15,20 @@ import { openGraphDatabase } from "./db/database.js";
 import type { SqliteDatabase } from "./db/sqlite.js";
 import { FingerprintStore } from "./fingerprint-store.js";
 import { deserializeFingerprint, serializeFingerprint } from "./fingerprint.js";
+import { acquireGraphMaintenanceLease } from "./maintenance.js";
 import { MinHashReconciler } from "./reconcile-engine.js";
 import type { Fingerprint, Reconciler } from "./reconcile.js";
 import {
   inspectGraphSidecars,
   inspectGraphStatus,
   inspectGraphStatusWithFreshObservation,
-  resolveContainedGraphDatabasePath,
   type InternalGraphStatusInspection,
-  type GraphSidecarProbe,
 } from "./status.js";
 import {
-  GRAPH_SNAPSHOT_METADATA_KEY,
-  computeSourceCorpusDigest,
-  parseGraphSnapshot,
-  type GraphSnapshot,
-} from "./snapshot.js";
+  loadFreshGraphReadSession,
+  openImmutableGraphReadSessionSync,
+  type InternalGraphReadSession,
+} from "./read-session.js";
 import type { GraphStatus } from "../team/contracts/graph.js";
 
 export interface GroundingRuntime {
@@ -95,145 +92,38 @@ export async function loadReadOnlyGroundingRuntime(
   const dbPath = resolve(config.projectRoot, ".mex", "graph.db");
   const internal = (options as LoadReadOnlyGroundingRuntimeInternalOptions).__internal;
   const statusOptions = { projectRoot: config.projectRoot, dbPath };
-  const inspection: InternalGraphStatusInspection = options.inspectStatus
-    ? {
-        graphStatus: await options.inspectStatus(statusOptions),
+  const inspectObservation = options.inspectStatus
+    ? async (): Promise<InternalGraphStatusInspection> => ({
+        graphStatus: await options.inspectStatus!(statusOptions),
         freshObservation: null,
-      }
-    : await (internal?.inspectObservation ?? inspectGraphStatusWithFreshObservation)(statusOptions);
-  await internal?.afterStatusInspection?.(inspection);
-  const { graphStatus, freshObservation } = inspection;
-  if (graphStatus.status !== "fresh" || options.loadRuntime === false) {
-    return { graphStatus, runtime: null };
-  }
-  if (!freshObservation
-    || createHash("sha256").update(freshObservation.snapshotRaw).digest("hex")
-      !== freshObservation.snapshotHash) {
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
-      "The fresh graph observation could not be bound to an exact snapshot; grounding was skipped.",
-    );
-  }
+      })
+    : internal?.inspectObservation ?? inspectGraphStatusWithFreshObservation;
+  const loaded = await loadFreshGraphReadSession(config.projectRoot, {
+    dbPath,
+    loadSession: options.loadRuntime,
+    inspectObservation,
+    inspectSidecars: options.inspectSidecars,
+    afterStatusInspection: internal?.afterStatusInspection,
+    hooks: {
+      afterDatabaseIdentityRead: internal?.afterDatabaseIdentityRead,
+      afterDatabaseOpen: internal?.afterDatabaseOpen,
+    },
+  });
+  if (!loaded.session) return { graphStatus: loaded.graphStatus, runtime: null };
 
-  const canonicalDbPath = resolveContainedGraphDatabasePath(config.projectRoot, dbPath);
-  if (!canonicalDbPath || canonicalDbPath !== freshObservation.canonicalDbPath) {
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_PATH_CHANGED",
-      "The graph database path changed or escaped the project after status inspection; grounding was skipped.",
-    );
-  }
-  let databaseIdentityBefore: string;
+  const session = loaded.session;
   try {
-    databaseIdentityBefore = readDatabaseIdentity(canonicalDbPath);
-  } catch {
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_PATH_CHANGED",
-      "The graph database became unavailable after status inspection; grounding was skipped.",
-    );
-  }
-  if (databaseIdentityBefore !== freshObservation.databaseIdentity) {
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_DATABASE_CHANGED",
-      "The graph database changed after status inspection; grounding was skipped.",
-    );
-  }
-  await internal?.afterDatabaseIdentityRead?.();
-  const inspectSidecars = options.inspectSidecars ?? inspectGraphSidecars;
-  const sidecarsBeforeOpen = inspectSidecars(canonicalDbPath);
-  if (sidecarsBeforeOpen.state !== "clear") {
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
-      sidecarMessage("before immutable readers opened", sidecarsBeforeOpen),
-    );
-  }
-
-  // Immutable readers never create or consume SQLite sidecars. Graph facts and
-  // fingerprints deliberately share one adopted connection, so atomic path
-  // replacement cannot split one grounding runtime across two database inodes.
-  let graph: GraphEngine | null = null;
-  let pendingDb: SqliteDatabase | null = null;
-  try {
-    pendingDb = openGraphDatabase(canonicalDbPath, { readOnly: true, immutable: true });
-    await internal?.afterDatabaseOpen?.(pendingDb);
-    const sharedDb = pendingDb;
-    graph = createGraphEngineFromOpenDatabase({
-      rootDir: config.projectRoot,
-      dbPath: canonicalDbPath,
-    }, sharedDb);
-    pendingDb = null;
-    const fingerprints = new FingerprintStore(sharedDb);
-    const snapshotIdentity = readRuntimeSnapshotIdentity(sharedDb);
-    const snapshot = snapshotIdentity.snapshot;
-    const indexedFiles = graph.getIndexedFiles?.();
-    if (snapshotIdentity.snapshotRaw !== freshObservation.snapshotRaw
-      || snapshotIdentity.snapshotHash !== freshObservation.snapshotHash
-      || !snapshot
-      || !snapshotMatchesStatus(snapshot, graphStatus)
-      || !indexedFiles
-      || !snapshotMatchesIndexedFiles(snapshot, indexedFiles)) {
-      graph.close();
-      graph = null;
-      return unavailableReadOnlyRuntime(
-        graphStatus,
-        "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
-        "The graph snapshot changed while immutable grounding readers were opening; grounding was skipped.",
-      );
-    }
+    const fingerprints = new FingerprintStore(session.db);
     const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
-    const resolvedAfterOpen = resolveContainedGraphDatabasePath(config.projectRoot, dbPath);
-    const sidecarsAfterOpen = inspectSidecars(canonicalDbPath);
-    let databaseIdentityAfter: string | null = null;
-    try {
-      databaseIdentityAfter = readDatabaseIdentity(canonicalDbPath);
-    } catch {
-      // The shared failure branch below closes both read facades.
-    }
-    const databaseChanged = databaseIdentityAfter !== freshObservation.databaseIdentity;
-    if (resolvedAfterOpen !== canonicalDbPath
-      || sidecarsAfterOpen.state !== "clear"
-      || databaseChanged) {
-      graph.close();
-      graph = null;
-      return unavailableReadOnlyRuntime(
-        graphStatus,
-        resolvedAfterOpen !== canonicalDbPath
-          ? "GRAPH_INDEX_READER_PATH_CHANGED"
-          : databaseChanged
-            ? "GRAPH_INDEX_READER_DATABASE_CHANGED"
-          : "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
-        resolvedAfterOpen !== canonicalDbPath
-          ? "The graph database path changed while immutable grounding readers were opening; grounding was skipped."
-          : databaseChanged
-            ? "The graph database changed while immutable grounding readers were opening; grounding was skipped."
-          : sidecarMessage("after immutable readers opened", sidecarsAfterOpen),
-      );
-    }
-    const guardedStatus: GraphStatus = {
-      ...graphStatus,
-      diagnostics: [...graphStatus.diagnostics],
-    };
     const guard: GroundingRuntimeGuard = {
-      validate: () => {
-        try {
-          return resolveContainedGraphDatabasePath(config.projectRoot, dbPath) === canonicalDbPath
-            && inspectSidecars(canonicalDbPath).state === "clear"
-            && readDatabaseIdentity(canonicalDbPath) === freshObservation.databaseIdentity;
-        } catch {
-          return false;
-        }
-      },
+      validate: () => session.validate().valid,
       invalidate: () => {
-        if (guardedStatus.diagnostics.some((entry) => entry.code === "GRAPH_INDEX_READER_DATABASE_CHANGED")) {
+        if (loaded.graphStatus.diagnostics.some((entry) => entry.code === "GRAPH_INDEX_READER_DATABASE_CHANGED")) {
           return;
         }
-        guardedStatus.status = "degraded";
-        guardedStatus.diagnostics = [
-          ...guardedStatus.diagnostics,
+        loaded.graphStatus.status = "degraded";
+        loaded.graphStatus.diagnostics = [
+          ...loaded.graphStatus.diagnostics,
           {
             code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
             severity: "warning",
@@ -244,105 +134,34 @@ export async function loadReadOnlyGroundingRuntime(
       },
     };
     return {
-      graphStatus: guardedStatus,
-      runtime: assembleGroundingRuntime(graph, null, fingerprints, anchorFingerprints, guard),
+      graphStatus: loaded.graphStatus,
+      runtime: assembleGroundingRuntime(
+        session.graph,
+        null,
+        fingerprints,
+        anchorFingerprints,
+        guard,
+      ),
     };
   } catch {
-    graph?.close();
-    pendingDb?.close();
-    return unavailableReadOnlyRuntime(
-      graphStatus,
-      "GRAPH_INDEX_READER_OPEN_FAILED",
-      "The graph changed or became unavailable while immutable grounding readers were opening; grounding was skipped.",
-    );
+    session.close();
+    return {
+      graphStatus: {
+        ...loaded.graphStatus,
+        status: "degraded",
+        diagnostics: [
+          ...loaded.graphStatus.diagnostics,
+          {
+            code: "GRAPH_INDEX_READER_OPEN_FAILED",
+            severity: "warning",
+            message: "The graph changed or became unavailable while immutable grounding readers were opening; grounding was skipped.",
+            remediation: [{ label: "Retry after graph maintenance finishes" }],
+          },
+        ],
+      },
+      runtime: null,
+    };
   }
-}
-
-function readDatabaseIdentity(dbPath: string): string {
-  const stats = statSync(dbPath);
-  return JSON.stringify([stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs]);
-}
-
-function readRuntimeSnapshotIdentity(db: SqliteDatabase): {
-  snapshotRaw: string | null;
-  snapshotHash: string | null;
-  snapshot: GraphSnapshot | null;
-} {
-  const row = db.prepare(
-    "SELECT value FROM project_metadata WHERE key = ?",
-  ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
-  const snapshotRaw = typeof row?.value === "string" ? row.value : null;
-  return {
-    snapshotRaw,
-    snapshotHash: snapshotRaw === null
-      ? null
-      : createHash("sha256").update(snapshotRaw).digest("hex"),
-    snapshot: parseGraphSnapshot(snapshotRaw),
-  };
-}
-
-function snapshotMatchesStatus(snapshot: GraphSnapshot, status: GraphStatus): boolean {
-  return snapshot.indexedAt === status.indexedAt
-    && snapshot.lastSuccessfulIndexAt === status.lastSuccessfulIndexAt
-    && snapshot.indexedBranch === status.indexedBranch
-    && snapshot.indexedHead === status.indexedHead
-    && snapshot.schemaVersion === status.schemaVersion
-    && snapshot.extractorVersion === status.extractorVersion
-    && snapshot.grammarHash === status.grammarVersion
-    && snapshot.parseHealth.total === status.parseHealth.total
-    && snapshot.parseHealth.ok === status.parseHealth.ok
-    && snapshot.parseHealth.partial === status.parseHealth.partial
-    && snapshot.parseHealth.failed === status.parseHealth.failed;
-}
-
-function snapshotMatchesIndexedFiles(
-  snapshot: GraphSnapshot,
-  files: readonly IndexedFileInfo[],
-): boolean {
-  if (snapshot.sourceCount !== files.length
-    || snapshot.sourceCorpusDigest !== computeSourceCorpusDigest(files)) return false;
-  let ok = 0;
-  let partial = 0;
-  let failed = 0;
-  for (const file of files) {
-    if (file.parseStatus === "ok") ok += 1;
-    else if (file.parseStatus === "partial") partial += 1;
-    else failed += 1;
-  }
-  return snapshot.parseHealth.total === files.length
-    && snapshot.parseHealth.ok === ok
-    && snapshot.parseHealth.partial === partial
-    && snapshot.parseHealth.failed === failed;
-}
-
-function unavailableReadOnlyRuntime(
-  status: GraphStatus,
-  code: string,
-  message: string,
-): ReadOnlyGroundingRuntimeResult {
-  return {
-    graphStatus: {
-      ...status,
-      status: "degraded",
-      diagnostics: [
-        ...status.diagnostics,
-        {
-          code,
-          severity: "warning",
-          message,
-          remediation: [{ label: "Retry after graph maintenance finishes" }],
-        },
-      ],
-    },
-    runtime: null,
-  };
-}
-
-function sidecarMessage(when: string, probe: GraphSidecarProbe): string {
-  const paths = probe.paths.length > 0 ? ` (${probe.paths.join(", ")})` : "";
-  return probe.state === "active"
-    ? `SQLite recovery activity was detected ${when}${paths}; grounding was skipped.`
-    : `SQLite recovery state could not be verified ${when}${paths}; grounding was skipped.`;
 }
 
 /**
@@ -350,22 +169,44 @@ function sidecarMessage(when: string, probe: GraphSidecarProbe): string {
  * workflows. Ordinary reads must use {@link loadReadOnlyGroundingRuntime}.
  */
 export async function loadGroundingRuntime(config: MexConfig): Promise<GroundingRuntime | null> {
-  const dbPath = resolve(config.projectRoot, ".mex", "graph.db");
-  if (!existsSync(dbPath)) return null;
-  const graph = createGraphEngine({ rootDir: config.projectRoot, dbPath });
+  const lease = acquireGraphMaintenanceLease(config.projectRoot, "refresh");
+  let priorSession: InternalGraphReadSession | null = null;
+  let graph: GraphEngine | null = null;
   let db: SqliteDatabase | null = null;
   try {
-    db = openGraphDatabase(dbPath);
+    // Preserve fingerprints for inline ids before refresh can replace them.
+    // The maintenance lease prevents a cooperating publisher from changing the
+    // old snapshot between this read and the isolated refresh publication.
+    priorSession = openImmutableGraphReadSessionSync(config.projectRoot, lease.databasePath);
+    const anchorFingerprints = snapshotAnchorFingerprints(config, new FingerprintStore(priorSession.db));
+    priorSession.close();
+    priorSession = null;
+
+    await lease.refresh();
+    graph = createGraphEngine({ rootDir: config.projectRoot, dbPath: lease.databasePath });
+    db = openGraphDatabase(lease.databasePath);
     const fingerprints = new FingerprintStore(db);
-    const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
-    // This is an explicitly mutating maintenance path. Rebuild from securely
-    // staged bytes so source/config/semantic-input drift cannot be hidden by
-    // restored mtimes, equal sizes, or an incomplete changed-file hint.
-    await graph.build();
-    return assembleGroundingRuntime(graph, db, fingerprints, anchorFingerprints);
+    const assembled = assembleGroundingRuntime(graph, db, fingerprints, anchorFingerprints);
+    graph = null;
+    db = null;
+    let closed = false;
+    return {
+      ...assembled,
+      close: () => {
+        if (closed) return;
+        closed = true;
+        try {
+          assembled.close();
+        } finally {
+          lease.release();
+        }
+      },
+    };
   } catch (error) {
-    graph.close();
-    db?.close();
+    try { priorSession?.close(); } catch { /* preserve the maintenance failure */ }
+    try { graph?.close(); } catch { /* preserve the maintenance failure */ }
+    try { db?.close(); } catch { /* preserve the maintenance failure */ }
+    lease.release();
     throw error;
   }
 }

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -1,20 +1,38 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { globSync } from "glob";
 import type { MexConfig, Grounding } from "../types.js";
 import { extractGroundings, findMexAnchors, rewriteMexAnchor, writeGroundings } from "../markdown.js";
 import { createGroundingChecker, type GroundingChecker, type GroundedSource } from "./grounding.js";
-import { createGraphEngine } from "./engine-impl.js";
-import type { GraphEngine } from "./engine.js";
-import { SUPPORTED_SOURCE_GLOB } from "./extraction/grammars.js";
+import { createGraphEngine, createGraphEngineFromOpenDatabase } from "./engine-impl.js";
+import type { GraphEngine, IndexedFileInfo } from "./engine.js";
+import {
+  GRAPH_CORPUS_GLOB_OPTIONS,
+  GRAPH_CORPUS_IGNORE_GLOBS,
+  GRAPH_SUPPORTED_SOURCE_GLOB,
+} from "./corpus-policy.js";
 import { openGraphDatabase } from "./db/database.js";
 import type { SqliteDatabase } from "./db/sqlite.js";
 import { FingerprintStore } from "./fingerprint-store.js";
 import { deserializeFingerprint, serializeFingerprint } from "./fingerprint.js";
 import { MinHashReconciler } from "./reconcile-engine.js";
 import type { Fingerprint, Reconciler } from "./reconcile.js";
-
-const SOURCE_IGNORE = ["**/node_modules/**", "**/.git/**", "**/dist/**", "**/build/**", "**/.mex/**", "**/coverage/**", "**/.next/**", "**/out/**"];
+import {
+  inspectGraphSidecars,
+  inspectGraphStatus,
+  inspectGraphStatusWithFreshObservation,
+  resolveContainedGraphDatabasePath,
+  type InternalGraphStatusInspection,
+  type GraphSidecarProbe,
+} from "./status.js";
+import {
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  computeSourceCorpusDigest,
+  parseGraphSnapshot,
+  type GraphSnapshot,
+} from "./snapshot.js";
+import type { GraphStatus } from "../team/contracts/graph.js";
 
 export interface GroundingRuntime {
   graph: GraphEngine;
@@ -37,6 +55,300 @@ export interface GroundingBaselineCaptureOptions {
   warn?: (message: string) => void;
 }
 
+export interface ReadOnlyGroundingRuntimeResult {
+  graphStatus: GraphStatus;
+  runtime: GroundingRuntime | null;
+}
+
+export interface LoadReadOnlyGroundingRuntimeOptions {
+  /** Internal seam for status/error-path tests. */
+  inspectStatus?: typeof inspectGraphStatus;
+  /** Internal seam for deterministic reader-handshake tests. */
+  inspectSidecars?: typeof inspectGraphSidecars;
+  /** Inspect status without opening graph readers when grounding is irrelevant. */
+  loadRuntime?: boolean;
+}
+
+interface ReadOnlyGroundingRuntimeInternalHooks {
+  inspectObservation?: typeof inspectGraphStatusWithFreshObservation;
+  afterStatusInspection?: (
+    inspection: InternalGraphStatusInspection,
+  ) => void | Promise<void>;
+  afterDatabaseIdentityRead?: () => void | Promise<void>;
+  afterDatabaseOpen?: (database: SqliteDatabase) => void | Promise<void>;
+}
+
+type LoadReadOnlyGroundingRuntimeInternalOptions = LoadReadOnlyGroundingRuntimeOptions & {
+  /** Module-private deterministic race seams; deliberately absent from declarations. */
+  __internal?: ReadOnlyGroundingRuntimeInternalHooks;
+};
+
+/**
+ * Load grounding readers without synchronizing or otherwise repairing the
+ * graph. A non-fresh snapshot is reported to the caller and never used for
+ * grounding, because doing so could incorrectly present stale facts as clean.
+ */
+export async function loadReadOnlyGroundingRuntime(
+  config: MexConfig,
+  options: LoadReadOnlyGroundingRuntimeOptions = {},
+): Promise<ReadOnlyGroundingRuntimeResult> {
+  const dbPath = resolve(config.projectRoot, ".mex", "graph.db");
+  const internal = (options as LoadReadOnlyGroundingRuntimeInternalOptions).__internal;
+  const statusOptions = { projectRoot: config.projectRoot, dbPath };
+  const inspection: InternalGraphStatusInspection = options.inspectStatus
+    ? {
+        graphStatus: await options.inspectStatus(statusOptions),
+        freshObservation: null,
+      }
+    : await (internal?.inspectObservation ?? inspectGraphStatusWithFreshObservation)(statusOptions);
+  await internal?.afterStatusInspection?.(inspection);
+  const { graphStatus, freshObservation } = inspection;
+  if (graphStatus.status !== "fresh" || options.loadRuntime === false) {
+    return { graphStatus, runtime: null };
+  }
+  if (!freshObservation
+    || createHash("sha256").update(freshObservation.snapshotRaw).digest("hex")
+      !== freshObservation.snapshotHash) {
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+      "The fresh graph observation could not be bound to an exact snapshot; grounding was skipped.",
+    );
+  }
+
+  const canonicalDbPath = resolveContainedGraphDatabasePath(config.projectRoot, dbPath);
+  if (!canonicalDbPath || canonicalDbPath !== freshObservation.canonicalDbPath) {
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database path changed or escaped the project after status inspection; grounding was skipped.",
+    );
+  }
+  let databaseIdentityBefore: string;
+  try {
+    databaseIdentityBefore = readDatabaseIdentity(canonicalDbPath);
+  } catch {
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_PATH_CHANGED",
+      "The graph database became unavailable after status inspection; grounding was skipped.",
+    );
+  }
+  if (databaseIdentityBefore !== freshObservation.databaseIdentity) {
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_DATABASE_CHANGED",
+      "The graph database changed after status inspection; grounding was skipped.",
+    );
+  }
+  await internal?.afterDatabaseIdentityRead?.();
+  const inspectSidecars = options.inspectSidecars ?? inspectGraphSidecars;
+  const sidecarsBeforeOpen = inspectSidecars(canonicalDbPath);
+  if (sidecarsBeforeOpen.state !== "clear") {
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+      sidecarMessage("before immutable readers opened", sidecarsBeforeOpen),
+    );
+  }
+
+  // Immutable readers never create or consume SQLite sidecars. Graph facts and
+  // fingerprints deliberately share one adopted connection, so atomic path
+  // replacement cannot split one grounding runtime across two database inodes.
+  let graph: GraphEngine | null = null;
+  let pendingDb: SqliteDatabase | null = null;
+  try {
+    pendingDb = openGraphDatabase(canonicalDbPath, { readOnly: true, immutable: true });
+    await internal?.afterDatabaseOpen?.(pendingDb);
+    const sharedDb = pendingDb;
+    graph = createGraphEngineFromOpenDatabase({
+      rootDir: config.projectRoot,
+      dbPath: canonicalDbPath,
+    }, sharedDb);
+    pendingDb = null;
+    const fingerprints = new FingerprintStore(sharedDb);
+    const snapshotIdentity = readRuntimeSnapshotIdentity(sharedDb);
+    const snapshot = snapshotIdentity.snapshot;
+    const indexedFiles = graph.getIndexedFiles?.();
+    if (snapshotIdentity.snapshotRaw !== freshObservation.snapshotRaw
+      || snapshotIdentity.snapshotHash !== freshObservation.snapshotHash
+      || !snapshot
+      || !snapshotMatchesStatus(snapshot, graphStatus)
+      || !indexedFiles
+      || !snapshotMatchesIndexedFiles(snapshot, indexedFiles)) {
+      graph.close();
+      graph = null;
+      return unavailableReadOnlyRuntime(
+        graphStatus,
+        "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+        "The graph snapshot changed while immutable grounding readers were opening; grounding was skipped.",
+      );
+    }
+    const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
+    const resolvedAfterOpen = resolveContainedGraphDatabasePath(config.projectRoot, dbPath);
+    const sidecarsAfterOpen = inspectSidecars(canonicalDbPath);
+    let databaseIdentityAfter: string | null = null;
+    try {
+      databaseIdentityAfter = readDatabaseIdentity(canonicalDbPath);
+    } catch {
+      // The shared failure branch below closes both read facades.
+    }
+    const databaseChanged = databaseIdentityAfter !== freshObservation.databaseIdentity;
+    if (resolvedAfterOpen !== canonicalDbPath
+      || sidecarsAfterOpen.state !== "clear"
+      || databaseChanged) {
+      graph.close();
+      graph = null;
+      return unavailableReadOnlyRuntime(
+        graphStatus,
+        resolvedAfterOpen !== canonicalDbPath
+          ? "GRAPH_INDEX_READER_PATH_CHANGED"
+          : databaseChanged
+            ? "GRAPH_INDEX_READER_DATABASE_CHANGED"
+          : "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+        resolvedAfterOpen !== canonicalDbPath
+          ? "The graph database path changed while immutable grounding readers were opening; grounding was skipped."
+          : databaseChanged
+            ? "The graph database changed while immutable grounding readers were opening; grounding was skipped."
+          : sidecarMessage("after immutable readers opened", sidecarsAfterOpen),
+      );
+    }
+    const guardedStatus: GraphStatus = {
+      ...graphStatus,
+      diagnostics: [...graphStatus.diagnostics],
+    };
+    const guard: GroundingRuntimeGuard = {
+      validate: () => {
+        try {
+          return resolveContainedGraphDatabasePath(config.projectRoot, dbPath) === canonicalDbPath
+            && inspectSidecars(canonicalDbPath).state === "clear"
+            && readDatabaseIdentity(canonicalDbPath) === freshObservation.databaseIdentity;
+        } catch {
+          return false;
+        }
+      },
+      invalidate: () => {
+        if (guardedStatus.diagnostics.some((entry) => entry.code === "GRAPH_INDEX_READER_DATABASE_CHANGED")) {
+          return;
+        }
+        guardedStatus.status = "degraded";
+        guardedStatus.diagnostics = [
+          ...guardedStatus.diagnostics,
+          {
+            code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+            severity: "warning",
+            message: "The graph changed while grounding checks were running; graph-derived results were discarded.",
+            remediation: [{ label: "Retry after graph maintenance finishes" }],
+          },
+        ];
+      },
+    };
+    return {
+      graphStatus: guardedStatus,
+      runtime: assembleGroundingRuntime(graph, null, fingerprints, anchorFingerprints, guard),
+    };
+  } catch {
+    graph?.close();
+    pendingDb?.close();
+    return unavailableReadOnlyRuntime(
+      graphStatus,
+      "GRAPH_INDEX_READER_OPEN_FAILED",
+      "The graph changed or became unavailable while immutable grounding readers were opening; grounding was skipped.",
+    );
+  }
+}
+
+function readDatabaseIdentity(dbPath: string): string {
+  const stats = statSync(dbPath);
+  return JSON.stringify([stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs]);
+}
+
+function readRuntimeSnapshotIdentity(db: SqliteDatabase): {
+  snapshotRaw: string | null;
+  snapshotHash: string | null;
+  snapshot: GraphSnapshot | null;
+} {
+  const row = db.prepare(
+    "SELECT value FROM project_metadata WHERE key = ?",
+  ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
+  const snapshotRaw = typeof row?.value === "string" ? row.value : null;
+  return {
+    snapshotRaw,
+    snapshotHash: snapshotRaw === null
+      ? null
+      : createHash("sha256").update(snapshotRaw).digest("hex"),
+    snapshot: parseGraphSnapshot(snapshotRaw),
+  };
+}
+
+function snapshotMatchesStatus(snapshot: GraphSnapshot, status: GraphStatus): boolean {
+  return snapshot.indexedAt === status.indexedAt
+    && snapshot.lastSuccessfulIndexAt === status.lastSuccessfulIndexAt
+    && snapshot.indexedBranch === status.indexedBranch
+    && snapshot.indexedHead === status.indexedHead
+    && snapshot.schemaVersion === status.schemaVersion
+    && snapshot.extractorVersion === status.extractorVersion
+    && snapshot.grammarHash === status.grammarVersion
+    && snapshot.parseHealth.total === status.parseHealth.total
+    && snapshot.parseHealth.ok === status.parseHealth.ok
+    && snapshot.parseHealth.partial === status.parseHealth.partial
+    && snapshot.parseHealth.failed === status.parseHealth.failed;
+}
+
+function snapshotMatchesIndexedFiles(
+  snapshot: GraphSnapshot,
+  files: readonly IndexedFileInfo[],
+): boolean {
+  if (snapshot.sourceCount !== files.length
+    || snapshot.sourceCorpusDigest !== computeSourceCorpusDigest(files)) return false;
+  let ok = 0;
+  let partial = 0;
+  let failed = 0;
+  for (const file of files) {
+    if (file.parseStatus === "ok") ok += 1;
+    else if (file.parseStatus === "partial") partial += 1;
+    else failed += 1;
+  }
+  return snapshot.parseHealth.total === files.length
+    && snapshot.parseHealth.ok === ok
+    && snapshot.parseHealth.partial === partial
+    && snapshot.parseHealth.failed === failed;
+}
+
+function unavailableReadOnlyRuntime(
+  status: GraphStatus,
+  code: string,
+  message: string,
+): ReadOnlyGroundingRuntimeResult {
+  return {
+    graphStatus: {
+      ...status,
+      status: "degraded",
+      diagnostics: [
+        ...status.diagnostics,
+        {
+          code,
+          severity: "warning",
+          message,
+          remediation: [{ label: "Retry after graph maintenance finishes" }],
+        },
+      ],
+    },
+    runtime: null,
+  };
+}
+
+function sidecarMessage(when: string, probe: GraphSidecarProbe): string {
+  const paths = probe.paths.length > 0 ? ` (${probe.paths.join(", ")})` : "";
+  return probe.state === "active"
+    ? `SQLite recovery activity was detected ${when}${paths}; grounding was skipped.`
+    : `SQLite recovery state could not be verified ${when}${paths}; grounding was skipped.`;
+}
+
+/**
+ * Load and synchronize grounding state for explicitly mutating setup/sync
+ * workflows. Ordinary reads must use {@link loadReadOnlyGroundingRuntime}.
+ */
 export async function loadGroundingRuntime(config: MexConfig): Promise<GroundingRuntime | null> {
   const dbPath = resolve(config.projectRoot, ".mex", "graph.db");
   if (!existsSync(dbPath)) return null;
@@ -46,24 +358,11 @@ export async function loadGroundingRuntime(config: MexConfig): Promise<Grounding
     db = openGraphDatabase(dbPath);
     const fingerprints = new FingerprintStore(db);
     const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
-    const changed = findChangedSourceFiles(config.projectRoot, db);
-    // sync also checks the persisted compiler/config/grammar manifest, so it
-    // must run even when source mtimes are unchanged.
-    await graph.sync(changed);
-    const reconciler = new MinHashReconciler(fingerprints);
-    const checkerReconciler: Reconciler & GroundingReconcilerCapabilities = {
-      reconcile: (nodeId, baseline) => reconciler.reconcile(nodeId, baseline),
-      getFingerprint: (nodeId) => anchorFingerprints.get(nodeId) ?? reconciler.getFingerprint(nodeId),
-      getGroundedSource: (file, nodeId) => reconciler.getGroundedSource(file, nodeId),
-    };
-    return {
-      graph,
-      reconciler,
-      checker: createGroundingChecker(graph, checkerReconciler),
-      fingerprints,
-      anchorFingerprints,
-      close: () => { graph.close(); db?.close(); db = null; },
-    };
+    // This is an explicitly mutating maintenance path. Rebuild from securely
+    // staged bytes so source/config/semantic-input drift cannot be hidden by
+    // restored mtimes, equal sizes, or an incomplete changed-file hint.
+    await graph.build();
+    return assembleGroundingRuntime(graph, db, fingerprints, anchorFingerprints);
   } catch (error) {
     graph.close();
     db?.close();
@@ -102,7 +401,11 @@ export function findChangedSourceFiles(projectRoot: string, db: SqliteDatabase):
     path: string; size: number; modified_at: number;
   }>;
   const tracked = new Map(rows.map((row) => [row.path, row]));
-  const current = globSync(SUPPORTED_SOURCE_GLOB, { cwd: projectRoot, ignore: SOURCE_IGNORE, nodir: true })
+  const current = globSync(GRAPH_SUPPORTED_SOURCE_GLOB, {
+    ...GRAPH_CORPUS_GLOB_OPTIONS,
+    cwd: projectRoot,
+    ignore: [...GRAPH_CORPUS_IGNORE_GLOBS],
+  })
     .map((path) => path.replaceAll("\\", "/"));
   const changed: string[] = [];
   for (const path of current) {
@@ -184,6 +487,59 @@ export function persistMovedGroundings(
 interface GroundingReconcilerCapabilities {
   getGroundedSource(scaffoldFile: string, nodeId: string): GroundedSource | null;
   getFingerprint(nodeId: string): Fingerprint | null;
+}
+
+interface GroundingRuntimeGuard {
+  validate(): boolean;
+  invalidate(): void;
+}
+
+function assembleGroundingRuntime(
+  graph: GraphEngine,
+  database: SqliteDatabase | null,
+  fingerprints: FingerprintStore,
+  anchorFingerprints: ReadonlyMap<string, Fingerprint>,
+  guard?: GroundingRuntimeGuard,
+): GroundingRuntime {
+  const reconciler = new MinHashReconciler(fingerprints);
+  const checkerReconciler: Reconciler & GroundingReconcilerCapabilities = {
+    reconcile: (nodeId, baseline) => reconciler.reconcile(nodeId, baseline),
+    getFingerprint: (nodeId) => anchorFingerprints.get(nodeId) ?? reconciler.getFingerprint(nodeId),
+    getGroundedSource: (file, nodeId) => reconciler.getGroundedSource(file, nodeId),
+  };
+  const rawChecker = createGroundingChecker(graph, checkerReconciler);
+  const checker: GroundingChecker = guard
+    ? (...args) => {
+        if (!guard.validate()) {
+          guard.invalidate();
+          return [];
+        }
+        let issues;
+        try {
+          issues = rawChecker(...args);
+        } catch (error) {
+          if (!guard.validate()) {
+            guard.invalidate();
+            return [];
+          }
+          throw error;
+        }
+        if (!guard.validate()) {
+          guard.invalidate();
+          return [];
+        }
+        return issues;
+      }
+    : rawChecker;
+  let db: SqliteDatabase | null = database;
+  return {
+    graph,
+    reconciler,
+    checker,
+    fingerprints,
+    anchorFingerprints,
+    close: () => { graph.close(); db?.close(); db = null; },
+  };
 }
 
 function snapshotAnchorFingerprints(config: MexConfig, store: FingerprintStore): Map<string, Fingerprint> {

--- a/src/graph/snapshot.ts
+++ b/src/graph/snapshot.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+
+export const GRAPH_SNAPSHOT_METADATA_KEY = "graph_snapshot_v1" as const;
+export const GRAPH_SNAPSHOT_VERSION = 1 as const;
+export const GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS = 1_024 as const;
+export const GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUT_PATH_LENGTH = 4_096 as const;
+
+export type GraphSnapshotParseStatus = "ok" | "partial" | "failed";
+
+export interface GraphSnapshotParseHealth {
+  total: number;
+  ok: number;
+  partial: number;
+  failed: number;
+}
+
+/** Canonical provenance for the last graph snapshot that completed publication. */
+export interface GraphSnapshot {
+  version: typeof GRAPH_SNAPSHOT_VERSION;
+  indexedAt: string;
+  lastSuccessfulIndexAt: string;
+  indexedBranch: string | null;
+  indexedHead: string | null;
+  schemaVersion: number;
+  compilerVersion: string;
+  extractorVersion: string;
+  resolverVersion: string;
+  grammarHash: string;
+  configHash: string;
+  manifestHash: string;
+  sourceCorpusDigest: string;
+  sourceCount: number;
+  semanticInputs: GraphSnapshotSemanticInput[];
+  parseHealth: GraphSnapshotParseHealth;
+}
+
+export interface GraphSnapshotSemanticInput {
+  path: string;
+  /** Exact UTF-8 hash, or null when the compiler observed that the path was absent. */
+  contentHash: string | null;
+}
+
+export interface GraphSnapshotSource {
+  path: string;
+  contentHash: string;
+  parseStatus: GraphSnapshotParseStatus;
+}
+
+export interface GraphGitProvenance {
+  branch: string | null;
+  head: string | null;
+}
+
+export interface CreateGraphSnapshotInput {
+  indexedAt: string;
+  git: GraphGitProvenance;
+  schemaVersion: number;
+  compilerVersion: string;
+  extractorVersion: string;
+  resolverVersion: string;
+  grammarHash: string;
+  configHash: string;
+  manifestHash: string;
+  sources: readonly GraphSnapshotSource[];
+  semanticInputs?: readonly GraphSnapshotSemanticInput[];
+}
+
+/** Hash only stable corpus identity: sorted repository path and exact content hash. */
+export function computeSourceCorpusDigest(
+  sources: readonly Pick<GraphSnapshotSource, "path" | "contentHash">[],
+): string {
+  const canonical = sources
+    .map(({ path, contentHash }) => [path, contentHash] as const)
+    .sort(([leftPath, leftHash], [rightPath, rightHash]) => (
+      compareText(leftPath, rightPath) || compareText(leftHash, rightHash)
+    ));
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+export function createGraphSnapshot(input: CreateGraphSnapshotInput): GraphSnapshot {
+  const parseHealth = countParseHealth(input.sources);
+  const sourcePaths = new Set(input.sources.map((source) => source.path));
+  const semanticInputs = canonicalSemanticInputs(input.semanticInputs ?? []);
+  if (semanticInputs.some((entry) => sourcePaths.has(entry.path))) {
+    throw new Error("Graph semantic inputs must not duplicate supported source paths.");
+  }
+  return {
+    version: GRAPH_SNAPSHOT_VERSION,
+    indexedAt: input.indexedAt,
+    lastSuccessfulIndexAt: input.indexedAt,
+    indexedBranch: input.git.branch,
+    indexedHead: input.git.head,
+    schemaVersion: input.schemaVersion,
+    compilerVersion: input.compilerVersion,
+    extractorVersion: input.extractorVersion,
+    resolverVersion: input.resolverVersion,
+    grammarHash: input.grammarHash,
+    configHash: input.configHash,
+    manifestHash: input.manifestHash,
+    sourceCorpusDigest: computeSourceCorpusDigest(input.sources),
+    sourceCount: input.sources.length,
+    semanticInputs,
+    parseHealth,
+  };
+}
+
+/** Serialize in one fixed field order so the metadata value is canonical. */
+export function serializeGraphSnapshot(snapshot: GraphSnapshot): string {
+  return JSON.stringify({
+    version: GRAPH_SNAPSHOT_VERSION,
+    indexedAt: snapshot.indexedAt,
+    lastSuccessfulIndexAt: snapshot.lastSuccessfulIndexAt,
+    indexedBranch: snapshot.indexedBranch,
+    indexedHead: snapshot.indexedHead,
+    schemaVersion: snapshot.schemaVersion,
+    compilerVersion: snapshot.compilerVersion,
+    extractorVersion: snapshot.extractorVersion,
+    resolverVersion: snapshot.resolverVersion,
+    grammarHash: snapshot.grammarHash,
+    configHash: snapshot.configHash,
+    manifestHash: snapshot.manifestHash,
+    sourceCorpusDigest: snapshot.sourceCorpusDigest,
+    sourceCount: snapshot.sourceCount,
+    semanticInputs: canonicalSemanticInputs(snapshot.semanticInputs),
+    parseHealth: {
+      total: snapshot.parseHealth.total,
+      ok: snapshot.parseHealth.ok,
+      partial: snapshot.parseHealth.partial,
+      failed: snapshot.parseHealth.failed,
+    },
+  });
+}
+
+/** Parse persisted metadata defensively; malformed or unsupported snapshots are absent. */
+export function parseGraphSnapshot(value: string | null | undefined): GraphSnapshot | null {
+  if (value == null) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed) || parsed.version !== GRAPH_SNAPSHOT_VERSION) return null;
+  if (!isIsoTimestamp(parsed.indexedAt) || !isIsoTimestamp(parsed.lastSuccessfulIndexAt)) return null;
+  if (!isNullableString(parsed.indexedBranch) || !isNullableString(parsed.indexedHead)) return null;
+  if (!isNonNegativeInteger(parsed.schemaVersion)) return null;
+  if (!isNonEmptyString(parsed.compilerVersion)
+    || !isNonEmptyString(parsed.extractorVersion)
+    || !isNonEmptyString(parsed.resolverVersion)) return null;
+  if (!isDigest(parsed.grammarHash)
+    || !isDigest(parsed.configHash)
+    || !isDigest(parsed.manifestHash)
+    || !isDigest(parsed.sourceCorpusDigest)) return null;
+  if (!isNonNegativeInteger(parsed.sourceCount)
+    || !Array.isArray(parsed.semanticInputs)
+    || !isRecord(parsed.parseHealth)) return null;
+  const semanticInputs = parseSemanticInputs(parsed.semanticInputs);
+  if (!semanticInputs) return null;
+  const { total, ok, partial, failed } = parsed.parseHealth;
+  if (!isNonNegativeInteger(total)
+    || !isNonNegativeInteger(ok)
+    || !isNonNegativeInteger(partial)
+    || !isNonNegativeInteger(failed)) return null;
+  if (total !== parsed.sourceCount || ok + partial + failed !== total) return null;
+
+  return {
+    version: GRAPH_SNAPSHOT_VERSION,
+    indexedAt: parsed.indexedAt,
+    lastSuccessfulIndexAt: parsed.lastSuccessfulIndexAt,
+    indexedBranch: parsed.indexedBranch,
+    indexedHead: parsed.indexedHead,
+    schemaVersion: parsed.schemaVersion,
+    compilerVersion: parsed.compilerVersion,
+    extractorVersion: parsed.extractorVersion,
+    resolverVersion: parsed.resolverVersion,
+    grammarHash: parsed.grammarHash,
+    configHash: parsed.configHash,
+    manifestHash: parsed.manifestHash,
+    sourceCorpusDigest: parsed.sourceCorpusDigest,
+    sourceCount: parsed.sourceCount,
+    semanticInputs,
+    parseHealth: { total, ok, partial, failed },
+  };
+}
+
+/**
+ * Read branch and HEAD without taking Git's optional index-refresh lock.
+ * A non-repository, unborn HEAD, detached HEAD, missing Git executable, or read
+ * failure is represented by the corresponding null provenance rather than
+ * making a graph build fail.
+ */
+export function readGraphGitProvenance(rootDir: string): GraphGitProvenance {
+  const result = spawnSync(
+    "git",
+    ["--no-optional-locks", "-C", rootDir, "status", "--porcelain=v2", "--branch", "--untracked-files=no"],
+    {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5_000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (result.status !== 0 || typeof result.stdout !== "string") {
+    return { branch: null, head: null };
+  }
+
+  let branch: string | null = null;
+  let head: string | null = null;
+  for (const line of result.stdout.split(/\r?\n/u)) {
+    if (line.startsWith("# branch.head ")) {
+      const value = line.slice("# branch.head ".length).trim();
+      branch = value && value !== "(detached)" ? value : null;
+    } else if (line.startsWith("# branch.oid ")) {
+      const value = line.slice("# branch.oid ".length).trim();
+      head = /^[a-f0-9]{40,64}$/u.test(value) ? value : null;
+    }
+  }
+  return { branch, head };
+}
+
+function countParseHealth(sources: readonly GraphSnapshotSource[]): GraphSnapshotParseHealth {
+  let ok = 0;
+  let partial = 0;
+  let failed = 0;
+  for (const source of sources) {
+    if (source.parseStatus === "ok") ok += 1;
+    else if (source.parseStatus === "partial") partial += 1;
+    else failed += 1;
+  }
+  return { total: sources.length, ok, partial, failed };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Locale-independent UTF-16 code-unit ordering, matching stable JS string identity. */
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isDigest(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/u.test(value);
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function canonicalSemanticInputs(
+  inputs: readonly GraphSnapshotSemanticInput[],
+): GraphSnapshotSemanticInput[] {
+  if (inputs.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS) {
+    throw new Error(`Graph semantic input provenance exceeds the ${GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS}-path safety cap.`);
+  }
+  const sorted = inputs
+    .map(({ path, contentHash }) => ({ path, contentHash }))
+    .sort((left, right) => compareText(left.path, right.path));
+  for (let index = 0; index < sorted.length; index += 1) {
+    const entry = sorted[index]!;
+    if (!isSafeRelativePath(entry.path) || !isNullableDigest(entry.contentHash)) {
+      throw new Error("Graph semantic input provenance contains an invalid path or digest.");
+    }
+    if (index > 0 && sorted[index - 1]!.path === entry.path) {
+      throw new Error(`Graph semantic input provenance contains duplicate path ${entry.path}.`);
+    }
+  }
+  return sorted;
+}
+
+function parseSemanticInputs(value: readonly unknown[]): GraphSnapshotSemanticInput[] | null {
+  if (value.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUTS) return null;
+  const inputs: GraphSnapshotSemanticInput[] = [];
+  let previousPath: string | undefined;
+  for (const entry of value) {
+    if (!isRecord(entry) || !isSafeRelativePath(entry.path) || !isNullableDigest(entry.contentHash)) return null;
+    if (previousPath !== undefined && compareText(previousPath, entry.path) >= 0) return null;
+    inputs.push({ path: entry.path, contentHash: entry.contentHash });
+    previousPath = entry.path;
+  }
+  return inputs;
+}
+
+function isSafeRelativePath(value: unknown): value is string {
+  if (typeof value !== "string"
+    || value.length === 0
+    || value.length > GRAPH_SNAPSHOT_MAX_SEMANTIC_INPUT_PATH_LENGTH
+    || value.includes("\\")
+    || value.includes("\0")) return false;
+  if (value.startsWith("/") || /^[A-Za-z]:\//u.test(value)) return false;
+  const parts = value.split("/");
+  return parts.every((part) => part.length > 0 && part !== "." && part !== "..");
+}
+
+function isNullableDigest(value: unknown): value is string | null {
+  return value === null || isDigest(value);
+}

--- a/src/graph/status.ts
+++ b/src/graph/status.ts
@@ -405,7 +405,7 @@ async function inspectGraphStatusAttempt(
         message: "The local code-graph index does not exist.",
         remediation: [{
           label: "Build graph",
-          ...(buildPrerequisitesComplete ? { command: "mex graph" } : {}),
+          ...(buildPrerequisitesComplete ? { command: "mex graph rebuild" } : {}),
         }],
       });
       return {
@@ -471,9 +471,21 @@ async function inspectGraphStatusAttempt(
 
   let db: SqliteDatabase | null = null;
   const finishDatabaseResult = (status: GraphStatus): InspectionAttempt => {
+    const recoverableStatus = status.status === "corrupt"
+      && !status.diagnostics.some((diagnostic) => (
+        diagnostic.remediation?.some((action) => isGraphMaintenanceCommand(action.command))
+      ))
+      ? {
+          ...status,
+          diagnostics: [
+            ...status.diagnostics,
+            rebuildDiagnostic("The contained graph index must be replaced by an isolated rebuild."),
+          ],
+        }
+      : status;
     const safeStatus = buildPrerequisitesComplete
-      ? status
-      : suppressExecutableGraphRemediations(status);
+      ? recoverableStatus
+      : suppressExecutableGraphRemediations(recoverableStatus);
     context.options.internal?.beforeDatabaseResult?.(safeStatus.status, attempt);
     return stabilizeDatabaseResult(
       projectRoot,
@@ -528,7 +540,6 @@ async function inspectGraphStatusAttempt(
     if (schemaVersion !== DB_SCHEMA_VERSION) {
       diagnostics.push(rebuildDiagnostic(
         `This mex build expects graph schema ${DB_SCHEMA_VERSION}; the index uses ${schemaVersion}.`,
-        schemaVersion < DB_SCHEMA_VERSION,
       ));
       return finishDatabaseResult(graphStatus({
           status: "rebuild_required",
@@ -620,7 +631,7 @@ async function inspectGraphStatusAttempt(
         code: "GRAPH_SNAPSHOT_LEGACY",
         severity: "warning",
         message: "The current-schema graph predates graph_snapshot_v1 and must be republished before freshness can be trusted.",
-        remediation: [{ label: "Republish graph snapshot", command: "mex graph" }],
+        remediation: [{ label: "Republish graph snapshot", command: "mex graph refresh" }],
       });
     } else if (snapshot.schemaVersion !== schemaVersion) {
       diagnostics.push({
@@ -715,7 +726,7 @@ async function inspectGraphStatusAttempt(
         code: "GRAPH_SOURCE_CORPUS_MISMATCH",
         severity: "warning",
         message: "The current supported-source corpus does not match the successful graph snapshot.",
-        remediation: [{ label: "Refresh graph", command: "mex graph" }],
+        remediation: [{ label: "Refresh graph", command: "mex graph refresh" }],
       });
     }
     if (semantic.changedPaths.length > 0) {
@@ -724,7 +735,7 @@ async function inspectGraphStatusAttempt(
         severity: "warning",
         message: "Compiler configuration inputs no longer match the successful graph snapshot.",
         ...(semantic.complete
-          ? { remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }] }
+          ? { remediation: [{ label: "Republish graph with current inputs", command: "mex graph refresh" }] }
           : {}),
       });
     }
@@ -740,7 +751,7 @@ async function inspectGraphStatusAttempt(
         code: "GRAPH_INDEX_BRANCH_CHANGED",
         severity: "warning",
         message: `The current branch (${currentRepo.branch ?? "detached"}) differs from the indexed branch (${snapshot?.indexedBranch ?? "unknown"}).`,
-        remediation: [{ label: "Republish graph for this branch", command: "mex graph" }],
+        remediation: [{ label: "Republish graph for this branch", command: "mex graph refresh" }],
       });
     }
     if (sourceChanges.changes.manifestChanged) {
@@ -754,7 +765,7 @@ async function inspectGraphStatusAttempt(
         message: changedInputs.length > 0
           ? `Graph build inputs changed (${changedInputs.join(", ")}).`
           : "The graph build manifest or discovery policy changed.",
-        remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }],
+        remediation: [{ label: "Republish graph with current inputs", command: "mex graph refresh" }],
       });
     }
     if (!live.complete) {
@@ -901,13 +912,13 @@ function suppressExecutableGraphRemediations(status: GraphStatus): GraphStatus {
   return {
     ...status,
     diagnostics: status.diagnostics.map((diagnostic) => {
-      if (!diagnostic.remediation?.some((action) => action.command === "mex graph")) {
+      if (!diagnostic.remediation?.some((action) => isGraphMaintenanceCommand(action.command))) {
         return diagnostic;
       }
       return {
         ...diagnostic,
         remediation: diagnostic.remediation.map((action) => {
-          if (action.command !== "mex graph") return action;
+          if (!isGraphMaintenanceCommand(action.command)) return action;
           const { command: _unsafeCommand, ...safeAction } = action;
           return safeAction;
         }),
@@ -2170,8 +2181,14 @@ function rebuildDiagnostic(message: string, executable = true): Diagnostic {
     code: "GRAPH_INDEX_REBUILD_REQUIRED",
     severity: "warning",
     message,
-    remediation: executable ? [{ label: "Rebuild graph", command: "mex graph" }] : undefined,
+    remediation: executable ? [{ label: "Rebuild graph", command: "mex graph rebuild" }] : undefined,
   };
+}
+
+function isGraphMaintenanceCommand(command: string | undefined): boolean {
+  return command === "mex graph"
+    || command === "mex graph refresh"
+    || command === "mex graph rebuild";
 }
 
 function resolveNow(now: InspectGraphStatusOptions["now"]): Date {

--- a/src/graph/status.ts
+++ b/src/graph/status.ts
@@ -1,0 +1,2217 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  accessSync,
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
+import { promisify } from "node:util";
+import { globSync } from "glob";
+import type {
+  GraphParseHealth,
+  GraphSourceChanges,
+  GraphStatus,
+  GraphStatusKind,
+} from "../team/contracts/graph.js";
+import type { Diagnostic, RepoState } from "../team/contracts/shared.js";
+import { DB_SCHEMA_VERSION } from "./db/database.js";
+import { openSqlite, type SqliteDatabase } from "./db/sqlite.js";
+import { BANDS, K } from "./config.js";
+import {
+  GRAPH_CORPUS_GLOB_OPTIONS,
+  GRAPH_CORPUS_IGNORE_GLOBS,
+  GRAPH_SUPPORTED_SOURCE_GLOB,
+} from "./corpus-policy.js";
+import { graphManifest } from "./engine-impl.js";
+import { isSupportedSourceFile } from "./extraction/grammars.js";
+import { bandHashes } from "./fingerprint.js";
+import type { Fingerprint } from "./reconcile.js";
+import {
+  computeSourceCorpusDigest,
+  GRAPH_SNAPSHOT_METADATA_KEY,
+  parseGraphSnapshot,
+  type GraphSnapshot,
+  type GraphSnapshotSemanticInput,
+} from "./snapshot.js";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_MAX_CHANGED_PATHS = 100;
+const MAX_FRESH_OBSERVATION_ATTEMPTS = 2;
+const REQUIRED_SCHEMA_OBJECTS = {
+  table: [
+    "_mex_grounded_source",
+    "edges",
+    "files",
+    "import_bindings",
+    "lsh_buckets",
+    "node_aliases",
+    "node_fingerprints",
+    "nodes",
+    "nodes_fts",
+    "nodes_fts_config",
+    "nodes_fts_data",
+    "nodes_fts_docsize",
+    "nodes_fts_idx",
+    "project_metadata",
+    "schema_versions",
+    "source_chunks",
+    "source_chunks_fts",
+    "source_chunks_fts_config",
+    "source_chunks_fts_data",
+    "source_chunks_fts_docsize",
+    "source_chunks_fts_idx",
+    "unresolved_refs",
+  ],
+  trigger: ["nodes_ad", "nodes_ai", "nodes_au"],
+  index: [
+    "idx_aliases_canonical",
+    "idx_edges_confidence",
+    "idx_edges_kind",
+    "idx_edges_provenance",
+    "idx_edges_semantic_callsite",
+    "idx_edges_source_kind",
+    "idx_edges_target_kind",
+    "idx_files_language",
+    "idx_files_modified_at",
+    "idx_grounded_node",
+    "idx_import_bindings_file",
+    "idx_import_bindings_local",
+    "idx_lsh",
+    "idx_nodes_container_id",
+    "idx_nodes_file_line",
+    "idx_nodes_file_path",
+    "idx_nodes_identity_key",
+    "idx_nodes_kind",
+    "idx_nodes_language",
+    "idx_nodes_lower_name",
+    "idx_nodes_name",
+    "idx_nodes_qualified_name",
+    "idx_source_chunks_file",
+    "idx_unresolved_file_path",
+    "idx_unresolved_from_name",
+    "idx_unresolved_from_node",
+    "idx_unresolved_name",
+    "idx_unresolved_status",
+  ],
+} as const;
+
+const REQUIRED_TABLE_COLUMNS: Readonly<Record<string, readonly string[]>> = {
+  schema_versions: ["version", "applied_at", "description"],
+  nodes: [
+    "id", "kind", "name", "qualified_name", "container_id", "identity_key",
+    "file_path", "language", "start_line", "end_line", "start_column", "end_column",
+    "docstring", "signature", "visibility", "is_exported", "is_async", "is_static",
+    "is_abstract", "decorators", "type_parameters", "return_type", "body_hash", "updated_at",
+  ],
+  edges: [
+    "id", "source", "target", "kind", "metadata", "line", "col", "provenance",
+    "confidence", "resolution_method", "evidence",
+  ],
+  files: [
+    "path", "content_hash", "language", "size", "modified_at", "indexed_at", "node_count",
+    "errors", "parse_status", "diagnostic_count", "missing_count", "error_coverage", "extractor_version",
+  ],
+  unresolved_refs: [
+    "id", "ref_key", "from_node_id", "reference_name", "reference_kind", "line", "col",
+    "candidates", "file_path", "language", "receiver", "qualifier", "import_source",
+    "metadata", "status", "target_id", "confidence", "resolver",
+  ],
+  import_bindings: [
+    "binding_key", "file_path", "local_name", "imported_name", "module_specifier",
+    "resolved_file_path", "target_id", "is_type_only", "metadata",
+  ],
+  node_aliases: ["alias_id", "canonical_node_id", "match_method", "confidence", "created_at"],
+  source_chunks: [
+    "id", "file_path", "start_line", "end_line", "content_hash", "path_terms",
+    "identifier_terms", "comment_terms",
+  ],
+  source_chunks_fts: ["path_terms", "identifier_terms", "comment_terms", "source_text"],
+  nodes_fts: ["id", "name", "qualified_name", "docstring", "signature"],
+  nodes_fts_config: ["k", "v"],
+  nodes_fts_data: ["id", "block"],
+  nodes_fts_docsize: ["id", "sz"],
+  nodes_fts_idx: ["segid", "term", "pgno"],
+  project_metadata: ["key", "value", "updated_at"],
+  node_fingerprints: ["node_id", "minhash", "neighbors", "token_count"],
+  lsh_buckets: ["band", "band_hash", "node_id"],
+  _mex_grounded_source: ["scaffold_file", "node_id", "source", "body_hash", "fingerprint"],
+  source_chunks_fts_config: ["k", "v"],
+  source_chunks_fts_data: ["id", "block"],
+  source_chunks_fts_docsize: ["id", "sz"],
+  source_chunks_fts_idx: ["segid", "term", "pgno"],
+};
+
+export type GraphSidecarState = "clear" | "active" | "unavailable";
+
+export interface GraphSidecarProbe {
+  state: GraphSidecarState;
+  /** Diagnostic-safe basenames; never absolute or caller-controlled paths. */
+  paths: readonly string[];
+}
+
+/** Resolve a graph database to one canonical, repository-contained read path. */
+export function resolveContainedGraphDatabasePath(
+  projectRoot: string,
+  dbPath: string,
+): string | null {
+  const root = resolve(projectRoot);
+  const requested = isAbsolute(dbPath) ? resolve(dbPath) : resolve(root, dbPath);
+  return resolveContainedDatabasePath(root, requested).database?.canonicalPath ?? null;
+}
+
+/** Probe SQLite recovery sidecars without opening or mutating the database. */
+export function inspectGraphSidecars(dbPath: string): GraphSidecarProbe {
+  const active: string[] = [];
+  const unavailable: string[] = [];
+  for (const sidecarPath of [`${dbPath}-journal`, `${dbPath}-wal`]) {
+    const safePath = diagnosticBasename(sidecarPath);
+    try {
+      const stats = lstatSync(sidecarPath);
+      if (!stats.isFile() || stats.isSymbolicLink()) {
+        unavailable.push(safePath);
+        continue;
+      }
+      try {
+        accessSync(sidecarPath, constants.R_OK);
+      } catch {
+        unavailable.push(safePath);
+        continue;
+      }
+      if (stats.size > 0) active.push(safePath);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") unavailable.push(safePath);
+    }
+  }
+  if (unavailable.length > 0) {
+    return { state: "unavailable", paths: [...unavailable, ...active].sort(compareCodePoints) };
+  }
+  if (active.length > 0) return { state: "active", paths: active.sort(compareCodePoints) };
+  return { state: "clear", paths: [] };
+}
+
+export interface InspectGraphStatusOptions {
+  projectRoot: string;
+  dbPath?: string;
+  /** Fixed clock for deterministic callers and tests. */
+  now?: Date | (() => Date);
+  /** One shared cap across added, modified, deleted, and failed path lists. */
+  maxChangedPaths?: number;
+  /** @internal Deterministic observation-race seam for conformance tests. */
+  internal?: {
+    beforeFreshValidation?: (attempt: number) => void | Promise<void>;
+    afterSourceRead?: (path: string, pass: "initial" | "validation") => void;
+    afterSemanticInputRead?: (path: string, pass: "initial" | "validation") => void;
+    beforeDatabaseResult?: (status: GraphStatusKind, attempt: number) => void;
+  };
+}
+
+/** @internal Exact identity from one stable, fresh status inspection. */
+export interface InternalGraphFreshObservationToken {
+  readonly canonicalDbPath: string;
+  readonly databaseIdentity: string;
+  readonly snapshotRaw: string;
+  readonly snapshotHash: string;
+}
+
+/** @internal Result consumed only by the read-only grounding handshake. */
+export interface InternalGraphStatusInspection {
+  readonly graphStatus: GraphStatus;
+  readonly freshObservation: InternalGraphFreshObservationToken | null;
+}
+
+interface FileRow {
+  path: string;
+  content_hash: string;
+  parse_status: "ok" | "partial" | "failed";
+  indexed_at: number;
+}
+
+interface MetadataValue {
+  value: string;
+  updatedAt: number;
+}
+
+interface LiveSources {
+  hashes: Map<string, string>;
+  discoveredPaths: Set<string>;
+  complete: boolean;
+  diagnostics: Diagnostic[];
+}
+
+interface LiveSemanticInputs {
+  hashes: Map<string, string | null>;
+  changedPaths: string[];
+  unavailablePaths: string[];
+  complete: boolean;
+  diagnostics: Diagnostic[];
+}
+
+interface RepoObservation {
+  state: RepoState;
+  complete: boolean;
+  diagnostics: Diagnostic[];
+}
+
+interface ContainedDatabasePath {
+  requestedPath: string;
+  canonicalPath: string;
+  projectRootRealPath: string;
+}
+
+type ContainedDatabaseResult =
+  | { database: ContainedDatabasePath; diagnostic?: never }
+  | { database?: never; diagnostic: Diagnostic };
+
+interface InspectionContext {
+  options: InspectGraphStatusOptions;
+  projectRoot: string;
+  requestedDbPath: string;
+  observedAt: string;
+  maxChangedPaths: number;
+}
+
+interface FreshObservation {
+  repo: RepoObservation;
+  live: LiveSources;
+  semantic: LiveSemanticInputs;
+  semanticInputs: readonly GraphSnapshotSemanticInput[];
+  manifest: ReturnType<typeof graphManifest>;
+  snapshotRaw: string;
+  database: ContainedDatabasePath;
+  databaseIdentity: string;
+}
+
+interface FreshValidation {
+  stable: boolean;
+  status: Extract<GraphStatusKind, "stale" | "degraded">;
+  retryable: boolean;
+  diagnostics: Diagnostic[];
+  freshObservation?: InternalGraphFreshObservationToken;
+}
+
+interface InspectionAttempt {
+  status: GraphStatus;
+  retry: boolean;
+  freshObservation?: InternalGraphFreshObservationToken;
+}
+
+interface ClassifiedError {
+  status: Extract<GraphStatusKind, "degraded" | "corrupt">;
+  diagnostic: Diagnostic;
+}
+
+class CorruptGraphIndexError extends Error {
+  override readonly name = "CorruptGraphIndexError";
+}
+
+/**
+ * Inspect graph freshness without creating, migrating, checkpointing, refreshing,
+ * or rebuilding the graph. SQLite is opened with `immutable=1`: this deliberately
+ * ignores an active WAL, which is reported as a transient degraded state instead
+ * of risking creation or mutation of SQLite sidecars.
+ */
+export async function inspectGraphStatus(
+  options: InspectGraphStatusOptions,
+): Promise<GraphStatus> {
+  return (await inspectGraphStatusWithFreshObservation(options)).graphStatus;
+}
+
+/**
+ * @internal Inspect status and, only for the exact stable fresh attempt, return
+ * the immutable database/snapshot identity needed to adopt read-only readers.
+ */
+export async function inspectGraphStatusWithFreshObservation(
+  options: InspectGraphStatusOptions,
+): Promise<InternalGraphStatusInspection> {
+  const projectRoot = resolve(options.projectRoot);
+  const requestedDbPath = options.dbPath
+    ? (isAbsolute(options.dbPath) ? resolve(options.dbPath) : resolve(projectRoot, options.dbPath))
+    : resolve(projectRoot, ".mex", "graph.db");
+  const context: InspectionContext = {
+    options,
+    projectRoot,
+    requestedDbPath,
+    observedAt: resolveNow(options.now).toISOString(),
+    maxChangedPaths: normalizeLimit(options.maxChangedPaths),
+  };
+  let lastAttempt: InspectionAttempt | null = null;
+  for (let attempt = 0; attempt < MAX_FRESH_OBSERVATION_ATTEMPTS; attempt++) {
+    const inspected = await inspectGraphStatusAttempt(context, attempt);
+    lastAttempt = inspected;
+    if (!inspected.retry) {
+      return {
+        graphStatus: inspected.status,
+        freshObservation: inspected.freshObservation ?? null,
+      };
+    }
+  }
+  return {
+    graphStatus: lastAttempt!.status,
+    freshObservation: null,
+  };
+}
+
+async function inspectGraphStatusAttempt(
+  context: InspectionContext,
+  attempt: number,
+): Promise<InspectionAttempt> {
+  const { projectRoot, requestedDbPath, observedAt, maxChangedPaths } = context;
+  const contained = resolveContainedDatabasePath(projectRoot, requestedDbPath);
+  if (!contained.database) {
+    const currentRepo = emptyRepoState(observedAt);
+    return {
+      retry: false,
+      status: graphStatus({
+        status: "degraded",
+        observedAt,
+        currentRepo,
+        parseHealth: emptyParseHealth(),
+        changes: emptySourceChanges(),
+        diagnostics: [contained.diagnostic],
+      }),
+    };
+  }
+  const database = contained.database;
+  const diagnostics: Diagnostic[] = [];
+  const repo = await inspectRepoState(projectRoot, observedAt);
+  const currentRepo = repo.state;
+  diagnostics.push(...repo.diagnostics);
+  const live = inspectLiveSources(
+    projectRoot,
+    database.projectRootRealPath,
+    maxChangedPaths,
+    (path) => context.options.internal?.afterSourceRead?.(path, "initial"),
+  );
+  diagnostics.push(...live.diagnostics);
+  const manifest = inspectCurrentManifest(projectRoot, diagnostics);
+  let buildPrerequisitesComplete = repo.complete && live.complete && manifest !== null;
+
+  let fileStat: ReturnType<typeof statSync>;
+  try {
+    fileStat = statSync(database.canonicalPath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      const changes = changesWithoutIndex(live, currentRepo, maxChangedPaths, true);
+      diagnostics.push({
+        code: "GRAPH_INDEX_MISSING",
+        severity: "warning",
+        message: "The local code-graph index does not exist.",
+        remediation: [{
+          label: "Build graph",
+          ...(buildPrerequisitesComplete ? { command: "mex graph" } : {}),
+        }],
+      });
+      return {
+        retry: false,
+        status: graphStatus({
+          status: "missing",
+          observedAt,
+          currentRepo,
+          parseHealth: emptyParseHealth(),
+          changes,
+          diagnostics,
+        }),
+      };
+    }
+    const classified = classifyDatabaseError(error, "inspect");
+    diagnostics.push(classified.diagnostic);
+    return {
+      retry: false,
+      status: graphStatus({
+        status: classified.status,
+        observedAt,
+        currentRepo,
+        parseHealth: emptyParseHealth(),
+        changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+        diagnostics,
+      }),
+    };
+  }
+  if (!fileStat.isFile()) {
+    diagnostics.push({
+      code: "GRAPH_INDEX_INVALID_FILE",
+      severity: "error",
+      message: "The graph index path is not a regular file.",
+    });
+    return {
+      retry: false,
+      status: graphStatus({
+        status: "corrupt",
+        observedAt,
+        currentRepo,
+        parseHealth: emptyParseHealth(),
+        changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+        diagnostics,
+      }),
+    };
+  }
+
+  const initialSidecars = inspectGraphSidecars(database.canonicalPath);
+  if (initialSidecars.state !== "clear") {
+    diagnostics.push(sidecarDiagnostic(initialSidecars));
+    return {
+      retry: false,
+      status: graphStatus({
+        status: "degraded",
+        observedAt,
+        currentRepo,
+        parseHealth: emptyParseHealth(),
+        changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+        diagnostics,
+      }),
+    };
+  }
+
+  let db: SqliteDatabase | null = null;
+  const finishDatabaseResult = (status: GraphStatus): InspectionAttempt => {
+    const safeStatus = buildPrerequisitesComplete
+      ? status
+      : suppressExecutableGraphRemediations(status);
+    context.options.internal?.beforeDatabaseResult?.(safeStatus.status, attempt);
+    return stabilizeDatabaseResult(
+      projectRoot,
+      requestedDbPath,
+      database.canonicalPath,
+      databaseFileIdentity(fileStat),
+      attempt,
+      safeStatus,
+    );
+  };
+  try {
+    db = openSqlite(database.canonicalPath, { readOnly: true, immutable: true });
+    if (!tableExists(db, "schema_versions")) {
+      const existingObjects = db.prepare(
+        "SELECT name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY name",
+      ).all() as Array<{ name?: unknown }>;
+      const partialSchema = existingObjects.some((row) => typeof row.name === "string");
+      diagnostics.push(partialSchema
+        ? {
+            code: "GRAPH_INDEX_SCHEMA_INVALID",
+            severity: "error",
+            message: "The versionless graph database already contains incompatible schema objects; automatic in-place repair is unsafe.",
+          }
+        : rebuildDiagnostic("The empty graph database has no schema version."));
+      return finishDatabaseResult(graphStatus({
+          status: partialSchema ? "corrupt" : "rebuild_required",
+          observedAt,
+          currentRepo,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+
+    const schemaVersion = readSchemaVersion(db);
+    if (schemaVersion === null) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_SCHEMA_INVALID",
+        severity: "error",
+        message: "The graph schema version table is empty or contains an invalid version; automatic in-place repair is unsafe.",
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+    if (schemaVersion !== DB_SCHEMA_VERSION) {
+      diagnostics.push(rebuildDiagnostic(
+        `This mex build expects graph schema ${DB_SCHEMA_VERSION}; the index uses ${schemaVersion}.`,
+        schemaVersion < DB_SCHEMA_VERSION,
+      ));
+      return finishDatabaseResult(graphStatus({
+          status: "rebuild_required",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+
+    const schemaFailures = inspectRequiredSchema(db);
+    if (schemaFailures.length > 0) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_SCHEMA_INVALID",
+        severity: "error",
+        message: `The current graph schema is missing required structure: ${schemaFailures.join("; ")}.`,
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+
+    const integrity = quickCheck(db);
+    if (integrity.length > 0) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_CORRUPT",
+        severity: "error",
+        message: `SQLite quick-check failed: ${integrity.join("; ")}`,
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+
+    const coreInvariantFailures = inspectCoreInvariants(db);
+    if (coreInvariantFailures.length > 0) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_INVARIANT_FAILED",
+        severity: "error",
+        message: `The graph violates persisted invariants: ${coreInvariantFailures.join("; ")}.`,
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+
+    const metadata = readMetadata(db);
+    const snapshotRaw = metadata.get(GRAPH_SNAPSHOT_METADATA_KEY)?.value;
+    const snapshotResult = readSnapshot(snapshotRaw);
+    if (snapshotResult.error) {
+      diagnostics.push({
+        code: "GRAPH_SNAPSHOT_INVALID",
+        severity: "error",
+        message: snapshotResult.error,
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+    const snapshot = snapshotResult.snapshot;
+    if (!snapshot) {
+      diagnostics.push({
+        code: "GRAPH_SNAPSHOT_LEGACY",
+        severity: "warning",
+        message: "The current-schema graph predates graph_snapshot_v1 and must be republished before freshness can be trusted.",
+        remediation: [{ label: "Republish graph snapshot", command: "mex graph" }],
+      });
+    } else if (snapshot.schemaVersion !== schemaVersion) {
+      diagnostics.push({
+        code: "GRAPH_SNAPSHOT_SCHEMA_MISMATCH",
+        severity: "error",
+        message: `Graph snapshot metadata records schema ${snapshot.schemaVersion}, but SQLite records ${schemaVersion}.`,
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth: emptyParseHealth(),
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+        diagnostics,
+      }));
+    }
+
+    const semantic = snapshot
+      ? inspectSemanticInputs(
+          projectRoot,
+          database.projectRootRealPath,
+          snapshot.semanticInputs,
+          maxChangedPaths,
+          (path) => context.options.internal?.afterSemanticInputRead?.(path, "initial"),
+        )
+      : emptySemanticInputs();
+    diagnostics.push(...semantic.diagnostics);
+    buildPrerequisitesComplete = buildPrerequisitesComplete && semantic.complete;
+
+    const files = readFiles(db);
+    const parseHealth = summarizeParseHealth(files, maxChangedPaths);
+    if (parseHealth.partial > 0 || parseHealth.failed > 0) {
+      const failedPaths = parseHealth.failedPaths.length > 0
+        ? ` Failed: ${parseHealth.failedPaths.join(", ")}${parseHealth.failedPathsTruncated ? ", …" : ""}.`
+        : "";
+      diagnostics.push({
+        code: "GRAPH_PARSE_DEGRADED",
+        severity: "warning",
+        message: `The published graph contains ${parseHealth.partial} partially parsed and ${parseHealth.failed} failed source file(s).${failedPaths}`,
+      });
+    }
+    if (snapshot && !snapshotMatchesStoredRows(snapshot, files, parseHealth)) {
+      diagnostics.push({
+        code: "GRAPH_SNAPSHOT_CONTENT_MISMATCH",
+        severity: "error",
+        message: "Graph snapshot source or parse-health totals disagree with the published SQLite rows.",
+      });
+      return finishDatabaseResult(graphStatus({
+          status: "corrupt",
+          observedAt,
+          currentRepo,
+          schemaVersion,
+          parseHealth,
+          changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+          diagnostics,
+        }));
+    }
+    if (snapshot && repo.complete && snapshot.indexedHead !== currentRepo.head) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_HEAD_CHANGED",
+        severity: "info",
+        message: "Repository HEAD differs from the commit recorded by the last successful graph snapshot.",
+      });
+    }
+    const comparedSources = compareSources(
+      files,
+      live,
+      snapshot,
+      currentRepo,
+      manifest,
+      metadata,
+      maxChangedPaths,
+    );
+    const semanticInputsChanged = !semantic.complete || semantic.changedPaths.length > 0;
+    const sourceChanges = semanticInputsChanged
+      ? {
+          ...comparedSources,
+          changes: { ...comparedSources.changes, configChanged: true },
+        }
+      : comparedSources;
+    const rebuildRequired = metadata.get("rebuild_required")?.value === "1";
+    if (rebuildRequired) {
+      const reason = metadata.get("rebuild_reason")?.value;
+      diagnostics.push(rebuildDiagnostic(
+        reason ? `The graph requires a full rebuild (${reason}).` : "The graph requires a full rebuild.",
+      ));
+    }
+
+    if (sourceChanges.digestChanged) {
+      diagnostics.push({
+        code: "GRAPH_SOURCE_CORPUS_MISMATCH",
+        severity: "warning",
+        message: "The current supported-source corpus does not match the successful graph snapshot.",
+        remediation: [{ label: "Refresh graph", command: "mex graph" }],
+      });
+    }
+    if (semantic.changedPaths.length > 0) {
+      diagnostics.push({
+        code: "GRAPH_SEMANTIC_INPUTS_CHANGED",
+        severity: "warning",
+        message: "Compiler configuration inputs no longer match the successful graph snapshot.",
+        ...(semantic.complete
+          ? { remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }] }
+          : {}),
+      });
+    }
+    if (!semantic.complete) {
+      diagnostics.push({
+        code: "GRAPH_SEMANTIC_INPUT_INSPECTION_INCOMPLETE",
+        severity: "warning",
+        message: "Compiler configuration input inspection was incomplete; graph freshness cannot be trusted.",
+      });
+    }
+    if (sourceChanges.changes.branchChanged) {
+      diagnostics.push({
+        code: "GRAPH_INDEX_BRANCH_CHANGED",
+        severity: "warning",
+        message: `The current branch (${currentRepo.branch ?? "detached"}) differs from the indexed branch (${snapshot?.indexedBranch ?? "unknown"}).`,
+        remediation: [{ label: "Republish graph for this branch", command: "mex graph" }],
+      });
+    }
+    if (sourceChanges.changes.manifestChanged) {
+      const changedInputs = [
+        sourceChanges.changes.configChanged ? "configuration" : null,
+        sourceChanges.changes.grammarChanged ? "grammar" : null,
+      ].filter((value): value is string => value !== null);
+      diagnostics.push({
+        code: "GRAPH_BUILD_MANIFEST_CHANGED",
+        severity: "warning",
+        message: changedInputs.length > 0
+          ? `Graph build inputs changed (${changedInputs.join(", ")}).`
+          : "The graph build manifest or discovery policy changed.",
+        remediation: [{ label: "Republish graph with current inputs", command: "mex graph" }],
+      });
+    }
+    if (!live.complete) {
+      diagnostics.push({
+        code: "GRAPH_SOURCE_INSPECTION_INCOMPLETE",
+        severity: "warning",
+        message: "Graph freshness could not be established because source inspection was incomplete.",
+      });
+    }
+    if (!repo.complete) {
+      diagnostics.push({
+        code: "GRAPH_REPO_INSPECTION_INCOMPLETE",
+        severity: "warning",
+        message: "Graph freshness could not be established because repository state inspection was incomplete.",
+      });
+    }
+
+    const freshnessUnproven = !live.complete
+      || !semantic.complete
+      || !repo.complete
+      || manifest === null;
+    const stale = sourceChanges.changes.total > 0
+      || sourceChanges.changes.branchChanged
+      || sourceChanges.changes.manifestChanged
+      || sourceChanges.changes.configChanged
+      || sourceChanges.digestChanged
+      || freshnessUnproven;
+    const parseDegraded = parseHealth.partial > 0 || parseHealth.failed > 0;
+    const status: GraphStatusKind = rebuildRequired
+      ? "rebuild_required"
+      : !snapshot
+        ? "stale"
+      : stale
+        ? "stale"
+        : parseDegraded
+          ? "degraded"
+          : "fresh";
+
+    const indexedAt = snapshot?.indexedAt ?? latestIndexedAt(files);
+    const lastSuccessfulIndexAt = snapshot?.lastSuccessfulIndexAt
+      ?? metadataTimestamp(metadata.get("manifest_hash"));
+    const result = graphStatus({
+      status,
+      observedAt,
+      currentRepo,
+      lastSuccessfulIndexAt,
+      indexedAt,
+      indexedBranch: snapshot?.indexedBranch ?? null,
+      indexedHead: snapshot?.indexedHead ?? null,
+      schemaVersion,
+      extractorVersion: snapshot?.extractorVersion ?? metadata.get("extractor_version")?.value ?? null,
+      grammarVersion: snapshot?.grammarHash ?? metadata.get("grammar_hash")?.value ?? null,
+      parseHealth,
+      changes: sourceChanges.changes,
+      diagnostics,
+    });
+    if (status !== "fresh" || !snapshot || !snapshotRaw || !manifest) {
+      return finishDatabaseResult(result);
+    }
+
+    await context.options.internal?.beforeFreshValidation?.(attempt);
+    const validation = await validateFreshObservation(context, {
+      repo,
+      live,
+      semantic,
+      semanticInputs: snapshot.semanticInputs,
+      manifest,
+      snapshotRaw,
+      database,
+      databaseIdentity: databaseFileIdentity(fileStat),
+    });
+    if (validation.stable) {
+      return {
+        retry: false,
+        status: result,
+        freshObservation: validation.freshObservation,
+      };
+    }
+    const unstable = {
+      ...result,
+      status: validation.status,
+      diagnostics: [...result.diagnostics, ...validation.diagnostics],
+    } satisfies GraphStatus;
+    return {
+      status: unstable,
+      retry: validation.retryable && attempt + 1 < MAX_FRESH_OBSERVATION_ATTEMPTS,
+    };
+  } catch (error) {
+    const classified = classifyDatabaseError(error, "read");
+    diagnostics.push(classified.diagnostic);
+    return finishDatabaseResult(graphStatus({
+        status: classified.status,
+        observedAt,
+        currentRepo,
+        parseHealth: emptyParseHealth(),
+        changes: changesWithoutIndex(live, currentRepo, maxChangedPaths),
+        diagnostics,
+      }));
+  } finally {
+    db?.close();
+  }
+}
+
+/** Canonical aggregate hash used by graph_snapshot_v1 writers and inspectors. */
+export function graphSourceCorpusDigest(entries: Iterable<readonly [string, string]>): string {
+  return computeSourceCorpusDigest(
+    [...entries].map(([path, contentHash]) => ({ path, contentHash })),
+  );
+}
+
+function graphStatus(input: {
+  status: GraphStatusKind;
+  observedAt: string;
+  currentRepo: RepoState;
+  lastSuccessfulIndexAt?: string | null;
+  indexedAt?: string | null;
+  indexedBranch?: string | null;
+  indexedHead?: string | null;
+  schemaVersion?: number | null;
+  extractorVersion?: string | null;
+  grammarVersion?: string | null;
+  parseHealth: GraphParseHealth;
+  changes: GraphSourceChanges;
+  diagnostics: readonly Diagnostic[];
+}): GraphStatus {
+  return {
+    status: input.status,
+    observedAt: input.observedAt,
+    currentRepo: input.currentRepo,
+    lastSuccessfulIndexAt: input.lastSuccessfulIndexAt ?? null,
+    indexedAt: input.indexedAt ?? null,
+    indexedBranch: input.indexedBranch ?? null,
+    indexedHead: input.indexedHead ?? null,
+    schemaVersion: input.schemaVersion ?? null,
+    extractorVersion: input.extractorVersion ?? null,
+    grammarVersion: input.grammarVersion ?? null,
+    parseHealth: input.parseHealth,
+    changes: input.changes,
+    diagnostics: input.diagnostics,
+  };
+}
+
+function suppressExecutableGraphRemediations(status: GraphStatus): GraphStatus {
+  return {
+    ...status,
+    diagnostics: status.diagnostics.map((diagnostic) => {
+      if (!diagnostic.remediation?.some((action) => action.command === "mex graph")) {
+        return diagnostic;
+      }
+      return {
+        ...diagnostic,
+        remediation: diagnostic.remediation.map((action) => {
+          if (action.command !== "mex graph") return action;
+          const { command: _unsafeCommand, ...safeAction } = action;
+          return safeAction;
+        }),
+      };
+    }),
+  };
+}
+
+function resolveContainedDatabasePath(
+  projectRoot: string,
+  requestedPath: string,
+): ContainedDatabaseResult {
+  if (!isPathContained(projectRoot, requestedPath)) {
+    return { database: undefined, diagnostic: containmentDiagnostic("GRAPH_INDEX_PATH_OUTSIDE_PROJECT") };
+  }
+  let projectRootRealPath: string;
+  try {
+    projectRootRealPath = realpathSync(projectRoot);
+  } catch {
+    return {
+      database: undefined,
+      diagnostic: {
+        code: "GRAPH_PROJECT_ROOT_UNAVAILABLE",
+        severity: "warning",
+        message: "The project root could not be resolved without following an unsafe path.",
+      },
+    };
+  }
+
+  let canonicalPath: string;
+  try {
+    const requestedStats = lstatSync(requestedPath);
+    if (requestedStats.isSymbolicLink()) {
+      try {
+        canonicalPath = realpathSync(requestedPath);
+      } catch {
+        return {
+          database: undefined,
+          diagnostic: {
+            code: "GRAPH_INDEX_PATH_UNAVAILABLE",
+            severity: "warning",
+            message: "The configured graph index symlink could not be resolved safely.",
+          },
+        };
+      }
+    } else {
+      canonicalPath = realpathSync(requestedPath);
+    }
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      return {
+        database: undefined,
+        diagnostic: {
+          code: "GRAPH_INDEX_PATH_UNAVAILABLE",
+          severity: "warning",
+          message: "The configured graph index path could not be inspected safely.",
+        },
+      };
+    }
+    try {
+      canonicalPath = canonicalizeMissingPath(requestedPath);
+    } catch {
+      return {
+        database: undefined,
+        diagnostic: {
+          code: "GRAPH_INDEX_PATH_UNAVAILABLE",
+          severity: "warning",
+          message: "The configured graph index parent path could not be resolved safely.",
+        },
+      };
+    }
+  }
+  if (!isPathContained(projectRootRealPath, canonicalPath)) {
+    return { database: undefined, diagnostic: containmentDiagnostic("GRAPH_INDEX_PATH_OUTSIDE_PROJECT") };
+  }
+  return {
+    database: {
+      requestedPath,
+      canonicalPath,
+      projectRootRealPath,
+    },
+  };
+}
+
+function canonicalizeMissingPath(path: string): string {
+  let ancestor = path;
+  for (;;) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) throw new Error("No existing path ancestor");
+    ancestor = parent;
+    try {
+      return resolve(realpathSync(ancestor), relative(ancestor, path));
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+  }
+}
+
+function containmentDiagnostic(code: string): Diagnostic {
+  return {
+    code,
+    severity: "error",
+    message: "The graph index resolves outside the project root; inspection was refused.",
+  };
+}
+
+function isPathContained(root: string, candidate: string): boolean {
+  const path = relative(root, candidate);
+  return path === "" || (!isAbsolute(path) && path !== ".." && !path.startsWith("../") && !path.startsWith("..\\"));
+}
+
+function emptyRepoState(observedAt: string): RepoState {
+  return { branch: null, head: null, dirty: false, observedAt };
+}
+
+function emptySourceChanges(): GraphSourceChanges {
+  return {
+    total: 0,
+    added: [],
+    modified: [],
+    deleted: [],
+    truncated: false,
+    branchChanged: false,
+    manifestChanged: false,
+    configChanged: false,
+    grammarChanged: false,
+  };
+}
+
+function sidecarDiagnostic(probe: GraphSidecarProbe): Diagnostic {
+  const paths = probe.paths.join(", ");
+  return probe.state === "active"
+    ? {
+        code: "GRAPH_INDEX_SIDECAR_ACTIVE",
+        severity: "warning",
+        message: `Graph maintenance or recovery is active (${paths}); immutable inspection was skipped.`,
+        remediation: [{ label: "Retry after graph maintenance finishes" }],
+      }
+    : {
+        code: "GRAPH_INDEX_SIDECAR_UNAVAILABLE",
+        severity: "warning",
+        message: `Graph recovery sidecars could not be inspected safely (${paths}); immutable inspection was skipped.`,
+        remediation: [{ label: "Retry graph status after checking file permissions" }],
+      };
+}
+
+function databaseFileIdentity(stats: NonNullable<ReturnType<typeof statSync>>): string {
+  return JSON.stringify([stats.dev, stats.ino, stats.size, stats.mtimeMs, stats.ctimeMs]);
+}
+
+function stabilizeDatabaseResult(
+  projectRoot: string,
+  requestedDbPath: string,
+  dbPath: string,
+  identityBefore: string,
+  attempt: number,
+  result: GraphStatus,
+): InspectionAttempt {
+  const sidecars = inspectGraphSidecars(dbPath);
+  const resolvedPath = resolveContainedGraphDatabasePath(projectRoot, requestedDbPath);
+  let identityAfter: string | null = null;
+  try {
+    identityAfter = databaseFileIdentity(statSync(dbPath));
+  } catch {
+    // A missing/replaced database is handled as an unstable observation below.
+  }
+  if (sidecars.state === "clear"
+    && resolvedPath === dbPath
+    && identityAfter === identityBefore) {
+    return { retry: false, status: result };
+  }
+  const diagnostics = [
+    ...(sidecars.state === "clear" ? [] : [sidecarDiagnostic(sidecars)]),
+    observationRaceDiagnostic([
+      resolvedPath !== dbPath
+        ? "graph database path"
+        : identityAfter === identityBefore
+          ? "SQLite sidecars"
+          : "graph database",
+    ]),
+  ];
+  return {
+    retry: attempt + 1 < MAX_FRESH_OBSERVATION_ATTEMPTS,
+    status: {
+      ...result,
+      status: "degraded",
+      diagnostics,
+    },
+  };
+}
+
+async function validateFreshObservation(
+  context: InspectionContext,
+  before: FreshObservation,
+): Promise<FreshValidation> {
+  const firstSidecars = inspectGraphSidecars(before.database.canonicalPath);
+  if (firstSidecars.state !== "clear") {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [sidecarDiagnostic(firstSidecars), observationRaceDiagnostic(["SQLite sidecars"])],
+    };
+  }
+
+  const contained = resolveContainedDatabasePath(context.projectRoot, context.requestedDbPath);
+  if (!contained.database) {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [contained.diagnostic, observationRaceDiagnostic(["database containment"])],
+    };
+  }
+  if (contained.database.canonicalPath !== before.database.canonicalPath
+    || contained.database.projectRootRealPath !== before.database.projectRootRealPath) {
+    return unstableObservation("degraded", ["database path"]);
+  }
+
+  const repo = await inspectRepoState(context.projectRoot, context.observedAt);
+  const live = inspectLiveSources(
+    context.projectRoot,
+    contained.database.projectRootRealPath,
+    context.maxChangedPaths,
+    (path) => context.options.internal?.afterSourceRead?.(path, "validation"),
+  );
+  const semantic = inspectSemanticInputs(
+    context.projectRoot,
+    contained.database.projectRootRealPath,
+    before.semanticInputs,
+    context.maxChangedPaths,
+    (path) => context.options.internal?.afterSemanticInputRead?.(path, "validation"),
+  );
+  const manifestDiagnostics: Diagnostic[] = [];
+  const manifest = inspectCurrentManifest(context.projectRoot, manifestDiagnostics);
+  if (!repo.complete || !live.complete || !semantic.complete || manifest === null) {
+    const status = !repo.complete ? "degraded" : "stale";
+    return {
+      stable: false,
+      status,
+      retryable: true,
+      diagnostics: [
+        ...repo.diagnostics,
+        ...live.diagnostics,
+        ...semantic.diagnostics,
+        ...manifestDiagnostics,
+        observationRaceDiagnostic(["freshness inputs"]),
+      ],
+    };
+  }
+
+  const preSnapshotSidecars = inspectGraphSidecars(contained.database.canonicalPath);
+  if (preSnapshotSidecars.state !== "clear") {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [sidecarDiagnostic(preSnapshotSidecars), observationRaceDiagnostic(["SQLite sidecars"])],
+    };
+  }
+
+  let snapshotRaw: string;
+  let identity: string;
+  try {
+    const snapshotIdentity = readSnapshotIdentity(contained.database.canonicalPath);
+    snapshotRaw = snapshotIdentity.snapshotRaw;
+    identity = snapshotIdentity.databaseIdentity;
+  } catch {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: true,
+      diagnostics: [{
+        code: "GRAPH_STATUS_SNAPSHOT_RECHECK_FAILED",
+        severity: "warning",
+        message: "The graph snapshot could not be re-read safely during freshness validation.",
+      }, observationRaceDiagnostic(["graph snapshot"])],
+    };
+  }
+
+  const finalSidecars = inspectGraphSidecars(contained.database.canonicalPath);
+  if (finalSidecars.state !== "clear") {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [sidecarDiagnostic(finalSidecars), observationRaceDiagnostic(["SQLite sidecars"])],
+    };
+  }
+
+  const finalContained = resolveContainedDatabasePath(
+    context.projectRoot,
+    context.requestedDbPath,
+  );
+  if (!finalContained.database) {
+    return {
+      stable: false,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [
+        finalContained.diagnostic,
+        observationRaceDiagnostic(["database containment"]),
+      ],
+    };
+  }
+
+  const changed: string[] = [];
+  if (!sameRepoState(before.repo.state, repo.state)) changed.push("Git state");
+  if (liveSourceIdentity(before.live) !== liveSourceIdentity(live)) changed.push("source corpus");
+  if (semanticInputIdentity(before.semantic) !== semanticInputIdentity(semantic)
+    || semantic.changedPaths.length > 0) changed.push("compiler semantic inputs");
+  if (!sameManifest(before.manifest, manifest)) changed.push("graph manifest");
+  if (before.snapshotRaw !== snapshotRaw || before.databaseIdentity !== identity) changed.push("graph snapshot");
+  if (finalContained.database.canonicalPath !== contained.database.canonicalPath
+    || finalContained.database.projectRootRealPath !== contained.database.projectRootRealPath) {
+    changed.push("database path");
+  }
+  if (changed.length === 0) {
+    return {
+      stable: true,
+      status: "degraded",
+      retryable: false,
+      diagnostics: [],
+      freshObservation: Object.freeze({
+        canonicalDbPath: finalContained.database.canonicalPath,
+        databaseIdentity: identity,
+        snapshotRaw,
+        snapshotHash: sha256(snapshotRaw),
+      }),
+    };
+  }
+  const unstable = unstableObservation(
+    changed.some((entry) => entry === "graph snapshot") ? "degraded" : "stale",
+    changed,
+  );
+  return {
+    ...unstable,
+    diagnostics: [...semantic.diagnostics, ...unstable.diagnostics],
+  };
+}
+
+function readSnapshotIdentity(dbPath: string): { snapshotRaw: string; databaseIdentity: string } {
+  const before = statSync(dbPath);
+  const db = openSqlite(dbPath, { readOnly: true, immutable: true });
+  let snapshotRaw: string;
+  try {
+    const row = db.prepare(
+      "SELECT value FROM project_metadata WHERE key = ?",
+    ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value?: unknown } | undefined;
+    if (typeof row?.value !== "string") throw new Error("Missing graph snapshot identity");
+    snapshotRaw = row.value;
+  } finally {
+    db.close();
+  }
+  const after = statSync(dbPath);
+  if (databaseFileIdentity(before) !== databaseFileIdentity(after)) {
+    throw new Error("The graph database changed while its snapshot identity was read.");
+  }
+  return { snapshotRaw, databaseIdentity: databaseFileIdentity(after) };
+}
+
+function unstableObservation(
+  status: Extract<GraphStatusKind, "stale" | "degraded">,
+  changed: string[],
+): FreshValidation {
+  return {
+    stable: false,
+    status,
+    retryable: true,
+    diagnostics: [observationRaceDiagnostic(changed)],
+  };
+}
+
+function observationRaceDiagnostic(changed: string[]): Diagnostic {
+  return {
+    code: "GRAPH_STATUS_OBSERVATION_RACE",
+    severity: "warning",
+    message: `Graph freshness changed during inspection (${changed.sort(compareCodePoints).join(", ")}); no fresh result was emitted.`,
+  };
+}
+
+function sameRepoState(left: RepoState, right: RepoState): boolean {
+  return left.branch === right.branch && left.head === right.head && left.dirty === right.dirty;
+}
+
+function sameManifest(
+  left: ReturnType<typeof graphManifest>,
+  right: ReturnType<typeof graphManifest>,
+): boolean {
+  return left.manifestHash === right.manifestHash
+    && left.configHash === right.configHash
+    && left.grammarHash === right.grammarHash;
+}
+
+function liveSourceIdentity(live: LiveSources): string {
+  return JSON.stringify([...live.hashes].sort(([left], [right]) => compareCodePoints(left, right)));
+}
+
+function semanticInputIdentity(semantic: LiveSemanticInputs): string {
+  return JSON.stringify([
+    [...semantic.hashes].sort(([left], [right]) => compareCodePoints(left, right)),
+    semantic.changedPaths,
+    semantic.unavailablePaths,
+    semantic.complete,
+  ]);
+}
+
+function emptySemanticInputs(): LiveSemanticInputs {
+  return {
+    hashes: new Map(),
+    changedPaths: [],
+    unavailablePaths: [],
+    complete: true,
+    diagnostics: [],
+  };
+}
+
+function inspectSemanticInputs(
+  projectRoot: string,
+  projectRootRealPath: string,
+  expected: readonly GraphSnapshotSemanticInput[],
+  diagnosticLimit: number,
+  afterRead?: (path: string) => void,
+): LiveSemanticInputs {
+  const hashes = new Map<string, string | null>();
+  const changedPaths: string[] = [];
+  const unavailablePaths: string[] = [];
+  const diagnostics: Diagnostic[] = [];
+  let complete = true;
+  let omittedDiagnostics = 0;
+  const report = (diagnostic: Diagnostic): void => {
+    if (diagnostics.length < diagnosticLimit) diagnostics.push(diagnostic);
+    else omittedDiagnostics += 1;
+  };
+
+  for (const input of expected) {
+    let contentHash: string | null | undefined;
+    try {
+      const content = readStableContainedUtf8File(
+        projectRoot,
+        projectRootRealPath,
+        input.path,
+        () => afterRead?.(input.path),
+      );
+      contentHash = sha256(content);
+    } catch (error) {
+      if (errorCode(error) === "ENOENT" || errorCode(error) === "ENOTDIR") {
+        try {
+          assertSecurelyContainedMissingPath(projectRoot, projectRootRealPath, input.path);
+          contentHash = null;
+        } catch (containmentError) {
+          error = containmentError;
+        }
+      }
+      if (contentHash === undefined) {
+        complete = false;
+        unavailablePaths.push(input.path);
+        const outsideProject = errorCode(error) === "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT";
+        report({
+          code: outsideProject
+            ? "GRAPH_SEMANTIC_INPUT_PATH_OUTSIDE_PROJECT"
+            : "GRAPH_SEMANTIC_INPUT_READ_FAILED",
+          severity: "warning",
+          message: outsideProject
+            ? `Refused to inspect compiler semantic input ${input.path} because its resolved target escapes the project root.`
+            : `Could not hash compiler semantic input ${input.path} safely.`,
+          path: input.path,
+        });
+        continue;
+      }
+    }
+    hashes.set(input.path, contentHash);
+    if (contentHash !== input.contentHash) {
+      changedPaths.push(input.path);
+      const change = input.contentHash === null
+        ? "appeared"
+        : contentHash === null
+          ? "disappeared"
+          : "changed";
+      report({
+        code: "GRAPH_SEMANTIC_INPUT_CHANGED",
+        severity: "warning",
+        message: `Compiler semantic input ${input.path} ${change} after graph publication.`,
+        path: input.path,
+      });
+    }
+  }
+  if (omittedDiagnostics > 0) {
+    diagnostics.push({
+      code: "GRAPH_SEMANTIC_INPUT_DIAGNOSTICS_TRUNCATED",
+      severity: "info",
+      message: `${omittedDiagnostics} additional compiler semantic-input diagnostic(s) were omitted.`,
+    });
+  }
+  return { hashes, changedPaths, unavailablePaths, complete, diagnostics };
+}
+
+function readStableContainedUtf8File(
+  projectRoot: string,
+  projectRootRealPath: string,
+  path: string,
+  afterRead?: () => void,
+): string {
+  const absolutePath = resolve(projectRoot, path);
+  if (!isPathContained(projectRoot, absolutePath)) {
+    throw containedFileError(
+      "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT",
+      "The repository-relative path escapes the project root.",
+    );
+  }
+  const canonicalPath = realpathSync(absolutePath);
+  if (!isPathContained(projectRootRealPath, canonicalPath)) {
+    throw containedFileError(
+      "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT",
+      "The resolved file target escapes the project root.",
+    );
+  }
+  const before = lstatSync(canonicalPath);
+  if (!before.isFile() || before.isSymbolicLink()) {
+    throw containedFileError(
+      "GRAPH_CONTAINED_FILE_INVALID",
+      "The resolved path is not a stable regular file.",
+    );
+  }
+  const noFollow = "O_NOFOLLOW" in constants ? constants.O_NOFOLLOW : 0;
+  const fd = openSync(canonicalPath, constants.O_RDONLY | noFollow);
+  try {
+    const opened = fstatSync(fd);
+    if (!opened.isFile() || databaseFileIdentity(opened) !== databaseFileIdentity(before)) {
+      throw containedFileError(
+        "GRAPH_CONTAINED_FILE_CHANGED",
+        "The resolved file changed before it could be read.",
+      );
+    }
+    const content = readFileSync(fd, "utf8");
+    afterRead?.();
+    const after = fstatSync(fd);
+    const resolvedAfter = realpathSync(absolutePath);
+    const pathAfter = lstatSync(resolvedAfter);
+    if (databaseFileIdentity(opened) !== databaseFileIdentity(after)
+      || resolvedAfter !== canonicalPath
+      || !pathAfter.isFile()
+      || pathAfter.isSymbolicLink()
+      || databaseFileIdentity(opened) !== databaseFileIdentity(pathAfter)) {
+      throw containedFileError(
+        "GRAPH_CONTAINED_FILE_CHANGED",
+        "The repository path changed while it was being read.",
+      );
+    }
+    return content;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function assertSecurelyContainedMissingPath(
+  projectRoot: string,
+  projectRootRealPath: string,
+  path: string,
+): void {
+  const absolutePath = resolve(projectRoot, path);
+  if (!isPathContained(projectRoot, absolutePath)) {
+    throw containedFileError(
+      "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT",
+      "The repository-relative path escapes the project root.",
+    );
+  }
+  try {
+    const exact = lstatSync(absolutePath);
+    if (exact.isSymbolicLink()) {
+      throw containedFileError(
+        "GRAPH_CONTAINED_FILE_UNAVAILABLE",
+        "A missing repository path is represented by an unresolved symlink.",
+      );
+    }
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT" && errorCode(error) !== "ENOTDIR") throw error;
+  }
+
+  let ancestor = dirname(absolutePath);
+  for (;;) {
+    try {
+      const canonicalAncestor = realpathSync(ancestor);
+      if (!isPathContained(projectRootRealPath, canonicalAncestor)) {
+        throw containedFileError(
+          "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT",
+          "The missing file's resolved ancestor escapes the project root.",
+        );
+      }
+      return;
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT" && errorCode(error) !== "ENOTDIR") throw error;
+      try {
+        if (lstatSync(ancestor).isSymbolicLink()) {
+          throw containedFileError(
+            "GRAPH_CONTAINED_FILE_UNAVAILABLE",
+            "A missing file's ancestor is an unresolved symlink.",
+          );
+        }
+      } catch (lstatError) {
+        if (errorCode(lstatError) !== "ENOENT" && errorCode(lstatError) !== "ENOTDIR") {
+          throw lstatError;
+        }
+      }
+      const parent = dirname(ancestor);
+      if (parent === ancestor) {
+        throw containedFileError(
+          "GRAPH_CONTAINED_FILE_UNAVAILABLE",
+          "No stable repository ancestor could be resolved.",
+        );
+      }
+      ancestor = parent;
+    }
+  }
+}
+
+function containedFileError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code });
+}
+
+function inspectLiveSources(
+  projectRoot: string,
+  projectRootRealPath: string,
+  diagnosticLimit: number,
+  afterSourceRead?: (path: string) => void,
+): LiveSources {
+  const diagnostics: Diagnostic[] = [];
+  const hashes = new Map<string, string>();
+  const discoveredPaths = new Set<string>();
+  let omittedDiagnostics = 0;
+  const reportPathDiagnostic = (diagnostic: Diagnostic): void => {
+    if (diagnostics.length < diagnosticLimit) diagnostics.push(diagnostic);
+    else omittedDiagnostics++;
+  };
+  let matches: string[];
+  try {
+    matches = globSync(GRAPH_SUPPORTED_SOURCE_GLOB, {
+      ...GRAPH_CORPUS_GLOB_OPTIONS,
+      cwd: projectRoot,
+      ignore: [...GRAPH_CORPUS_IGNORE_GLOBS],
+    }).map(toPosix).filter(isSupportedSourceFile).sort(compareCodePoints);
+  } catch (error) {
+    diagnostics.push({
+      code: "GRAPH_SOURCE_DISCOVERY_FAILED",
+      severity: "warning",
+      message: `Could not discover supported source files: ${errorMessage(error)}`,
+    });
+    return { hashes, discoveredPaths, complete: false, diagnostics };
+  }
+
+  let complete = true;
+  for (const path of matches) {
+    discoveredPaths.add(path);
+    try {
+      const content = readStableContainedUtf8File(
+        projectRoot,
+        projectRootRealPath,
+        path,
+        () => afterSourceRead?.(path),
+      );
+      hashes.set(path, sha256(content));
+    } catch (error) {
+      complete = false;
+      const code = errorCode(error);
+      const outsideProject = code === "GRAPH_CONTAINED_FILE_OUTSIDE_PROJECT";
+      const invalidPath = code === "GRAPH_CONTAINED_FILE_INVALID";
+      reportPathDiagnostic({
+        code: outsideProject
+          ? "GRAPH_SOURCE_PATH_OUTSIDE_PROJECT"
+          : invalidPath
+            ? "GRAPH_SOURCE_PATH_INVALID"
+            : "GRAPH_SOURCE_READ_FAILED",
+        severity: "warning",
+        message: outsideProject
+          ? `Refused to inspect supported source path ${path} because its resolved target escapes the project root.`
+          : invalidPath
+            ? `Refused to inspect supported source path ${path} because it is not a regular file.`
+            : `Could not hash supported source file ${path}: ${errorMessage(error)}`,
+        path,
+      });
+    }
+  }
+  if (omittedDiagnostics > 0) {
+    diagnostics.push({
+      code: "GRAPH_SOURCE_DIAGNOSTICS_TRUNCATED",
+      severity: "info",
+      message: `${omittedDiagnostics} additional source inspection diagnostic(s) were omitted.`,
+    });
+  }
+  return { hashes, discoveredPaths, complete, diagnostics };
+}
+
+function compareSources(
+  files: FileRow[],
+  live: LiveSources,
+  snapshot: GraphSnapshot | undefined,
+  currentRepo: RepoState,
+  manifest: ReturnType<typeof graphManifest> | null,
+  metadata: Map<string, MetadataValue>,
+  limit: number,
+): { changes: GraphSourceChanges; digestChanged: boolean } {
+  const indexed = new Map(files.map((file) => [file.path, file.content_hash]));
+  const all: Array<{ path: string; kind: "added" | "modified" | "deleted" }> = [];
+  for (const [path, contentHash] of live.hashes) {
+    const stored = indexed.get(path);
+    if (stored === undefined) all.push({ path, kind: "added" });
+    else if (stored !== contentHash) all.push({ path, kind: "modified" });
+  }
+  if (live.complete) {
+    for (const path of indexed.keys()) {
+      if (!live.discoveredPaths.has(path)) all.push({ path, kind: "deleted" });
+    }
+  }
+  all.sort((left, right) => compareCodePoints(left.path, right.path) || compareCodePoints(left.kind, right.kind));
+  const visible = all.slice(0, limit);
+
+  const storedManifest = snapshot?.manifestHash ?? metadata.get("manifest_hash")?.value;
+  const storedConfig = snapshot?.configHash ?? metadata.get("config_hash")?.value;
+  const storedGrammar = snapshot?.grammarHash ?? metadata.get("grammar_hash")?.value;
+  const manifestChanged = manifest !== null && storedManifest !== undefined
+    ? storedManifest !== manifest.manifestHash
+    : false;
+  const configChanged = manifest !== null && storedConfig !== undefined
+    ? storedConfig !== manifest.configHash
+    : false;
+  const grammarChanged = manifest !== null && storedGrammar !== undefined
+    ? storedGrammar !== manifest.grammarHash
+    : false;
+  const branchChanged = snapshot !== undefined
+    ? snapshot.indexedBranch !== currentRepo.branch
+    : false;
+  const digestChanged = live.complete && snapshot !== undefined
+    ? snapshot.sourceCount !== live.hashes.size
+      || snapshot.sourceCorpusDigest !== graphSourceCorpusDigest(live.hashes)
+    : false;
+  return {
+    changes: {
+      total: all.length,
+      added: visible.filter((entry) => entry.kind === "added").map((entry) => entry.path),
+      modified: visible.filter((entry) => entry.kind === "modified").map((entry) => entry.path),
+      deleted: visible.filter((entry) => entry.kind === "deleted").map((entry) => entry.path),
+      truncated: all.length > visible.length,
+      branchChanged,
+      manifestChanged,
+      configChanged,
+      grammarChanged,
+    },
+    digestChanged,
+  };
+}
+
+function changesWithoutIndex(
+  live: LiveSources,
+  _currentRepo: RepoState,
+  limit: number,
+  knownMissing = false,
+): GraphSourceChanges {
+  if (!knownMissing) return emptySourceChanges();
+  const paths = [...live.hashes.keys()].sort(compareCodePoints);
+  return {
+    total: paths.length,
+    added: paths.slice(0, limit),
+    modified: [],
+    deleted: [],
+    truncated: paths.length > limit,
+    branchChanged: false,
+    manifestChanged: false,
+    configChanged: false,
+    grammarChanged: false,
+  };
+}
+
+function summarizeParseHealth(files: FileRow[], limit: number): GraphParseHealth {
+  const failed = files.filter((file) => file.parse_status === "failed")
+    .map((file) => file.path)
+    .sort(compareCodePoints);
+  return {
+    total: files.length,
+    ok: files.filter((file) => file.parse_status === "ok").length,
+    partial: files.filter((file) => file.parse_status === "partial").length,
+    failed: failed.length,
+    failedPaths: failed.slice(0, limit),
+    failedPathsTruncated: failed.length > limit,
+  };
+}
+
+function snapshotMatchesStoredRows(
+  snapshot: GraphSnapshot,
+  files: FileRow[],
+  parseHealth: GraphParseHealth,
+): boolean {
+  return snapshot.sourceCount === parseHealth.total
+    && snapshot.sourceCorpusDigest === graphSourceCorpusDigest(
+      files.map((file) => [file.path, file.content_hash] as const),
+    )
+    && snapshot.parseHealth.total === parseHealth.total
+    && snapshot.parseHealth.ok === parseHealth.ok
+    && snapshot.parseHealth.partial === parseHealth.partial
+    && snapshot.parseHealth.failed === parseHealth.failed;
+}
+
+function emptyParseHealth(): GraphParseHealth {
+  return {
+    total: 0,
+    ok: 0,
+    partial: 0,
+    failed: 0,
+    failedPaths: [],
+    failedPathsTruncated: false,
+  };
+}
+
+function readFiles(db: SqliteDatabase): FileRow[] {
+  const rows = db.prepare(
+    "SELECT path, content_hash, parse_status, indexed_at FROM files ORDER BY path",
+  ).all() as FileRow[];
+  for (const row of rows) {
+    if (!row.path || !row.content_hash || !["ok", "partial", "failed"].includes(row.parse_status)) {
+      throw new CorruptGraphIndexError("The graph files table contains an invalid row.");
+    }
+  }
+  return rows;
+}
+
+function inspectRequiredSchema(db: SqliteDatabase): string[] {
+  const failures: string[] = [];
+  const missingTables = new Set<string>();
+  for (const [type, names] of Object.entries(REQUIRED_SCHEMA_OBJECTS)) {
+    for (const name of names) {
+      const row = db.prepare(
+        "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ?",
+      ).get(type, name);
+      if (!row) {
+        failures.push(`missing ${type} ${name}`);
+        if (type === "table") missingTables.add(name);
+      }
+    }
+  }
+  // Missing FTS shadow tables can make even PRAGMA table_info on the virtual
+  // table fail with a generic SQL error. Report the precise missing objects
+  // before attempting column-level validation.
+  if ([...missingTables].some((name) => /_(?:fts)_(?:config|data|docsize|idx)$/u.test(name))) {
+    return failures.sort(compareCodePoints);
+  }
+  for (const [table, requiredColumns] of Object.entries(REQUIRED_TABLE_COLUMNS)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(table)) {
+      throw new CorruptGraphIndexError("The required graph schema list contains an invalid identifier.");
+    }
+    if (missingTables.has(table)) continue;
+    const rows = db.prepare(`PRAGMA table_info("${table}")`).all() as Array<{ name?: unknown }>;
+    const columns = new Set(rows.map((row) => row.name).filter((name): name is string => typeof name === "string"));
+    for (const column of requiredColumns) {
+      if (!columns.has(column)) failures.push(`missing column ${table}.${column}`);
+    }
+  }
+  return failures.sort(compareCodePoints);
+}
+
+function inspectCoreInvariants(db: SqliteDatabase): string[] {
+  const checks: ReadonlyArray<readonly [string, string]> = [
+    ["duplicate edge group(s)", `
+      SELECT COUNT(*) AS count FROM (
+        SELECT 1 FROM edges
+        GROUP BY source, target, kind, IFNULL(line, -1), IFNULL(col, -1)
+        HAVING COUNT(*) > 1
+      )
+    `],
+    ["dangling edge(s)", `
+      SELECT COUNT(*) AS count FROM edges e
+      LEFT JOIN nodes source_node ON source_node.id = e.source
+      LEFT JOIN nodes target_node ON target_node.id = e.target
+      WHERE source_node.id IS NULL OR target_node.id IS NULL
+    `],
+    ["node(s) without an owning file", `
+      SELECT COUNT(*) AS count FROM nodes n
+      LEFT JOIN files f ON f.path = n.file_path
+      WHERE f.path IS NULL
+    `],
+    ["node(s) with a dangling container", `
+      SELECT COUNT(*) AS count FROM nodes n
+      LEFT JOIN nodes container ON container.id = n.container_id
+      WHERE n.container_id IS NOT NULL AND container.id IS NULL
+    `],
+    ["file(s) with an incorrect node_count", `
+      SELECT COUNT(*) AS count FROM files f
+      LEFT JOIN (
+        SELECT file_path, COUNT(*) AS actual_count FROM nodes GROUP BY file_path
+      ) n ON n.file_path = f.path
+      WHERE COALESCE(f.node_count, -1) <> COALESCE(n.actual_count, 0)
+    `],
+    ["source chunk(s) without an owning file", `
+      SELECT COUNT(*) AS count FROM source_chunks c
+      LEFT JOIN files f ON f.path = c.file_path
+      WHERE f.path IS NULL
+    `],
+    ["alias(es) without a canonical node", `
+      SELECT COUNT(*) AS count FROM node_aliases a
+      LEFT JOIN nodes n ON n.id = a.canonical_node_id
+      WHERE n.id IS NULL
+    `],
+    ["unresolved reference(s) without an owning node", `
+      SELECT COUNT(*) AS count FROM unresolved_refs r
+      LEFT JOIN nodes n ON n.id = r.from_node_id
+      WHERE n.id IS NULL
+    `],
+    ["unresolved reference(s) with a dangling target", `
+      SELECT COUNT(*) AS count FROM unresolved_refs r
+      LEFT JOIN nodes n ON n.id = r.target_id
+      WHERE r.target_id IS NOT NULL AND n.id IS NULL
+    `],
+    ["unresolved reference(s) without an owning file", `
+      SELECT COUNT(*) AS count FROM unresolved_refs r
+      LEFT JOIN files f ON f.path = r.file_path
+      WHERE r.file_path <> '' AND f.path IS NULL
+    `],
+    ["import binding(s) without an owning file", `
+      SELECT COUNT(*) AS count FROM import_bindings b
+      LEFT JOIN files f ON f.path = b.file_path
+      WHERE f.path IS NULL
+    `],
+    ["import binding(s) with a dangling target", `
+      SELECT COUNT(*) AS count FROM import_bindings b
+      LEFT JOIN nodes n ON n.id = b.target_id
+      WHERE b.target_id IS NOT NULL AND n.id IS NULL
+    `],
+    ["fingerprint(s) without a node", `
+      SELECT COUNT(*) AS count FROM node_fingerprints f
+      LEFT JOIN nodes n ON n.id = f.node_id
+      WHERE n.id IS NULL
+    `],
+    ["LSH bucket(s) without a node", `
+      SELECT COUNT(*) AS count FROM lsh_buckets b
+      LEFT JOIN nodes n ON n.id = b.node_id
+      WHERE n.id IS NULL
+    `],
+    ["LSH bucket(s) without a fingerprint", `
+      SELECT COUNT(*) AS count FROM lsh_buckets b
+      LEFT JOIN node_fingerprints f ON f.node_id = b.node_id
+      WHERE f.node_id IS NULL
+    `],
+    ["node(s) missing from full-text search", `
+      SELECT COUNT(*) AS count FROM nodes n
+      LEFT JOIN nodes_fts_docsize fts ON fts.id = n.rowid
+      WHERE fts.id IS NULL
+    `],
+    ["orphan node full-text row(s)", `
+      SELECT COUNT(*) AS count FROM nodes_fts_docsize fts
+      LEFT JOIN nodes n ON n.rowid = fts.id
+      WHERE n.rowid IS NULL
+    `],
+    ["source chunk(s) missing from full-text search", `
+      SELECT COUNT(*) AS count FROM source_chunks c
+      LEFT JOIN source_chunks_fts_docsize fts ON fts.id = c.id
+      WHERE fts.id IS NULL
+    `],
+    ["orphan source-chunk full-text row(s)", `
+      SELECT COUNT(*) AS count FROM source_chunks_fts_docsize fts
+      LEFT JOIN source_chunks c ON c.id = fts.id
+      WHERE c.id IS NULL
+    `],
+  ];
+  const failures: string[] = [];
+  for (const [label, sql] of checks) {
+    const count = readCount(db, sql);
+    if (count > 0) failures.push(`${count} ${label}`);
+  }
+  failures.push(...inspectFingerprintInvariants(db));
+  return failures.sort(compareCodePoints);
+}
+
+interface StoredFingerprintRow {
+  node_id: unknown;
+  minhash: unknown;
+  neighbors: unknown;
+  token_count: unknown;
+}
+
+interface StoredLshBucketRow {
+  node_id: unknown;
+  band: unknown;
+  band_hash: unknown;
+}
+
+/**
+ * Validate the exact persisted shape consumed by FingerprintStore and the
+ * reconciler. Iterating two independently ordered cursors avoids retaining the
+ * repository's full fingerprint or LSH corpus in memory.
+ */
+function inspectFingerprintInvariants(db: SqliteDatabase): string[] {
+  let malformedFingerprints = 0;
+  let malformedBucketOwners = 0;
+  let missingBands = 0;
+  let duplicateBuckets = 0;
+  let outOfRangeBands = 0;
+  let wrongBandHashes = 0;
+
+  const bucketIterator = db.prepare(
+    `SELECT node_id, band, band_hash FROM lsh_buckets
+     ORDER BY node_id COLLATE BINARY, band, band_hash, rowid`,
+  ).iterate()[Symbol.iterator]() as IterableIterator<StoredLshBucketRow>;
+  let bucketStep = bucketIterator.next();
+
+  const advanceMalformedBucketOwners = (): void => {
+    while (!bucketStep.done && typeof bucketStep.value.node_id !== "string") {
+      malformedBucketOwners += 1;
+      bucketStep = bucketIterator.next();
+    }
+  };
+  advanceMalformedBucketOwners();
+
+  const fingerprints = db.prepare(
+    `SELECT node_id, minhash, neighbors, token_count FROM node_fingerprints
+     ORDER BY node_id COLLATE BINARY`,
+  ).iterate() as IterableIterator<StoredFingerprintRow>;
+  for (const row of fingerprints) {
+    if (typeof row.node_id !== "string") {
+      malformedFingerprints += 1;
+      continue;
+    }
+    const nodeId = row.node_id;
+    while (!bucketStep.done
+      && compareSqliteText(bucketStep.value.node_id as string, nodeId) < 0) {
+      bucketStep = bucketIterator.next();
+      advanceMalformedBucketOwners();
+    }
+
+    const fingerprint = decodeStoredFingerprint(row);
+    if (!fingerprint) malformedFingerprints += 1;
+    const expectedHashes = fingerprint ? bandHashes(fingerprint) : null;
+    const bandCounts = Array.from({ length: BANDS }, () => 0);
+    while (!bucketStep.done && bucketStep.value.node_id === nodeId) {
+      const bucket = bucketStep.value;
+      if (typeof bucket.band !== "number"
+        || !Number.isSafeInteger(bucket.band)
+        || bucket.band < 0
+        || bucket.band >= BANDS) {
+        outOfRangeBands += 1;
+      } else {
+        bandCounts[bucket.band]! += 1;
+        if (expectedHashes && bucket.band_hash !== expectedHashes[bucket.band]) {
+          wrongBandHashes += 1;
+        }
+      }
+      bucketStep = bucketIterator.next();
+      advanceMalformedBucketOwners();
+    }
+    for (const count of bandCounts) {
+      if (count === 0) missingBands += 1;
+      else if (count > 1) duplicateBuckets += count - 1;
+    }
+  }
+
+  const failures: string[] = [];
+  if (malformedFingerprints > 0) {
+    failures.push(`${malformedFingerprints} malformed fingerprint row(s)`);
+  }
+  if (malformedBucketOwners > 0) {
+    failures.push(`${malformedBucketOwners} malformed LSH bucket owner row(s)`);
+  }
+  if (missingBands > 0) failures.push(`${missingBands} missing fingerprint LSH band(s)`);
+  if (duplicateBuckets > 0) {
+    failures.push(`${duplicateBuckets} duplicate fingerprint LSH bucket row(s)`);
+  }
+  if (outOfRangeBands > 0) {
+    failures.push(`${outOfRangeBands} out-of-range fingerprint LSH bucket row(s)`);
+  }
+  if (wrongBandHashes > 0) {
+    failures.push(`${wrongBandHashes} fingerprint LSH bucket hash mismatch(es)`);
+  }
+  return failures;
+}
+
+function decodeStoredFingerprint(row: StoredFingerprintRow): Fingerprint | null {
+  if (typeof row.minhash !== "string"
+    || typeof row.neighbors !== "string"
+    || typeof row.token_count !== "number"
+    || !Number.isSafeInteger(row.token_count)
+    || row.token_count < 0) return null;
+  let minhash: unknown;
+  let neighbors: unknown;
+  try {
+    minhash = JSON.parse(row.minhash);
+    neighbors = JSON.parse(row.neighbors);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(minhash)
+    || minhash.length !== K
+    || minhash.some((value) => (
+      typeof value !== "number"
+      || !Number.isInteger(value)
+      || value < 0
+      || value > 0xffff_ffff
+    ))
+    || !Array.isArray(neighbors)
+    || neighbors.some((value) => typeof value !== "string")) return null;
+  return { minhash, neighbors, tokenCount: row.token_count };
+}
+
+/** Match SQLite's BINARY ordering for the ASCII ids emitted by the engine. */
+function compareSqliteText(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+function readCount(db: SqliteDatabase, sql: string): number {
+  const row = db.prepare(sql).get() as { count?: unknown } | undefined;
+  const value = row?.count;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new CorruptGraphIndexError("A graph invariant query returned an invalid count.");
+  }
+  return value;
+}
+
+function readMetadata(db: SqliteDatabase): Map<string, MetadataValue> {
+  const rows = db.prepare(
+    "SELECT key, value, updated_at FROM project_metadata ORDER BY key",
+  ).all() as Array<{ key: string; value: string; updated_at: number }>;
+  return new Map(rows.map((row) => [row.key, { value: row.value, updatedAt: row.updated_at }]));
+}
+
+function readSnapshot(raw: string | undefined): { snapshot?: GraphSnapshot; error?: string } {
+  if (raw === undefined) return {};
+  const snapshot = parseGraphSnapshot(raw);
+  return snapshot
+    ? { snapshot }
+    : { error: "graph_snapshot_v1 has invalid JSON, fields, or version." };
+}
+
+function quickCheck(db: SqliteDatabase): string[] {
+  const rows = db.prepare("PRAGMA quick_check").all() as Array<Record<string, unknown>>;
+  return rows.map((row) => String(row.quick_check ?? Object.values(row)[0] ?? ""))
+    .filter((result) => result.toLowerCase() !== "ok");
+}
+
+function tableExists(db: SqliteDatabase, name: string): boolean {
+  return Boolean(db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+  ).get(name));
+}
+
+function readSchemaVersion(db: SqliteDatabase): number | null {
+  const row = db.prepare(
+    "SELECT version FROM schema_versions ORDER BY version DESC LIMIT 1",
+  ).get() as { version: number } | undefined;
+  return row && Number.isInteger(row.version) ? row.version : null;
+}
+
+function latestIndexedAt(files: FileRow[]): string | null {
+  const latest = Math.max(...files.map((file) => Number(file.indexed_at)).filter(Number.isFinite));
+  return Number.isFinite(latest) ? new Date(latest).toISOString() : null;
+}
+
+function metadataTimestamp(metadata: MetadataValue | undefined): string | null {
+  if (!metadata || !Number.isFinite(metadata.updatedAt)) return null;
+  return new Date(metadata.updatedAt).toISOString();
+}
+
+function inspectCurrentManifest(
+  projectRoot: string,
+  diagnostics: Diagnostic[],
+): ReturnType<typeof graphManifest> | null {
+  try {
+    return graphManifest(projectRoot);
+  } catch (error) {
+    diagnostics.push({
+      code: "GRAPH_MANIFEST_INSPECTION_FAILED",
+      severity: "warning",
+      message: `Could not inspect the current graph build manifest: ${errorMessage(error)}`,
+    });
+    return null;
+  }
+}
+
+async function inspectRepoState(
+  projectRoot: string,
+  observedAt: string,
+): Promise<RepoObservation> {
+  const env = { ...process.env, GIT_OPTIONAL_LOCKS: "0" };
+  try {
+    const result = await execFileAsync("git", [
+      "--no-optional-locks",
+      "-C",
+      projectRoot,
+      "status",
+      "--porcelain=v2",
+      "--branch",
+      "--untracked-files=normal",
+    ], {
+      cwd: projectRoot,
+      env,
+      encoding: "utf8",
+      timeout: 5_000,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+    let branch: string | null = null;
+    let head: string | null = null;
+    let dirty = false;
+    for (const line of result.stdout.split(/\r?\n/)) {
+      if (line.startsWith("# branch.head ")) {
+        const value = line.slice("# branch.head ".length);
+        branch = value === "(detached)" ? null : value || null;
+      } else if (line.startsWith("# branch.oid ")) {
+        const value = line.slice("# branch.oid ".length);
+        head = /^[0-9a-f]{40,64}$/i.test(value) ? value : null;
+      } else if (line !== "" && !line.startsWith("# ")) {
+        dirty = true;
+      }
+    }
+    return {
+      state: { branch, head, dirty, observedAt },
+      complete: true,
+      diagnostics: [],
+    };
+  } catch (error) {
+    const message = errorMessage(error);
+    if (/not a git repository/i.test(message)) {
+      return { state: emptyRepoState(observedAt), complete: true, diagnostics: [] };
+    }
+    return {
+      state: emptyRepoState(observedAt),
+      complete: false,
+      diagnostics: [{
+        code: "GRAPH_REPO_STATE_UNAVAILABLE",
+        severity: "info",
+        message: `Could not inspect Git working-tree state: ${message}`,
+      }],
+    };
+  }
+}
+
+function classifyDatabaseError(error: unknown, operation: string): ClassifiedError {
+  const message = errorMessage(error);
+  const code = errorCode(error);
+  const corrupt = error instanceof CorruptGraphIndexError
+    || /corrupt|malformed|not a database|file is encrypted|no such (?:table|column)/i.test(message)
+    || /CORRUPT|NOTADB/.test(code);
+  if (corrupt) {
+    return {
+      status: "corrupt",
+      diagnostic: {
+        code: "GRAPH_INDEX_CORRUPT",
+        severity: "error",
+        message: `Could not ${operation} the graph index: ${message}`,
+      },
+    };
+  }
+  return {
+    status: "degraded",
+    diagnostic: {
+      code: /busy|locked/i.test(`${code} ${message}`) ? "GRAPH_INDEX_LOCKED" : "GRAPH_INDEX_UNAVAILABLE",
+      severity: "warning",
+      message: `Could not ${operation} the graph index without mutation: ${message}`,
+      remediation: [{ label: "Retry graph status" }],
+    },
+  };
+}
+
+function rebuildDiagnostic(message: string, executable = true): Diagnostic {
+  return {
+    code: "GRAPH_INDEX_REBUILD_REQUIRED",
+    severity: "warning",
+    message,
+    remediation: executable ? [{ label: "Rebuild graph", command: "mex graph" }] : undefined,
+  };
+}
+
+function resolveNow(now: InspectGraphStatusOptions["now"]): Date {
+  const value = typeof now === "function" ? now() : now ?? new Date();
+  if (Number.isNaN(value.getTime())) throw new Error("inspectGraphStatus requires a valid clock value.");
+  return value;
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_MAX_CHANGED_PATHS;
+  if (!Number.isFinite(limit)) return DEFAULT_MAX_CHANGED_PATHS;
+  return Math.max(0, Math.floor(limit));
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function toPosix(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function diagnosticBasename(path: string): string {
+  const safe = basename(path).replace(/[\u0000-\u001f\u007f]/g, "?");
+  return safe.length <= 160 ? safe : `${safe.slice(0, 159)}…`;
+}
+
+function compareCodePoints(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function errorCode(error: unknown): string {
+  if (!isRecord(error)) return "";
+  return typeof error.code === "string" ? error.code : "";
+}

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -1,5 +1,9 @@
 import chalk from "chalk";
 import type { DriftReport, DriftIssue, Severity } from "./types.js";
+import type { GraphAwareDriftReport } from "./drift/index.js";
+import type { GraphStatus } from "./team/contracts/graph.js";
+
+type ReportableDriftReport = DriftReport & Partial<Pick<GraphAwareDriftReport, "graphStatus">>;
 
 const severityColor: Record<Severity, (s: string) => string> = {
   error: chalk.red,
@@ -13,7 +17,7 @@ const severityIcon: Record<Severity, string> = {
   info: "ℹ",
 };
 
-export function reportConsole(report: DriftReport): void {
+export function reportConsole(report: ReportableDriftReport): void {
   // Show score at top so it's visible before scrolling through issues
   if (report.issues.length > 0) {
     printSummary(report);
@@ -44,9 +48,10 @@ export function reportConsole(report: DriftReport): void {
   }
 
   printSummary(report);
+  printGraphStatus(report.graphStatus);
 }
 
-export function reportQuiet(report: DriftReport): void {
+export function reportQuiet(report: ReportableDriftReport): void {
   const errors = report.issues.filter((i) => i.severity === "error").length;
   const warnings = report.issues.filter(
     (i) => i.severity === "warning"
@@ -61,15 +66,16 @@ export function reportQuiet(report: DriftReport): void {
       : report.score >= 50
         ? chalk.yellow
         : chalk.red;
-  console.log(`mex: drift score ${color(`${report.score}/100`)}${detail}`);
+  const graph = report.graphStatus ? ` · ${graphStatusSummary(report.graphStatus)}` : "";
+  console.log(`mex: drift score ${color(`${report.score}/100`)}${detail}${graph}`);
 }
 
-export function reportJSON(report: DriftReport, opts?: { verbose?: boolean }): void {
+export function reportJSON(report: ReportableDriftReport, opts?: { verbose?: boolean }): void {
   const output = opts?.verbose ? report : { ...report, verboseLog: undefined };
   console.log(JSON.stringify(output, null, 2));
 }
 
-export function reportVerbose(report: DriftReport): void {
+export function reportVerbose(report: ReportableDriftReport): void {
   if (!report.verboseLog?.length) return;
   console.log(chalk.dim("── Verbose ──"));
   for (const line of report.verboseLog) {
@@ -97,6 +103,52 @@ function printSummary(report: DriftReport): void {
     )
   );
   console.log(chalk.dim(`${report.filesChecked} files checked`));
+}
+
+function printGraphStatus(graph: GraphStatus | undefined): void {
+  if (!graph) return;
+  console.log(chalk.dim(graphStatusSummary(graph)));
+  const visible = graph.diagnostics.slice(0, 3);
+  for (const diagnostic of visible) {
+    console.log(chalk.dim(`  ${diagnostic.code}: ${diagnostic.message}`));
+  }
+  if (graph.diagnostics.length > visible.length) {
+    console.log(chalk.dim(`  ${graph.diagnostics.length - visible.length} additional graph diagnostic(s) omitted`));
+  }
+}
+
+function graphStatusSummary(graph: GraphStatus): string {
+  return `graph ${graph.status} · ${graphChangeDetail(graph)}`;
+}
+
+/** Compact, truthful graph-drift detail shared by first-party text surfaces. */
+export function graphChangeDetail(graph: GraphStatus): string {
+  const changes = graph.changes;
+  const count = `${changes.total} source change${changes.total === 1 ? "" : "s"}`;
+  const breakdown = changes.truncated
+    ? "path details truncated"
+    : `${changes.added.length} added, ${changes.modified.length} modified, ${changes.deleted.length} deleted`;
+  const causes: string[] = [];
+  if (changes.branchChanged) causes.push("branch changed");
+  if (changes.configChanged) causes.push("config changed");
+  if (changes.grammarChanged) causes.push("grammar changed");
+  if (changes.manifestChanged && !changes.configChanged && !changes.grammarChanged) {
+    causes.push("build manifest changed");
+  }
+  const command = graphRemediationCommand(graph);
+  return `${count} (${breakdown})${causes.length > 0 ? ` · ${causes.join(" · ")}` : ""}${command ? ` · run \`${command}\`` : ""}`;
+}
+
+/** Return only a remediation command explicitly supplied by graph diagnostics. */
+export function graphRemediationCommand(graph: GraphStatus): string | undefined {
+  return graph.diagnostics
+    .flatMap((diagnostic) => diagnostic.remediation ?? [])
+    .find((action) => action.command)?.command;
+}
+
+export function graphPrimaryDiagnostic(graph: GraphStatus): string | undefined {
+  const diagnostic = graph.diagnostics[0];
+  return diagnostic ? `${diagnostic.code}: ${diagnostic.message}` : undefined;
 }
 
 function groupBySeverityThenFile(

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -239,14 +239,9 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   if (mode === "code-repo" && !dryRun) {
     try {
       info("Building code graph...");
-      const { createGraphEngine } = await import("../graph/index.js");
-      const graph = createGraphEngine({ rootDir: projectRoot });
-      try {
-        await graph.build();
-        ok("Code graph ready");
-      } finally {
-        graph.close();
-      }
+      const { rebuildGraph } = await import("../graph/maintenance.js");
+      await rebuildGraph(projectRoot);
+      ok("Code graph ready");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       warn(`Code graph unavailable — setup will continue: ${message}`);

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -1,12 +1,16 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { render, Box, Text, useApp, useInput } from "ink";
 import { stdin, stdout } from "node:process";
-import type { DriftReport, MexConfig } from "./types.js";
+import type { MexConfig } from "./types.js";
 import { findConfig } from "./config.js";
-import { runDriftCheck } from "./drift/index.js";
+import {
+  runDriftCheckWithGraphStatus,
+  type GraphAwareDriftReport,
+} from "./drift/index.js";
 import { checkHeartbeat, type HeartbeatResult } from "./heartbeat.js";
 import { appendEvent, readEvents, type EventEntry, type EventKind } from "./events.js";
 import { shouldShowInvite, recordInviteShown, INVITE_TEXT } from "./feedback/index.js";
+import { graphChangeDetail, graphPrimaryDiagnostic } from "./reporter.js";
 
 const h = React.createElement;
 
@@ -14,7 +18,7 @@ type View = "dashboard" | "check" | "heartbeat" | "doctor" | "timeline" | "log-k
 type LoadState = "loading" | "ready" | "error";
 
 export interface DashboardData {
-  report: DriftReport;
+  report: GraphAwareDriftReport;
   heartbeat: HeartbeatResult;
   events: EventEntry[];
 }
@@ -64,7 +68,7 @@ export function launchTui(): void {
 }
 
 export async function loadDashboard(config: MexConfig): Promise<DashboardData> {
-  const report = await runDriftCheck(config);
+  const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
   const heartbeat = checkHeartbeat(config);
   const events = readEvents(config).sort((a, b) => b.timestamp.localeCompare(a.timestamp));
   return { report, heartbeat, events };
@@ -237,6 +241,7 @@ export function Summary({ data, notice }: { data: DashboardData; notice: string 
   const heartbeatColor = data.heartbeat.ok ? "green" : "yellow";
   const heartbeatValue = data.heartbeat.ok ? 100 : Math.max(10, 100 - data.heartbeat.staleFiles.length * 25);
   const activity = eventActivityBars(data.events);
+  const graph = data.report.graphStatus;
   return h(Box, { flexDirection: "column" },
     notice ? h(Text, { color: "green" }, notice) : null,
     h(StatusLine, {
@@ -252,6 +257,13 @@ export function Summary({ data, notice }: { data: DashboardData; notice: string 
       bar: progressBar(heartbeatValue),
       color: heartbeatColor,
       detail: `${formatCount(data.heartbeat.staleFiles.length, "stale file")}`,
+    }),
+    h(StatusLine, {
+      label: "Graph",
+      value: graph.status === "fresh" ? "Fresh" : "Attention",
+      bar: progressBar(graph.status === "fresh" ? 100 : 35),
+      color: graph.status === "fresh" ? "green" : "yellow",
+      detail: `${graph.status} · ${graphChangeDetail(graph)}`,
     }),
     h(Text, null,
       h(Text, { color: COLORS.shell, bold: true }, "Events    "),
@@ -364,14 +376,18 @@ export function HeartbeatPanel({ data }: { data: DashboardData }) {
   );
 }
 
-function DoctorPanel({ data }: { data: DashboardData }) {
+export function DoctorPanel({ data }: { data: DashboardData }) {
   const errors = data.report.issues.filter((i) => i.severity === "error").length;
   const warnings = data.report.issues.filter((i) => i.severity === "warning").length;
-  const healthy = errors === 0 && data.heartbeat.ok;
+  const graphHealthy = data.report.graphStatus.status === "fresh";
+  const graphDiagnostic = graphPrimaryDiagnostic(data.report.graphStatus);
+  const healthy = errors === 0 && data.heartbeat.ok && graphHealthy;
   return h(Box, { flexDirection: "column" },
     h(Text, { bold: true }, "Doctor summary"),
     h(Text, { color: healthy ? "green" : "yellow" }, healthy ? "Scaffold looks healthy." : "Scaffold needs attention."),
     h(Text, null, `Drift ${data.report.score}/100 (${errors} errors, ${warnings} warnings)`),
+    h(Text, null, `Graph ${data.report.graphStatus.status} (${graphChangeDetail(data.report.graphStatus)})`),
+    graphDiagnostic ? h(Text, null, `Graph detail: ${graphDiagnostic}`) : null,
     h(Text, null, data.heartbeat.ok ? "Heartbeat OK" : "Run `mex heartbeat` for details."),
     h(Text, null, `${data.events.length} logged events`),
   );

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -217,7 +217,7 @@ describe("built CLI main-module guard", () => {
 
   beforeAll(() => {
     execSync("npm run build", { cwd: repoRoot, stdio: "pipe" });
-  });
+  }, 30_000);
 
   it("parses argv when invoked through a symlinked bin (npm/npx layout)", () => {
     const binDir = mkdtempSync(join(tmpdir(), "mex-bin-"));
@@ -271,7 +271,7 @@ describe("built CLI main-module guard", () => {
     } finally {
       rmSync(fixture, { recursive: true, force: true });
     }
-  });
+  }, 10_000);
 });
 
 describe("mex --version", () => {

--- a/test/graph-cli-freshness.test.ts
+++ b/test/graph-cli-freshness.test.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentCommandDeps } from "../src/graph/cli-agent.js";
+import {
+  runGraphGet,
+  runGraphQuery,
+  runGraphScope,
+  runImpact,
+} from "../src/graph/cli-agent.js";
+import { openSqlite } from "../src/graph/db/sqlite.js";
+import { createGraphEngine } from "../src/graph/engine-impl.js";
+import {
+  openImmutableGraphReadSession,
+  openImmutableGraphReadSessionSync,
+} from "../src/graph/read-session.js";
+import { inspectGraphStatusWithFreshObservation } from "../src/graph/status.js";
+
+const roots: string[] = [];
+
+interface Fixture {
+  root: string;
+  sourcePath: string;
+  dbPath: string;
+  nodeId: string;
+  original: string;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+async function fixture(prefix: string): Promise<Fixture> {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  mkdirSync(join(root, "src"), { recursive: true });
+  const sourcePath = join(root, "src", "service.ts");
+  const original = "export function stableFact(): string { return \"old\"; }\n";
+  writeFileSync(sourcePath, original);
+  const engine = createGraphEngine({ rootDir: root });
+  await engine.build();
+  const node = engine.searchNodes("stableFact").find((entry) => entry.name === "stableFact");
+  if (!node) throw new Error("fixture node missing");
+  engine.close();
+  const dbPath = join(root, ".mex", "graph.db");
+  removeEmptySidecars(dbPath);
+  return { root, sourcePath, dbPath, nodeId: node.id, original };
+}
+
+async function capture(command: (deps: AgentCommandDeps) => void | Promise<void>): Promise<Record<string, unknown>[]> {
+  const output: string[] = [];
+  await command({ write: (line) => output.push(line) });
+  return output.map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+function internalDeps(
+  output: string[],
+  internal: Record<string, unknown>,
+): AgentCommandDeps {
+  return {
+    write: (line) => output.push(line),
+    __internal: internal,
+  } as unknown as AgentCommandDeps;
+}
+
+function expectUnavailableOnly(records: Record<string, unknown>[], reason?: string): void {
+  expect(records).toHaveLength(1);
+  expect(records[0]).toMatchObject({
+    type: "error",
+    code: "GRAPH_UNAVAILABLE",
+    ...(reason ? { reasonCode: reason } : {}),
+  });
+  expect(records.some((record) => ["meta", "source", "result", "fact", "summary"].includes(String(record.type))))
+    .toBe(false);
+}
+
+describe("agent graph freshness-bound readers", () => {
+  it("makes Get, Query, and Impact abstain instead of pairing old nodes with changed live source", async () => {
+    const built = await fixture("mex-cli-stale-read-");
+    const fixed = new Date("2024-01-01T00:00:00.000Z");
+    const changed = built.original.replace("\"old\"", "\"new\"");
+    expect(Buffer.byteLength(changed)).toBe(Buffer.byteLength(built.original));
+    writeFileSync(built.sourcePath, changed);
+    utimesSync(built.sourcePath, fixed, fixed);
+
+    const get = await capture((deps) => runGraphGet([built.nodeId], built.root, deps));
+    const query = await capture((deps) => runGraphQuery(
+      "where-defined", "stableFact", built.root, deps, { detail: "source" },
+    ));
+    const impact = await capture((deps) => runImpact(
+      "stableFact", built.root, deps, { detail: "source" },
+    ));
+
+    for (const records of [get, query, impact]) {
+      expectUnavailableOnly(records, "GRAPH_SOURCE_CORPUS_MISMATCH");
+      expect(records[0]).toMatchObject({ graphStatus: "stale", recoveryCommand: "mex graph refresh" });
+      expect(JSON.stringify(records)).not.toContain("return \\\"new\\\"");
+    }
+  });
+
+  it("discards a fully prepared Get stream when source changes before final freshness validation", async () => {
+    const built = await fixture("mex-cli-mid-source-");
+    const output: string[] = [];
+    const fixed = new Date("2024-01-01T00:00:00.000Z");
+    const changed = built.original.replace("\"old\"", "\"new\"");
+    const deps = internalDeps(output, {
+      beforeFinalFreshnessValidation() {
+        writeFileSync(built.sourcePath, changed);
+        utimesSync(built.sourcePath, fixed, fixed);
+      },
+    });
+
+    await runGraphGet([built.nodeId], built.root, deps);
+
+    const records = output.map((line) => JSON.parse(line) as Record<string, unknown>);
+    expectUnavailableOnly(records, "GRAPH_SOURCE_CORPUS_MISMATCH");
+    expect(JSON.stringify(records)).not.toContain("return \\\"old\\\"");
+    expect(JSON.stringify(records)).not.toContain("return \\\"new\\\"");
+  });
+
+  it("rejects an A-to-B-to-A source ABA even when both freshness observations see A", async () => {
+    const built = await fixture("mex-cli-source-aba-");
+    const transient = built.original.replace("\"old\"", "\"new\"");
+    expect(Buffer.byteLength(transient)).toBe(Buffer.byteLength(built.original));
+    const output: string[] = [];
+    const observedStatuses: string[] = [];
+    let reachedFinalValidation = false;
+    const deps = internalDeps(output, {
+      freshRead: {
+        async inspectObservation(input: Parameters<typeof inspectGraphStatusWithFreshObservation>[0]) {
+          const inspection = await inspectGraphStatusWithFreshObservation(input);
+          observedStatuses.push(inspection.graphStatus.status);
+          return inspection;
+        },
+        hooks: {
+          beforeIndexedSourceRead() {
+            writeFileSync(built.sourcePath, transient);
+          },
+          afterIndexedSourceRead() {
+            writeFileSync(built.sourcePath, built.original);
+          },
+        },
+      },
+      beforeFinalFreshnessValidation() {
+        reachedFinalValidation = true;
+      },
+    });
+
+    await runGraphGet([built.nodeId], built.root, deps);
+
+    const records = output.map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(reachedFinalValidation).toBe(true);
+    expect(observedStatuses).toEqual(["fresh", "fresh"]);
+    expect(readFileSync(built.sourcePath, "utf8")).toBe(built.original);
+    expectUnavailableOnly(records, "GRAPH_SOURCE_CORPUS_MISMATCH");
+    expect(JSON.stringify(records)).not.toContain("return \\\"old\\\"");
+    expect(JSON.stringify(records)).not.toContain("return \\\"new\\\"");
+  });
+
+  it("refuses an immutable reader when WAL activity begins after the fresh observation", async () => {
+    const built = await fixture("mex-cli-wal-race-");
+    const output: string[] = [];
+    let writer: ReturnType<typeof openSqlite> | null = null;
+    let walSize = 0;
+    const deps = internalDeps(output, {
+      freshRead: {
+        afterStatusInspection() {
+          writer = openSqlite(built.dbPath);
+          writer.exec("PRAGMA wal_autocheckpoint = 0");
+          writer.prepare(
+            "UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'",
+          ).run(Date.now());
+          walSize = statSync(`${built.dbPath}-wal`).size;
+        },
+      },
+    });
+
+    try {
+      await runGraphQuery("where-defined", "stableFact", built.root, deps);
+      const records = output.map((line) => JSON.parse(line) as Record<string, unknown>);
+      expectUnavailableOnly(records, "GRAPH_INDEX_READER_SIDECAR_ACTIVITY");
+      expect(walSize).toBeGreaterThan(0);
+      expect(statSync(`${built.dbPath}-wal`).size).toBe(walSize);
+    } finally {
+      writer?.close();
+    }
+  });
+
+  it("rejects atomic database replacement between identity capture and immutable open", async () => {
+    const built = await fixture("mex-cli-db-replace-");
+    const replacementPath = join(built.root, ".mex", "replacement.db");
+    copyFileSync(built.dbPath, replacementPath);
+    const replacementBytes = readFileSync(replacementPath);
+    const output: string[] = [];
+    const deps = internalDeps(output, {
+      freshRead: {
+        hooks: {
+          afterDatabaseIdentityRead() {
+            renameSync(replacementPath, built.dbPath);
+          },
+        },
+      },
+    });
+
+    await runGraphGet([built.nodeId], built.root, deps);
+
+    const records = output.map((line) => JSON.parse(line) as Record<string, unknown>);
+    expectUnavailableOnly(records, "GRAPH_INDEX_READER_DATABASE_CHANGED");
+    expect(readFileSync(built.dbPath)).toEqual(replacementBytes);
+  });
+
+  it("binds SQLite to the inspected database across a path A-to-B-to-A swap", async () => {
+    const built = await fixture("mex-cli-db-aba-");
+    const originalPath = join(built.root, ".mex", "original.db");
+    const forgedPath = join(built.root, ".mex", "forged.db");
+    copyFileSync(built.dbPath, forgedPath);
+    const forged = openSqlite(forgedPath);
+    try {
+      const changed = forged.prepare("UPDATE nodes SET name = ? WHERE id = ?")
+        .run("forgedFact", built.nodeId);
+      expect(changed.changes).toBe(1);
+      forged.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } finally {
+      forged.close();
+    }
+    removeEmptySidecars(forgedPath);
+
+    const session = await openImmutableGraphReadSession(built.root, built.dbPath, {
+      deferPostOpenValidation: true,
+      afterDatabaseIdentityRead() {
+        renameSync(built.dbPath, originalPath);
+        renameSync(forgedPath, built.dbPath);
+      },
+      afterDatabaseOpen() {
+        renameSync(built.dbPath, forgedPath);
+        renameSync(originalPath, built.dbPath);
+      },
+    });
+    try {
+      expect(session.graph.getNode(built.nodeId)?.name).toBe("stableFact");
+    } finally {
+      session.close();
+    }
+  });
+
+  it("closes the bound database descriptor on every pre-open failure", async () => {
+    const built = await fixture("mex-cli-db-fd-cleanup-");
+    const inspection = await inspectGraphStatusWithFreshObservation({
+      projectRoot: built.root,
+      dbPath: built.dbPath,
+    });
+    expect(inspection.freshObservation).not.toBeNull();
+    let closed = 0;
+    const observedClose = () => { closed += 1; };
+
+    await expect(openImmutableGraphReadSession(built.root, built.dbPath, {
+      expectedObservation: {
+        ...inspection.freshObservation!,
+        databaseIdentity: "different-database-identity",
+      },
+      afterDatabaseDescriptorClose: observedClose,
+    })).rejects.toMatchObject({ code: "GRAPH_INDEX_READER_DATABASE_CHANGED" });
+    expect(closed).toBe(1);
+
+    await expect(openImmutableGraphReadSession(built.root, built.dbPath, {
+      afterDatabaseIdentityRead() {
+        throw new Error("injected identity-hook failure");
+      },
+      afterDatabaseDescriptorClose: observedClose,
+    })).rejects.toMatchObject({ code: "GRAPH_INDEX_READER_OPEN_FAILED" });
+    expect(closed).toBe(2);
+
+    await expect(openImmutableGraphReadSession(built.root, built.dbPath, {
+      inspectSidecars: () => ({ state: "active", paths: ["graph.db-wal"] }),
+      afterDatabaseDescriptorClose: observedClose,
+    })).rejects.toMatchObject({ code: "GRAPH_INDEX_READER_SIDECAR_ACTIVITY" });
+    expect(closed).toBe(3);
+
+    expect(() => openImmutableGraphReadSessionSync(built.root, built.dbPath, {
+      inspectSidecars: () => ({ state: "active", paths: ["graph.db-wal"] }),
+      afterDatabaseDescriptorClose: observedClose,
+    })).toThrow(expect.objectContaining({ code: "GRAPH_INDEX_READER_SIDECAR_ACTIVITY" }));
+    expect(closed).toBe(4);
+  });
+
+  it("keeps successful production reads and Scope filesystem-read-only", async () => {
+    const built = await fixture("mex-cli-readonly-");
+    const before = directorySnapshot(join(built.root, ".mex"));
+    const sourceBefore = fileIdentity(built.sourcePath);
+
+    const get = await capture((deps) => runGraphGet([built.nodeId], built.root, deps));
+    const query = await capture((deps) => runGraphQuery("where-defined", "stableFact", built.root, deps));
+    const scope = await capture((deps) => runGraphScope("stableFact", built.root, deps));
+
+    expect(get.some((record) => record.type === "source")).toBe(true);
+    expect(query.some((record) => record.type === "result")).toBe(true);
+    expect(scope.some((record) => record.type === "source")).toBe(true);
+    expect(directorySnapshot(join(built.root, ".mex"))).toEqual(before);
+    expect(fileIdentity(built.sourcePath)).toEqual(sourceBefore);
+    expect(existsSync(`${built.dbPath}-wal`)).toBe(false);
+    expect(existsSync(`${built.dbPath}-shm`)).toBe(false);
+  });
+
+  it("uses the indexer's UTF-8 decoding semantics for an invalid source byte", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-cli-invalid-utf8-"));
+    roots.push(root);
+    mkdirSync(join(root, "src"), { recursive: true });
+    const sourcePath = join(root, "src", "invalid.ts");
+    writeFileSync(sourcePath, Buffer.concat([
+      Buffer.from("export function invalidUtf8Fact(): string { return \"ok\"; }\n// invalid: "),
+      Buffer.from([0xff]),
+      Buffer.from("\n"),
+    ]));
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const node = engine.searchNodes("invalidUtf8Fact")
+      .find((entry) => entry.name === "invalidUtf8Fact");
+    engine.close();
+    expect(node).toBeDefined();
+    removeEmptySidecars(join(root, ".mex", "graph.db"));
+
+    const records = await capture((deps) => runGraphGet([node!.id], root, deps));
+
+    expect(records.some((record) => record.type === "source")).toBe(true);
+    expect(records.some((record) => record.type === "error")).toBe(false);
+  });
+
+  it("does not suggest graph mutation when a missing index has unsafe build prerequisites", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-cli-unsafe-missing-"));
+    const external = mkdtempSync(join(tmpdir(), "mex-cli-unsafe-config-"));
+    roots.push(root, external);
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(join(root, "src", "entry.ts"), "export const entry = 1;\n");
+    writeFileSync(join(external, "package.json"), "{\"name\":\"outside\"}\n");
+    const manifestPath = join(root, "package.json");
+    symlinkSync(join(external, "package.json"), manifestPath);
+
+    const records = await capture((deps) => runGraphGet(["function:missing"], root, deps));
+
+    expectUnavailableOnly(records);
+    expect(records[0]).toMatchObject({ graphStatus: "missing" });
+    expect(records[0]).not.toHaveProperty("recoveryCommand");
+    unlinkSync(manifestPath);
+  });
+});
+
+function removeEmptySidecars(dbPath: string): void {
+  for (const suffix of ["-wal", "-shm"]) {
+    const path = `${dbPath}${suffix}`;
+    if (existsSync(path) && statSync(path).size === 0) rmSync(path, { force: true });
+  }
+}
+
+function fileIdentity(path: string): Record<string, unknown> {
+  const stat = statSync(path);
+  return {
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+    hash: createHash("sha256").update(readFileSync(path)).digest("hex"),
+  };
+}
+
+function directorySnapshot(path: string): Record<string, ReturnType<typeof fileIdentity>> {
+  return Object.fromEntries(readdirSync(path).sort().map((name) => [name, fileIdentity(join(path, name))]));
+}

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -1,14 +1,41 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MexConfig } from "../src/types.js";
-import { runDriftCheck } from "../src/drift/index.js";
+import { runDriftCheckWithGraphStatus } from "../src/drift/index.js";
 import { createGraphEngine } from "../src/graph/engine-impl.js";
-import { loadGroundingRuntime, persistMovedGroundings, refreshGroundingBaselines } from "../src/graph/runtime.js";
+import {
+  loadGroundingRuntime,
+  loadReadOnlyGroundingRuntime,
+  persistMovedGroundings,
+  refreshGroundingBaselines,
+  type GroundingRuntime,
+} from "../src/graph/runtime.js";
 import { extractGroundings, writeGroundings } from "../src/markdown.js";
 import { buildCombinedBrief } from "../src/sync/brief-builder.js";
 import { serializeFingerprint } from "../src/graph/fingerprint.js";
+import { openSqlite } from "../src/graph/db/sqlite.js";
+import {
+  inspectGraphSidecars,
+  inspectGraphStatus,
+  inspectGraphStatusWithFreshObservation,
+} from "../src/graph/status.js";
+import { GRAPH_SNAPSHOT_METADATA_KEY } from "../src/graph/snapshot.js";
+import type { GraphStatus, GraphStatusKind } from "../src/team/contracts/graph.js";
+import { runDoctor } from "../src/doctor.js";
+import { loadDashboard } from "../src/tui.js";
 
 const roots: string[] = [];
 
@@ -24,11 +51,251 @@ function fixture(): { root: string; config: MexConfig; source: string; scaffold:
   return { root, source, scaffold, config: { projectRoot: root, scaffoldRoot: join(root, ".mex"), aiTools: [] } };
 }
 
+function graphPersistenceSnapshot(root: string) {
+  const dbPath = join(root, ".mex", "graph.db");
+  const db = openSqlite(dbPath, { readOnly: true, immutable: true });
+  try {
+    return {
+      bytes: readFileSync(dbPath),
+      mtimeMs: statSync(dbPath).mtimeMs,
+      metadata: db.prepare(
+        "SELECT key, value, updated_at FROM project_metadata ORDER BY key",
+      ).all(),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+type FilesystemSnapshotEntry =
+  | { path: string; kind: "directory"; mtimeMs: number }
+  | { path: string; kind: "file"; bytes: Buffer; mtimeMs: number };
+
+function filesystemSnapshot(root: string): FilesystemSnapshotEntry[] {
+  const records: FilesystemSnapshotEntry[] = [{
+    path: ".",
+    kind: "directory",
+    mtimeMs: statSync(root).mtimeMs,
+  }];
+  const visit = (directory: string) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const absolute = join(directory, entry.name);
+      const path = absolute.slice(root.length + 1);
+      if (entry.isDirectory()) {
+        records.push({ path, kind: "directory", mtimeMs: statSync(absolute).mtimeMs });
+        visit(absolute);
+      } else if (entry.isFile()) {
+        records.push({
+          path,
+          kind: "file",
+          bytes: readFileSync(absolute),
+          mtimeMs: statSync(absolute).mtimeMs,
+        });
+      }
+    }
+  };
+  visit(root);
+  return records.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function graphStatus(status: GraphStatusKind): GraphStatus {
+  return {
+    status,
+    observedAt: "2026-08-22T00:00:00.000Z",
+    currentRepo: {
+      branch: null,
+      head: null,
+      dirty: false,
+      observedAt: "2026-08-22T00:00:00.000Z",
+    },
+    lastSuccessfulIndexAt: null,
+    indexedAt: null,
+    indexedBranch: null,
+    indexedHead: null,
+    schemaVersion: null,
+    extractorVersion: null,
+    grammarVersion: null,
+    parseHealth: {
+      total: 0,
+      ok: 0,
+      partial: 0,
+      failed: 0,
+      failedPaths: [],
+      failedPathsTruncated: false,
+    },
+    changes: {
+      total: 0,
+      added: [],
+      modified: [],
+      deleted: [],
+      truncated: false,
+      branchChanged: false,
+      manifestChanged: false,
+      configChanged: false,
+      grammarChanged: false,
+    },
+    diagnostics: [],
+  };
+}
+
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
 describe("code-graph grounding integration", () => {
+  it("inspects status unconditionally without opening grounding readers when irrelevant", async () => {
+    const { config } = fixture();
+    const missing = graphStatus("missing");
+    const loader = vi.fn(async () => ({ graphStatus: missing, runtime: null }));
+    const warning = vi.fn();
+
+    const report = await runDriftCheckWithGraphStatus(config, {
+      scaffoldPatterns: ["ROUTER.md"],
+      readOnlyGroundingRuntimeLoader: loader,
+      graphWarning: warning,
+    });
+
+    expect(loader).toHaveBeenCalledWith(config, { loadRuntime: false });
+    expect(report.graphStatus).toEqual(missing);
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("leaves graph-aware output to first-party renderers unless a warning sink is supplied", async () => {
+    const { config } = fixture();
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const report = await runDriftCheckWithGraphStatus(config, {
+      readOnlyGroundingRuntimeLoader: async () => ({
+        graphStatus: graphStatus("missing"),
+        runtime: null,
+      }),
+    });
+
+    expect(report.graphStatus.status).toBe("missing");
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("does not invent graph commands when status says maintenance is unsafe", async () => {
+    const { config } = fixture();
+    const warning = vi.fn();
+    const missing: GraphStatus = {
+      ...graphStatus("missing"),
+      diagnostics: [{
+        code: "GRAPH_REPO_UNAVAILABLE",
+        severity: "warning",
+        message: "Repository provenance could not be inspected safely.",
+      }],
+    };
+
+    await runDriftCheckWithGraphStatus(config, {
+      readOnlyGroundingRuntimeLoader: async () => ({ graphStatus: missing, runtime: null }),
+      groundingRuntimeLoader: async () => null,
+      graphWarning: warning,
+    });
+
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("GRAPH_REPO_UNAVAILABLE"));
+    expect(warning).not.toHaveBeenCalledWith(expect.stringContaining("Run `mex graph`"));
+  });
+
+  it("abstains before opening SQLite when the inspected graph is not fresh", async () => {
+    const { config } = fixture();
+    const stale = graphStatus("stale");
+    const result = await loadReadOnlyGroundingRuntime(config, {
+      inspectStatus: async () => stale,
+    });
+
+    expect(result).toEqual({ graphStatus: stale, runtime: null });
+  });
+
+  it("drops immutable readers when SQLite recovery activity starts during open", async () => {
+    const { root, source, config } = fixture();
+    writeFileSync(source, "export function stableGrounding(): number { return 1; }\n");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    const inspectSidecars = vi.fn()
+      .mockReturnValueOnce({ state: "clear" as const, paths: [] })
+      .mockReturnValueOnce({ state: "active" as const, paths: ["graph.db-wal"] });
+
+    const result = await loadReadOnlyGroundingRuntime(config, { inspectSidecars });
+
+    expect(inspectSidecars).toHaveBeenCalledTimes(2);
+    expect(result.runtime).toBeNull();
+    expect(result.graphStatus.status).toBe("degraded");
+    expect(result.graphStatus.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "GRAPH_INDEX_READER_SIDECAR_ACTIVITY" }),
+    ]));
+  });
+
+  it("drops immutable readers whose snapshot identity differs from fresh status", async () => {
+    const { root, source, config } = fixture();
+    writeFileSync(source, "export function stableGrounding(): number { return 1; }\n");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    const dbPath = join(root, ".mex", "graph.db");
+    const inspected = await inspectGraphStatusWithFreshObservation({ projectRoot: root, dbPath });
+    expect(inspected.graphStatus.status).toBe("fresh");
+    expect(inspected.freshObservation).not.toBeNull();
+    const mismatched: GraphStatus = {
+      ...inspected.graphStatus,
+      indexedHead: "a".repeat(40),
+    };
+    const inspectSidecars = vi.fn(() => ({ state: "clear" as const, paths: [] }));
+
+    const result = await loadReadOnlyGroundingRuntime(config, {
+      inspectSidecars,
+      __internal: {
+        inspectObservation: async () => ({
+          ...inspected,
+          graphStatus: mismatched,
+        }),
+      },
+    } as unknown as Parameters<typeof loadReadOnlyGroundingRuntime>[1]);
+
+    expect(inspectSidecars).toHaveBeenCalledTimes(1);
+    expect(result.runtime).toBeNull();
+    expect(result.graphStatus.status).toBe("degraded");
+    expect(result.graphStatus.diagnostics).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "GRAPH_INDEX_READER_SNAPSHOT_CHANGED" }),
+    ]));
+  });
+
+  it("rebuilds mutating grounding state from exact bytes despite restored size and mtime", async () => {
+    const { root, source, config } = fixture();
+    const original = "export function oldBodyFact(): number { return 1; }\n";
+    const replacement = "export function newBodyFact(): number { return 2; }\n";
+    const fixedTime = new Date("2024-01-01T00:00:00.000Z");
+    expect(Buffer.byteLength(replacement)).toBe(Buffer.byteLength(original));
+    writeFileSync(source, original);
+    utimesSync(source, fixedTime, fixedTime);
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+
+    writeFileSync(source, replacement);
+    utimesSync(source, fixedTime, fixedTime);
+    expect(statSync(source).mtimeMs).toBe(fixedTime.getTime());
+
+    const runtime = await loadGroundingRuntime(config);
+    expect(runtime).not.toBeNull();
+    expect(runtime!.graph.searchNodes("oldBodyFact").some((node) => node.name === "oldBodyFact"))
+      .toBe(false);
+    expect(runtime!.graph.searchNodes("newBodyFact").some((node) => node.name === "newBodyFact"))
+      .toBe(true);
+    runtime!.close();
+
+    const db = openSqlite(join(root, ".mex", "graph.db"), { readOnly: true, immutable: true });
+    try {
+      const grounded = db.prepare("SELECT COUNT(*) AS count FROM _mex_grounded_source")
+        .get() as { count: number };
+      expect(grounded.count).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
   it("builds fingerprints, detects body drift, re-grounds, and durably rewrites MOVED", async () => {
     const { root, source, scaffold, config } = fixture();
     const original = `export function calculateOrderTotal(items: number[]): number {\n  const subtotal = items.reduce((sum, item) => sum + item, 0);\n  const tax = subtotal * 0.18;\n  const shipping = subtotal > 1000 ? 0 : 75;\n  const discount = items.length > 5 ? subtotal * 0.05 : 0;\n  return subtotal + tax + shipping - discount;\n}\n`;
@@ -57,9 +324,22 @@ describe("code-graph grounding integration", () => {
       "subtotal > 1000 ? 0 : 75",
       "Math.max(0, 75 - subtotal * 0.05)",
     ));
-    let report = await runDriftCheck(config);
-    expect(report.issues.filter((issue) => issue.code === "GROUNDING_DRIFT")).toHaveLength(1);
+    const beforeCheck = graphPersistenceSnapshot(root);
+    const warning = vi.fn();
+    let report = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(report.graphStatus?.status).toBe("stale");
+    expect(report.issues.filter((issue) => issue.code === "GROUNDING_DRIFT")).toHaveLength(0);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph`"));
+    expect(graphPersistenceSnapshot(root)).toEqual(beforeCheck);
 
+    // Explicitly mutating workflows retain the existing correctness-first sync.
+    runtime = await loadGroundingRuntime(config);
+    runtime!.close();
+    const beforeFreshCheck = graphPersistenceSnapshot(root);
+    report = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(report.graphStatus?.status).toBe("fresh");
+    expect(report.issues.filter((issue) => issue.code === "GROUNDING_DRIFT")).toHaveLength(1);
+    expect(graphPersistenceSnapshot(root)).toEqual(beforeFreshCheck);
     runtime = await loadGroundingRuntime(config);
     const bodyRepairBrief = await buildCombinedBrief([{
       file: ".mex/context/architecture.md", gitDiff: null,
@@ -73,7 +353,8 @@ describe("code-graph grounding integration", () => {
     runtime!.close();
     const refreshedContent = readFileSync(scaffold, "utf-8");
     expect(extractGroundings(refreshedContent)[0].fingerprint).not.toBe(initialFingerprint);
-    report = await runDriftCheck(config);
+    report = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(report.graphStatus?.status).toBe("fresh");
     expect(report.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toHaveLength(0);
 
     writeFileSync(source, readFileSync(source, "utf-8").replace("calculateOrderTotal", "computeOrderTotal"));
@@ -112,9 +393,10 @@ describe("code-graph grounding integration", () => {
     const persistedContent = readFileSync(scaffold, "utf-8");
     expect(persistedContent).not.toContain(`mex://${node.id}`);
     expect(persistedContent).toContain(`mex://${persisted[0].node}`);
-    report = await runDriftCheck(config);
+    report = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(report.graphStatus?.status).toBe("fresh");
     expect(report.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toHaveLength(0);
-  }, 10_000);
+  }, 20_000);
 
   it("keeps legacy checks running when the graph engine fails to load", async () => {
     const { scaffold, config } = fixture();
@@ -122,7 +404,7 @@ describe("code-graph grounding integration", () => {
       node: "function:missing", fingerprint: "mh:64:00",
     }]));
     const warning = vi.fn();
-    const report = await runDriftCheck(config, {
+    const report = await runDriftCheckWithGraphStatus(config, {
       groundingRuntimeLoader: async () => { throw new Error("simulated WASM load failure"); },
       graphWarning: warning,
       verbose: true,
@@ -131,5 +413,282 @@ describe("code-graph grounding integration", () => {
     expect(report.issues.some((issue) => issue.code.startsWith("GROUNDING_"))).toBe(false);
     expect(report.verboseLog).toContain("Checker paths: 0 issues");
     expect(warning).toHaveBeenCalledWith(expect.stringContaining("simulated WASM load failure"));
+  });
+
+  it("closes the read-only runtime when a grounding checker throws", async () => {
+    const { scaffold, config } = fixture();
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{
+      node: "function:throws",
+      fingerprint: "mh:64:00",
+    }]));
+    const close = vi.fn();
+    const runtime = {
+      checker: () => { throw new Error("simulated checker failure"); },
+      close,
+    } as unknown as GroundingRuntime;
+
+    await expect(runDriftCheckWithGraphStatus(config, {
+      readOnlyGroundingRuntimeLoader: async () => ({
+        graphStatus: graphStatus("fresh"),
+        runtime,
+      }),
+      graphWarning: vi.fn(),
+    })).rejects.toThrow("simulated checker failure");
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes WAL state on the canonical target of a contained graph symlink", async () => {
+    const { root, config, source } = fixture();
+    writeFileSync(source, "export const service = 1;\n");
+    const graphPath = join(root, ".mex", "graph.db");
+    const targetPath = join(root, ".mex", "graph-target.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    renameSync(graphPath, targetPath);
+    symlinkSync("graph-target.db", graphPath);
+    const fresh = await inspectGraphStatus({ projectRoot: root });
+    expect(fresh.status).toBe("fresh");
+
+    let writer: ReturnType<typeof openSqlite> | null = null;
+    try {
+      const loaded = await loadReadOnlyGroundingRuntime(config, {
+        __internal: {
+          afterStatusInspection() {
+            writer = openSqlite(targetPath);
+            writer.exec("PRAGMA wal_autocheckpoint = 0");
+            writer.prepare("UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'")
+              .run(Date.now());
+          },
+        },
+      } as unknown as Parameters<typeof loadReadOnlyGroundingRuntime>[1]);
+      expect(loaded.runtime).toBeNull();
+      expect(loaded.graphStatus.status).toBe("degraded");
+      expect(loaded.graphStatus.diagnostics).toContainEqual(expect.objectContaining({
+        code: "GRAPH_INDEX_READER_SIDECAR_ACTIVITY",
+      }));
+    } finally {
+      writer?.close();
+    }
+  });
+
+  it("rejects a graph that commits and checkpoints between immutable reader probes", async () => {
+    const { root, config, source } = fixture();
+    writeFileSync(source, "export const service = 1;\n");
+    const graphPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    const fresh = await inspectGraphStatus({ projectRoot: root });
+    expect(fresh.status).toBe("fresh");
+    let probes = 0;
+
+    const loaded = await loadReadOnlyGroundingRuntime(config, {
+      inspectSidecars(path) {
+        probes += 1;
+        if (probes === 2) {
+          const writer = openSqlite(graphPath);
+          try {
+            writer.prepare("UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'")
+              .run(Date.now());
+            writer.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+          } finally {
+            writer.close();
+          }
+        }
+        return inspectGraphSidecars(path);
+      },
+    });
+
+    expect(probes).toBe(2);
+    expect(loaded.runtime).toBeNull();
+    expect(loaded.graphStatus.status).toBe("degraded");
+    expect(loaded.graphStatus.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+    }));
+  });
+
+  it("rejects an atomically replaced database whose public status fields still match", async () => {
+    const { root, config, source } = fixture();
+    writeFileSync(source, "export const service = 1;\n");
+    const graphPath = join(root, ".mex", "graph.db");
+    const replacementPath = join(root, ".mex", "graph-replacement.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+
+    writeFileSync(replacementPath, readFileSync(graphPath));
+    const replacement = openSqlite(replacementPath);
+    try {
+      const row = replacement.prepare(
+        "SELECT value FROM project_metadata WHERE key = ?",
+      ).get(GRAPH_SNAPSHOT_METADATA_KEY) as { value: string };
+      const originalSnapshot = JSON.parse(row.value) as Record<string, unknown>;
+      const forged = {
+        ...originalSnapshot,
+        manifestHash: "a".repeat(64),
+        configHash: "b".repeat(64),
+        compilerVersion: "forged-private-compiler",
+        resolverVersion: "forged-private-resolver",
+        semanticInputs: [{ path: "private-compiler.json", contentHash: null }],
+      };
+      expect(forged).toMatchObject({
+        version: originalSnapshot.version,
+        indexedAt: originalSnapshot.indexedAt,
+        lastSuccessfulIndexAt: originalSnapshot.lastSuccessfulIndexAt,
+        indexedBranch: originalSnapshot.indexedBranch,
+        indexedHead: originalSnapshot.indexedHead,
+        schemaVersion: originalSnapshot.schemaVersion,
+        extractorVersion: originalSnapshot.extractorVersion,
+        grammarHash: originalSnapshot.grammarHash,
+        sourceCorpusDigest: originalSnapshot.sourceCorpusDigest,
+        sourceCount: originalSnapshot.sourceCount,
+        parseHealth: originalSnapshot.parseHealth,
+      });
+      replacement.prepare(
+        "UPDATE project_metadata SET value = ? WHERE key = ?",
+      ).run(JSON.stringify(forged), GRAPH_SNAPSHOT_METADATA_KEY);
+      replacement.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } finally {
+      replacement.close();
+    }
+    expect(inspectGraphSidecars(replacementPath).state).toBe("clear");
+
+    let openedReader: ReturnType<typeof openSqlite> | null = null;
+    let replaced = false;
+    const loaded = await loadReadOnlyGroundingRuntime(config, {
+      __internal: {
+        afterDatabaseIdentityRead() {
+          renameSync(replacementPath, graphPath);
+          replaced = true;
+        },
+        afterDatabaseOpen(database) {
+          openedReader = database;
+        },
+      },
+    } as unknown as Parameters<typeof loadReadOnlyGroundingRuntime>[1]);
+
+    expect(replaced).toBe(true);
+    expect(loaded.runtime).toBeNull();
+    expect(loaded.graphStatus.status).toBe("degraded");
+    expect(loaded.graphStatus.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+    }));
+    expect(openedReader).not.toBeNull();
+    expect(openedReader!.open).toBe(false);
+  });
+
+  it("discards grounding results when the graph changes after the loader returns", async () => {
+    const { root, config, source, scaffold } = fixture();
+    writeFileSync(source, "export const service = 1;\n");
+    const graphPath = join(root, ".mex", "graph.db");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    const loaded = await loadReadOnlyGroundingRuntime(config);
+    expect(loaded.runtime).not.toBeNull();
+
+    const writer = openSqlite(graphPath);
+    try {
+      writer.prepare("UPDATE project_metadata SET updated_at = ? WHERE key = 'manifest_hash'")
+        .run(Date.now());
+      writer.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    } finally {
+      writer.close();
+    }
+
+    const issues = loaded.runtime!.checker(
+      null,
+      scaffold,
+      ".mex/context/architecture.md",
+      root,
+      join(root, ".mex"),
+    );
+    expect(issues).toEqual([]);
+    expect(loaded.graphStatus.status).toBe("degraded");
+    expect(loaded.graphStatus.diagnostics).toContainEqual(expect.objectContaining({
+      code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+      message: expect.stringContaining("results were discarded"),
+    }));
+    loaded.runtime!.close();
+  });
+
+  it("discards the whole grounding batch when a later file observes graph replacement", async () => {
+    const { root, config, scaffold } = fixture();
+    const secondScaffold = join(root, ".mex", "context", "stack.md");
+    const grounding = [{ node: "function:service", fingerprint: "mh:64:00" }];
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), grounding));
+    writeFileSync(secondScaffold, writeGroundings("# Stack\n", grounding));
+    const fresh = graphStatus("fresh");
+    fresh.diagnostics.push({
+      code: "GRAPH_INDEX_HEAD_CHANGED",
+      severity: "info",
+      message: "The checkout HEAD differs but source contents still match.",
+    });
+    const close = vi.fn();
+    const checker = vi.fn((_frontmatter, _filePath, source: string) => {
+      if (checker.mock.calls.length === 1) {
+        return [{
+          code: "GROUNDING_DRIFT",
+          severity: "warning" as const,
+          file: source,
+          line: null,
+          message: "Finding derived from the original graph snapshot.",
+        }];
+      }
+      fresh.status = "degraded";
+      fresh.diagnostics.push({
+        code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
+        severity: "warning",
+        message: "The graph changed while grounding checks were running; graph-derived results were discarded.",
+      });
+      return [];
+    });
+    const runtime = { checker, close } as unknown as GroundingRuntime;
+    const warning = vi.fn();
+
+    const report = await runDriftCheckWithGraphStatus(config, {
+      scaffoldPatterns: ["context/*.md"],
+      readOnlyGroundingRuntimeLoader: async () => ({ graphStatus: fresh, runtime }),
+      graphWarning: warning,
+    });
+
+    expect(checker).toHaveBeenCalledTimes(2);
+    expect(report.graphStatus.status).toBe("degraded");
+    expect(report.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toEqual([]);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("results were discarded"));
+    expect(warning).not.toHaveBeenCalledWith(expect.stringContaining("checkout HEAD differs"));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps doctor and dashboard graph inspection filesystem-read-only", async () => {
+    const { root, source, config } = fixture();
+    writeFileSync(source, "export function service(): string { return 'v1'; }\n");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    writeFileSync(source, "export function service(): string { return 'v2'; }\n");
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      const beforeDoctor = filesystemSnapshot(join(root, ".mex"));
+      await runDoctor(config);
+      expect(filesystemSnapshot(join(root, ".mex"))).toEqual(beforeDoctor);
+      expect(log.mock.calls.flat().join("\n")).toContain("stale; 1 source change");
+      expect(warning).not.toHaveBeenCalled();
+
+      const beforeDashboard = filesystemSnapshot(join(root, ".mex"));
+      const dashboard = await loadDashboard(config);
+      expect(dashboard.report.graphStatus.status).toBe("stale");
+      expect(dashboard.report.graphStatus.changes.total).toBe(1);
+      expect(filesystemSnapshot(join(root, ".mex"))).toEqual(beforeDashboard);
+      expect(warning).not.toHaveBeenCalled();
+    } finally {
+      process.exitCode = previousExitCode;
+    }
   });
 });

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -329,7 +329,7 @@ describe("code-graph grounding integration", () => {
     let report = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
     expect(report.graphStatus?.status).toBe("stale");
     expect(report.issues.filter((issue) => issue.code === "GROUNDING_DRIFT")).toHaveLength(0);
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph`"));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph refresh`"));
     expect(graphPersistenceSnapshot(root)).toEqual(beforeCheck);
 
     // Explicitly mutating workflows retain the existing correctness-first sync.
@@ -573,7 +573,7 @@ describe("code-graph grounding integration", () => {
     expect(loaded.runtime).toBeNull();
     expect(loaded.graphStatus.status).toBe("degraded");
     expect(loaded.graphStatus.diagnostics).toContainEqual(expect.objectContaining({
-      code: "GRAPH_INDEX_READER_SNAPSHOT_CHANGED",
+      code: "GRAPH_INDEX_READER_DATABASE_CHANGED",
     }));
     expect(openedReader).not.toBeNull();
     expect(openedReader!.open).toBe(false);

--- a/test/graph-migration.test.ts
+++ b/test/graph-migration.test.ts
@@ -7,7 +7,7 @@ import { buildGroundMigrationPrompt, runGraphGround } from "../src/graph/cli-gro
 import { createGraphEngine } from "../src/graph/engine-impl.js";
 import { runGraphScope } from "../src/graph/cli-agent.js";
 import { extractGroundings, findMexAnchors, writeGroundings } from "../src/markdown.js";
-import { runDriftCheck } from "../src/drift/index.js";
+import { runDriftCheckWithGraphStatus } from "../src/drift/index.js";
 import { loadGroundingRuntime } from "../src/graph/runtime.js";
 
 const roots: string[] = [];
@@ -116,12 +116,21 @@ describe("pre-0.7 graph grounding migration", () => {
     const source = join(root, "src", "checkout.ts");
     writeFileSync(source, readFileSync(source, "utf-8")
       .replace("subtotal >= 100 ? 0 : 12", "subtotal >= 125 ? 0 : 15"));
-    const drift = await runDriftCheck(config);
+    const warning = vi.fn();
+    let drift = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(drift.graphStatus?.status).toBe("stale");
+    expect(drift.issues.some((issue) => issue.code.startsWith("GROUNDING_"))).toBe(false);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph`"));
+
+    const refreshRuntime = await loadGroundingRuntime(config);
+    refreshRuntime!.close();
+    drift = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
+    expect(drift.graphStatus?.status).toBe("fresh");
     expect(drift.issues).toContainEqual(expect.objectContaining({
       code: "GROUNDING_DRIFT",
       file: ".mex/patterns/checkout.md",
     }));
-  });
+  }, 30_000);
 
   it("requires a built graph", async () => {
     const { config } = fixture();
@@ -133,14 +142,14 @@ describe("pre-0.7 graph grounding migration", () => {
   it("nudges populated ungrounded scaffolds through graph build then migration", async () => {
     const { root, config } = fixture();
     const warning = vi.fn();
-    await runDriftCheck(config, { groundingRuntimeLoader: async () => null, graphWarning: warning });
+    await runDriftCheckWithGraphStatus(config, { groundingRuntimeLoader: async () => null, graphWarning: warning });
     expect(warning).toHaveBeenCalledWith(expect.stringContaining("mex graph`, then `mex graph ground"));
 
     const engine = createGraphEngine({ rootDir: root });
     await engine.build();
     engine.close();
     const runtime = await import("../src/graph/runtime.js").then(({ loadGroundingRuntime }) => loadGroundingRuntime(config));
-    await runDriftCheck(config, { groundingRuntimeLoader: async () => runtime, graphWarning: warning });
+    await runDriftCheckWithGraphStatus(config, { groundingRuntimeLoader: async () => runtime, graphWarning: warning });
     expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph ground` to connect it"));
-  });
+  }, 10_000);
 });

--- a/test/graph-migration.test.ts
+++ b/test/graph-migration.test.ts
@@ -120,7 +120,7 @@ describe("pre-0.7 graph grounding migration", () => {
     let drift = await runDriftCheckWithGraphStatus(config, { graphWarning: warning });
     expect(drift.graphStatus?.status).toBe("stale");
     expect(drift.issues.some((issue) => issue.code.startsWith("GROUNDING_"))).toBe(false);
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph`"));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("Run `mex graph refresh`"));
 
     const refreshRuntime = await loadGroundingRuntime(config);
     refreshRuntime!.close();
@@ -143,7 +143,7 @@ describe("pre-0.7 graph grounding migration", () => {
     const { root, config } = fixture();
     const warning = vi.fn();
     await runDriftCheckWithGraphStatus(config, { groundingRuntimeLoader: async () => null, graphWarning: warning });
-    expect(warning).toHaveBeenCalledWith(expect.stringContaining("mex graph`, then `mex graph ground"));
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("mex graph rebuild`, then `mex graph ground"));
 
     const engine = createGraphEngine({ rootDir: root });
     await engine.build();

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -10,7 +10,7 @@
  * the doc.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as publicApi from "../src/index.js";
@@ -267,8 +267,10 @@ describe("public API — runDriftCheck", () => {
 
   it("includes a primary diagnostic when the stripped public report has no repair command", async () => {
     mkdirSync(join(tmpDir, ".mex/context"), { recursive: true });
+    mkdirSync(join(tmpDir, "src"), { recursive: true });
     writeFileSync(join(tmpDir, ".mex/context/architecture.md"), "# Architecture\n\nExisting context.\n");
     writeFileSync(join(tmpDir, ".mex/graph.db"), "not a sqlite database");
+    symlinkSync(tmpdir(), join(tmpDir, "src/unsafe.ts"), "dir");
     const warnings: string[] = [];
 
     const report = await runDriftCheck(config, {

--- a/test/public-api.test.ts
+++ b/test/public-api.test.ts
@@ -9,10 +9,11 @@
  * Any change here is a breaking change — bump the major version and update
  * the doc.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import * as publicApi from "../src/index.js";
 
 import {
   // functions
@@ -75,6 +76,7 @@ describe("public API — function exports", () => {
     expect(typeof findConfig).toBe("function");
     expect(typeof createConfig).toBe("function");
     expect(typeof getScaffoldIdentity).toBe("function");
+    expect("runDriftCheckWithGraphStatus" in publicApi).toBe(false);
   });
 });
 
@@ -221,6 +223,7 @@ describe("public API — runDriftCheck", () => {
     expect(Array.isArray(report.issues)).toBe(true);
     expect(typeof report.filesChecked).toBe("number");
     expect(typeof report.timestamp).toBe("string");
+    expect("graphStatus" in report).toBe(false);
   });
 
   it("accepts scaffoldPatterns override without throwing", async () => {
@@ -229,6 +232,53 @@ describe("public API — runDriftCheck", () => {
     };
     const report = await runDriftCheck(config, opts);
     expect(report).toBeDefined();
+  });
+
+  it("retains the legacy grounding runtime loader behavior", async () => {
+    mkdirSync(join(tmpDir, ".mex/context"), { recursive: true });
+    writeFileSync(join(tmpDir, ".mex/context/architecture.md"), "# Architecture\n\nExisting context.\n");
+    const checker = vi.fn(() => [{
+      code: "GROUNDING_DRIFT",
+      severity: "warning" as const,
+      file: ".mex/context/architecture.md",
+      line: null,
+      message: "Legacy injected grounding finding.",
+    }]);
+    const close = vi.fn();
+    type InjectedRuntime = NonNullable<Awaited<ReturnType<
+      NonNullable<RunDriftCheckOpts["groundingRuntimeLoader"]>
+    >>>;
+    const runtime = { checker, close } as unknown as InjectedRuntime;
+    const groundingRuntimeLoader = vi.fn(async () => runtime);
+
+    const report = await runDriftCheck(config, {
+      groundingRuntimeLoader,
+      graphWarning: () => {},
+    });
+
+    expect(groundingRuntimeLoader).toHaveBeenCalledWith(config);
+    expect(checker).toHaveBeenCalled();
+    expect(report.issues).toContainEqual(expect.objectContaining({
+      code: "GROUNDING_DRIFT",
+      message: "Legacy injected grounding finding.",
+    }));
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes a primary diagnostic when the stripped public report has no repair command", async () => {
+    mkdirSync(join(tmpDir, ".mex/context"), { recursive: true });
+    writeFileSync(join(tmpDir, ".mex/context/architecture.md"), "# Architecture\n\nExisting context.\n");
+    writeFileSync(join(tmpDir, ".mex/graph.db"), "not a sqlite database");
+    const warnings: string[] = [];
+
+    const report = await runDriftCheck(config, {
+      graphWarning: (message) => warnings.push(message),
+    });
+
+    expect("graphStatus" in report).toBe(false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Code graph is corrupt");
+    expect(warnings[0]).toContain("GRAPH_INDEX_CORRUPT");
   });
 });
 

--- a/test/reporter.test.ts
+++ b/test/reporter.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reportConsole, reportQuiet } from "../src/reporter.js";
+import type { GraphAwareDriftReport } from "../src/drift/index.js";
+import type { GraphStatus } from "../src/team/contracts/graph.js";
+
+function status(
+  kind: GraphStatus["status"],
+  diagnostics: GraphStatus["diagnostics"] = [],
+): GraphStatus {
+  return {
+    status: kind,
+    observedAt: "2026-08-22T00:00:00.000Z",
+    currentRepo: {
+      branch: "feat/graph-freshness-recovery",
+      head: "a".repeat(40),
+      dirty: true,
+      observedAt: "2026-08-22T00:00:00.000Z",
+    },
+    lastSuccessfulIndexAt: "2026-08-21T00:00:00.000Z",
+    indexedAt: "2026-08-21T00:00:00.000Z",
+    indexedBranch: "feat/graph-freshness-recovery",
+    indexedHead: "a".repeat(40),
+    schemaVersion: 2,
+    extractorVersion: "test",
+    grammarVersion: "b".repeat(64),
+    parseHealth: {
+      total: 2,
+      ok: 2,
+      partial: 0,
+      failed: 0,
+      failedPaths: [],
+      failedPathsTruncated: false,
+    },
+    changes: {
+      total: 2,
+      added: ["src/new.ts"],
+      modified: ["src/service.ts"],
+      deleted: [],
+      truncated: false,
+      branchChanged: false,
+      manifestChanged: false,
+      configChanged: false,
+      grammarChanged: false,
+    },
+    diagnostics,
+  };
+}
+
+function report(graphStatus: GraphStatus): GraphAwareDriftReport {
+  return {
+    score: 100,
+    issues: [],
+    filesChecked: 3,
+    timestamp: "2026-08-22T00:00:00.000Z",
+    graphStatus,
+  };
+}
+
+function output(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.flat().join("\n");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("graph-aware reporters", () => {
+  it("renders status, change counts, and a diagnostic-provided command in console output", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const graph = status("stale", [{
+      code: "GRAPH_SOURCE_STALE",
+      severity: "warning",
+      message: "Sources changed.",
+      remediation: [{ label: "Refresh graph", command: "mex graph" }],
+    }]);
+
+    reportConsole(report(graph));
+
+    const rendered = output(log);
+    expect(rendered).toContain("graph stale");
+    expect(rendered).toContain("2 source changes");
+    expect(rendered).toContain("1 added, 1 modified, 0 deleted");
+    expect(rendered).toContain("run `mex graph`");
+    expect(rendered).toContain("GRAPH_SOURCE_STALE: Sources changed.");
+  });
+
+  it("renders graph status in quiet output without inventing a recovery command", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const graph = status("stale", [{
+      code: "GRAPH_BRANCH_CHANGED",
+      severity: "warning",
+      message: "The branch changed.",
+      remediation: [{ label: "Review branch state" }],
+    }]);
+    graph.changes.total = 0;
+    graph.changes.added = [];
+    graph.changes.modified = [];
+    graph.changes.branchChanged = true;
+
+    reportQuiet(report(graph));
+
+    const rendered = output(log);
+    expect(rendered).toContain("graph stale");
+    expect(rendered).toContain("0 source changes");
+    expect(rendered).toContain("branch changed");
+    expect(rendered).not.toContain("mex graph");
+  });
+
+  it("does not present bounded path arrays as exact category totals", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const graph = status("stale");
+    graph.changes.total = 101;
+    graph.changes.added = Array.from({ length: 100 }, (_, index) => `src/new-${index}.ts`);
+    graph.changes.modified = [];
+    graph.changes.truncated = true;
+
+    reportQuiet(report(graph));
+
+    const rendered = output(log);
+    expect(rendered).toContain("101 source changes");
+    expect(rendered).toContain("path details truncated");
+    expect(rendered).not.toContain("100 added, 0 modified, 0 deleted");
+  });
+});

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -101,7 +101,7 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
     let drift = await runDriftCheckWithGraphStatus(config, { graphWarning: (message) => warnings.push(message) });
     expect(drift.graphStatus?.status).toBe("stale");
     expect(drift.issues.some((issue) => issue.code.startsWith("GROUNDING_"))).toBe(false);
-    expect(warnings).toContainEqual(expect.stringContaining("Run `mex graph`"));
+    expect(warnings).toContainEqual(expect.stringContaining("Run `mex graph refresh`"));
 
     const refreshRuntime = await loadGroundingRuntime(config);
     refreshRuntime!.close();

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -8,7 +8,7 @@ import { runGraphScope } from "../src/graph/cli-agent.js";
 import { deserializeFingerprint } from "../src/graph/fingerprint.js";
 import { extractGroundings, findMexAnchors, writeGroundings } from "../src/markdown.js";
 import { checkBrokenLinks } from "../src/drift/checkers/broken-link.js";
-import { runDriftCheck } from "../src/drift/index.js";
+import { runDriftCheckWithGraphStatus } from "../src/drift/index.js";
 import { captureGroundingBaselines, loadGroundingRuntime } from "../src/graph/runtime.js";
 
 const roots: string[] = [];
@@ -97,7 +97,16 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
 
     writeFileSync(join(sourceDir, "checkout.ts"), readFileSync(join(sourceDir, "checkout.ts"), "utf-8")
       .replace("subtotal >= 100 ? 0 : 12", "subtotal >= 125 ? 0 : 15"));
-    const drift = await runDriftCheck(config);
+    const warnings: string[] = [];
+    let drift = await runDriftCheckWithGraphStatus(config, { graphWarning: (message) => warnings.push(message) });
+    expect(drift.graphStatus?.status).toBe("stale");
+    expect(drift.issues.some((issue) => issue.code.startsWith("GROUNDING_"))).toBe(false);
+    expect(warnings).toContainEqual(expect.stringContaining("Run `mex graph`"));
+
+    const refreshRuntime = await loadGroundingRuntime(config);
+    refreshRuntime!.close();
+    drift = await runDriftCheckWithGraphStatus(config, { graphWarning: (message) => warnings.push(message) });
+    expect(drift.graphStatus?.status).toBe("fresh");
     expect(drift.issues).toContainEqual(expect.objectContaining({
       code: "GROUNDING_DRIFT",
       file: ".mex/patterns/calculate-checkout.md",
@@ -106,9 +115,10 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
     // Same shared post-authoring routine used by sync: refresh, then check clean.
     expect(await captureGroundingBaselines(config, { updateFingerprints: true }))
       .toEqual({ captured: 2, skipped: 0 });
-    const clean = await runDriftCheck(config);
+    const clean = await runDriftCheckWithGraphStatus(config, { graphWarning: (message) => warnings.push(message) });
+    expect(clean.graphStatus?.status).toBe("fresh");
     expect(clean.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toEqual([]);
-  }, 15_000);
+  }, 30_000);
 
   it("skips and warns when authored grounding no longer resolves", async () => {
     const root = mkdtempSync(join(tmpdir(), "mex-setup-grounding-miss-"));

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -4,22 +4,69 @@ import { render } from "ink-testing-library";
 import {
   ErrorScreen,
   HeartbeatPanel,
+  DoctorPanel,
   Summary,
   TimelinePanel,
   eventActivityBars,
   progressBar,
   type DashboardData,
 } from "../src/tui.js";
+import type { GraphStatus } from "../src/team/contracts/graph.js";
 
 const h = React.createElement;
 
-function data(overrides: Partial<DashboardData> = {}): DashboardData {
+function graphStatus(status: GraphStatus["status"] = "fresh"): GraphStatus {
   return {
+    status,
+    observedAt: "2026-05-14T00:00:00.000Z",
+    currentRepo: {
+      branch: "feat/graph-freshness-recovery",
+      head: "a".repeat(40),
+      dirty: false,
+      observedAt: "2026-05-14T00:00:00.000Z",
+    },
+    lastSuccessfulIndexAt: "2026-05-14T00:00:00.000Z",
+    indexedAt: "2026-05-14T00:00:00.000Z",
+    indexedBranch: "feat/graph-freshness-recovery",
+    indexedHead: "a".repeat(40),
+    schemaVersion: 2,
+    extractorVersion: "test",
+    grammarVersion: "b".repeat(64),
+    parseHealth: {
+      total: 0,
+      ok: 0,
+      partial: 0,
+      failed: 0,
+      failedPaths: [],
+      failedPathsTruncated: false,
+    },
+    changes: {
+      total: 0,
+      added: [],
+      modified: [],
+      deleted: [],
+      truncated: false,
+      branchChanged: false,
+      manifestChanged: false,
+      configChanged: false,
+      grammarChanged: false,
+    },
+    diagnostics: [],
+  };
+}
+
+type DashboardOverrides = Omit<Partial<DashboardData>, "report"> & {
+  report?: Partial<DashboardData["report"]>;
+};
+
+function data(overrides: DashboardOverrides = {}): DashboardData {
+  const base: DashboardData = {
     report: {
       score: 100,
       issues: [],
       filesChecked: 3,
       timestamp: "2026-05-14T00:00:00.000Z",
+      graphStatus: graphStatus(),
     },
     heartbeat: {
       ok: true,
@@ -28,7 +75,11 @@ function data(overrides: Partial<DashboardData> = {}): DashboardData {
       oldDailyMemoryFiles: [],
     },
     events: [],
+  };
+  return {
+    ...base,
     ...overrides,
+    report: { ...base.report, ...overrides.report },
   };
 }
 
@@ -57,6 +108,48 @@ describe("TUI components", () => {
       notice: null,
     }));
     expect(app.lastFrame()).toContain("1 error · 1 warning");
+  });
+
+  it("renders graph freshness without triggering maintenance", () => {
+    const app = render(h(Summary, {
+      data: data({
+        report: {
+          score: 100,
+          issues: [],
+          filesChecked: 3,
+          timestamp: "2026-05-14T00:00:00.000Z",
+          graphStatus: {
+            ...graphStatus("stale"),
+            changes: {
+              ...graphStatus("stale").changes,
+              total: 1,
+              modified: ["src/service.ts"],
+              branchChanged: true,
+            },
+          },
+        },
+      }),
+      notice: null,
+    }));
+    expect(app.lastFrame()).toContain("Graph");
+    expect(app.lastFrame()).toContain("Attention");
+    expect(app.lastFrame()).toContain("stale · 1 source change");
+    expect(app.lastFrame()).toContain("branch changed");
+  });
+
+  it("renders the primary graph diagnostic in the doctor panel", () => {
+    const stale = graphStatus("corrupt");
+    stale.diagnostics = [{
+      code: "GRAPH_INDEX_CORRUPT",
+      severity: "error",
+      message: "SQLite quick-check failed.",
+    }];
+    const app = render(h(DoctorPanel, {
+      data: data({ report: { graphStatus: stale } }),
+    }));
+    expect(app.lastFrame()).toContain("Graph detail");
+    expect(app.lastFrame()).toContain("GRAPH_INDEX_CORRUPT");
+    expect(app.lastFrame()).toContain("SQLite quick-check failed");
   });
 
   it("renders heartbeat stale files", () => {


### PR DESCRIPTION
## Summary

- publish provenance-bound graph snapshots atomically with graph facts
- stage and revalidate source, config, compiler-input, and Git identity before publication
- add strictly read-only graph freshness inspection and exact inode/snapshot-bound readers
- gate `graph get`, `graph query`, and `impact` on fresh observations without changing ranking or protocol-v3 output
- add explicit `mex graph status`, `refresh`, and isolated `rebuild` commands; bare `mex graph` remains a safe rebuild alias
- serialize writers with owner-token locking, validate same-directory candidates, preserve continuity where safe, and retain/restore exact recovery bytes on failure
- include semantic snapshot provenance in evaluator determinism while excluding only timestamps and Git coordinates
- add a non-gating graph-status benchmark and document the maintenance/read boundary

## Stack

This remains a draft stacked on `feat/wiki-port-contract-lock`, not `main`. It does not depend on the teammate Wiki implementation and must not be merged into `main` directly.

## Behavior and boundaries

- Ordinary status/check/doctor/TUI and targeted graph reads never rebuild or refresh implicitly.
- `refresh` only accepts a compatible inspectable graph; `rebuild` handles missing, incompatible, malformed legacy, and corrupt graphs through an isolated candidate.
- Failed parse, cancellation, publication, rollback, lock races, database/path ABA, WAL activity, and `.mex` retargeting fail closed without publishing mixed facts.
- `graph scope` deliberately retains its existing stale live-text fallback, while using one stable immutable database session.
- Retrieval ranking, graph query algorithms, protocol-v3 records/goldens, package-root declarations, and the Wiki boundary are unchanged.

## Performance characterization

The committed benchmark is informational rather than a timing gate. On Apple M4 / Node 22.17.1 / SQLite 3.50.0, fresh status measured 579 ms median for 100 files and 714 ms median for 400 files, including CLI startup. See `docs/design/graph-freshness-recovery.md` for environment and caveats.

## Verification

- `npm run typecheck`
- `npm test` — 52 files, 675 tests
- `npm run eval:test` — 38 graph evaluator + 47 comparison tests
- `npm run build`
- protocol-v3 JSONL goldens — 4/4, unchanged
- real built-CLI `graph status|refresh|rebuild` help plus rebuild/status benchmark smoke
- `npm pack --dry-run --json` using an isolated npm cache
- declaration-leak check: maintenance/read-session APIs absent from `dist/index.d.ts`
- `git diff --check`
- independent read-side and maintenance P0/P1 reviews: clean

## Deferred

- Real Wiki adapter/type parity remains blocked on the teammate branch/commit and is outside this PR.
- Performance budgets remain non-gating until a pinned runner and representative larger-repo baselines exist.
