### PR TITLE
docs: close the read-only Hub checkpoint

### DIFF
--- a/docs/design/human-team-memory-contract-lock.md
+++ b/docs/design/human-team-memory-contract-lock.md
@@ -1,11 +1,11 @@
 # Human-Team Memory Contract Lock
 
-Status: provisional consumer contract and mock verified; teammate adapter pending
+Status: Checkpoint 0 closed; mock and repository adapter verified
 
-This brief records the proposed application boundary for the MEX OSS human-team
-memory program. It remains provisional until the teammate implementation is
-pinned and passes the same suite. It is an implementation aid, not authorization to widen the
-product scope described in the user-approved build program.
+This brief records the application boundary for the MEX OSS human-team memory
+program. The contract remains an internal, provisional API until a separate
+public-semver decision is made. It is an implementation aid, not authorization
+to widen the product scope described in the user-approved build program.
 
 ## Source authority and pins
 
@@ -33,16 +33,11 @@ health/error UX inspiration only. No Tencent service topology, central database,
 repository cloning, scheduled synchronization, agent hierarchy, proxy, or
 business-response envelope is adopted.
 
-The teammate Wiki implementation branch and commit do not currently exist or
-are not yet available. The supplied Wiki build spec is authoritative for design,
-but it is not proof of implementation identity. Consequently:
-
-- the consumer contracts, behavioral mock, fixture, and conformance suite may
-  progress;
-- no real Wiki adapter is claimed;
-- no parity assertion against teammate types is claimed;
-- the real adapter test remains blocked until an exact branch and commit are
-  provided.
+The Wiki engine dependency is pinned at
+`1b5da62c84ae8f65e897e6958985a658e408315c`. The integration branch carries the
+remaining consumer-contract closure and a repository-bound adapter. The
+behavioral mock and the real adapter both run the same consumer-owned
+conformance suite without skips, including the final canonical team paths.
 
 ## Integration ownership
 
@@ -53,7 +48,7 @@ Checkpoint 0 intentionally changes none of those hotspots.
 
 The internal contract surface is under `src/team/contracts`. It is not exported
 from the package root yet; doing so would create a public semver commitment
-before the real adapter passes the suite.
+before the provisional team API has stabilized.
 
 ## Provisional consumer boundary
 
@@ -123,16 +118,17 @@ failure.
 ## Consumer-owned verification
 
 `test/contracts/wiki-port.contract.ts` is a reusable Vitest conformance suite.
-The current registration uses the in-memory behavioral mock. A teammate adapter
-must register the same suite rather than replacing it with adapter-owned tests.
+Both the in-memory behavioral mock and the repository adapter register the same
+suite rather than replacing it with adapter-owned expectations.
 
 The mock proves consumer-facing ordering, filtering, bounds, read non-mutation,
 preview/apply conflicts, idempotency, scoped refresh behavior, typed failures,
-and abstract migration behavior. It does not prove the future engine's Markdown
-parser, byte-range patcher, SQLite publication/recovery, filesystem atomicity,
-symlink defense, graph-produced grounding provenance, or apply-time ULID
-generation. Those claims require the pinned real adapter and its integration
-fixtures.
+and abstract migration behavior. The pinned repository adapter and its
+integration fixtures additionally cover the Markdown parser, byte-range
+patcher, SQLite publication/recovery, filesystem atomicity, symlink defense,
+graph-produced grounding provenance, and apply-time ULID generation. The
+integration architecture is recorded in
+[`wiki-port-integration.md`](wiki-port-integration.md).
 
 The populated fixture exercises a payment-reliability knowledge slice with
 topics, Specs, requirements, acceptance criteria, current and deprecated
@@ -180,7 +176,7 @@ developer branching and commits explicitly requested for this implementation.
 
 ## Checkpoint status
 
-Implemented as a provisional consumer draft:
+Checkpoint 0 is closed with:
 
 - source revision pins and ownership record;
 - shared application contracts and stable required error codes;
@@ -189,26 +185,21 @@ Implemented as a provisional consumer draft:
 - typed operation metadata with engine-owned operation and migration payloads;
 - populated behavior mock and legacy fixture;
 - reusable Wiki conformance suite;
+- pinned Wiki engine implementation and repository adapter;
+- mock and real-adapter conformance registrations with no skips;
 - protocol-v3 graph golden regressions;
 - explicit exclusions and integration-owner assignment.
 
-Pending before Checkpoint 0 can be fully closed:
-
-- exact teammate implementation branch and commit;
-- confirmation that the teammate parser accepts the final canonical team paths;
-- real Wiki adapter implementation;
-- contract-suite and type-parity results against that pinned implementation.
-
-Downstream lanes may compile against the mock for interface development, but
-must treat it as a test double rather than proof of parser, index, patcher,
-grounding, or migration compliance. They must not invent alternate
-Wiki storage, entity, relationship, operation, migration, or grounding behavior
-while the real adapter is pending.
+Production consumers use the repository adapter. The mock remains a bounded
+test double for consumer behavior, not an alternate storage or mutation
+implementation. Checkpoint 2's completed read-only Hub integration is recorded
+in [`hub-wiki-readonly.md`](hub-wiki-readonly.md).
 
 ## Verification commands
 
 ```bash
 npx vitest run test/wiki-port-mock.contract.test.ts
+npx vitest run test/wiki-port-real.contract.test.ts
 npx vitest run src/graph/__tests__/protocol-v3-golden.test.ts
 npm run typecheck
 npm test

--- a/docs/design/project-hub-foundation.md
+++ b/docs/design/project-hub-foundation.md
@@ -1,6 +1,11 @@
 # Project Hub Foundation
 
-Status: Lane B local foundation plus real read-only Activity; Graph and Wiki adapters pending
+Status: Lane B foundation complete; Graph and Wiki integrations recorded separately
+
+This document records the Lane B foundation as it originally landed. Its
+Graph- and Wiki-unavailable statements are historical slice boundaries,
+superseded by [`hub-graph-integration.md`](hub-graph-integration.md) and
+[`hub-wiki-readonly.md`](hub-wiki-readonly.md).
 
 Functional reference: TencentDB-Agent-Memory commit
 `97f94654280b2932c35ba4806a491999ed244cc9`, limited to explicit asynchronous
@@ -10,9 +15,10 @@ taxonomy are not adopted.
 
 The Project Hub is a desktop-oriented, local control room for one repository.
 It adds a browser surface without changing the public library API, terminal UI,
-or code-graph retrieval behavior. Production data remains truthful: repository
-context, local job history, and repository-backed team activity may be shown,
-while unavailable Graph and Wiki capabilities are labelled rather than simulated.
+or code-graph retrieval behavior. At the Lane B boundary, production data
+remained truthful: repository context, local job history, and repository-backed
+team activity could be shown, while unavailable Graph and Wiki capabilities
+were labelled rather than simulated.
 
 ## Runtime flow
 
@@ -93,12 +99,12 @@ Modules, semantic design tokens, keyboard/focus handling, and reduced-motion
 support. Fixture data is compile-time development/test input and is absent from
 the production bundle.
 
-## Deliberate boundaries
+## Original Lane B boundaries
 
 - No remote bind, proxy trust, hosted authentication, telemetry, or outbound assets.
-- No real Graph status or maintenance until Lane A is integrated.
-- No real Wiki read, search, health, or maintenance until the teammate adapter
-  passes the Checkpoint 0 contract and Lane D is complete.
+- Graph status and maintenance were deferred to the later Graph integration.
+- Wiki read, search, health, and maintenance were deferred to the later Wiki
+  integration.
 - No Workstream, Inbox, Relay, Spec, or Playbook mutation in Lane B.
 - No Activity creation or Catch Up cursor advancement in the read-only Hub slice.
 - No change to `src/index.ts`, graph retrieval/ranking, protocol-v3 JSONL, or `mex tui`.


### PR DESCRIPTION
## Summary

- mark the human-team contract lock closed against the pinned Wiki engine and real repository adapter
- label the Project Hub foundation's Graph/Wiki-pending language as historical
- link the completed Graph, WikiPort, and read-only Wiki Hub integration records

## Verification

- `git diff --check`
- `npx vitest run test/wiki-port-mock.contract.test.ts test/wiki-port-real.contract.test.ts` (50 passed)

This PR contains documentation changes only and targets `integration/human-team-memory-v1`.
