### PR TITLE
Graph performance and recovery (0.7.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-27
+
+### Added
+- `mex graph repair` checkpoints a stranded write-ahead log and verifies store integrity in place, so a graph left behind by an interrupted build or check no longer requires a full rebuild to recover.
+
+### Changed
+- `mex check` now reads the last published graph read-only. It never synchronizes the graph as a side effect, and reports how many source files the graph is behind instead of silently re-staging the corpus.
+- TypeScript projects are extracted one at a time, with each compiler program released before the next is created, instead of holding every project's program and type checker in memory simultaneously.
+- Graph stores use schema v3, a compact encoding of the fingerprint and locality-sensitive-hashing tables: binary MinHash sketches, integer band hashes, integer fingerprint references, and the composite primary key as the only index.
+- The per-file semantic type-check pass is now opt-in. Parser health has always been derived from syntactic diagnostics, and reference resolution uses the type checker directly, so the full semantic pass only added diagnostic detail at a cost that scaled with the installed dependency surface.
+- Discovered TypeScript projects are configured with `skipLibCheck` and `noEmit`, because extraction needs symbol and type queries rather than a full compile.
+
+### Fixed
+- A malformed source file that triggers an internal TypeScript compiler assertion no longer aborts the entire graph build. The affected project is isolated and its files fall back to Tree-sitter extraction.
+- Two same-identity declarations in one TypeScript or JavaScript file no longer abort corpus staging with a duplicate node id; they are ordinal-disambiguated, matching the existing Python and Rust extractors.
+- Tree-sitter parse trees are released after extraction. They are allocated in the WebAssembly heap and were never reclaimed, so every parsed file leaked for the lifetime of the process.
+- Grammars are now loaded for compiler-language files that compiler extraction could not stage, so the Tree-sitter fallback can actually extract them.
+
+### Performance
+- On a 3,254-file multi-project repository, peak resident memory during a graph build fell from 5.17 GB to 2.11 GB and wall-clock time fell from 448 s to 309 s, with byte-identical graph output.
+- Graph stores are roughly 36-40% smaller: 700.1 MB to 451.1 MB on that repository, and 269.8 MB to 162.9 MB on a 494-file repository. The fingerprint and LSH tables themselves shrank by about 86% and are no longer the largest consumer in a store.
+- A drift check on a repository with edited sources no longer pays graph-staging cost at all, because `mex check` no longer stages.
+
+### Compatibility
+- Node.js 22.5 or newer remains required.
+- Schema-v2 `.mex/graph.db` files migrate to v3 losslessly the next time a writing command runs (`mex graph`, `mex sync`, `mex graph ground`). No rebuild is required and existing groundings continue to resolve. Read-only commands report the usual rebuild guidance until that migration has run.
+- Schema-v1 stores still require a one-time `mex graph` rebuild, unchanged from 0.7.2.
+- Serialized `mh:64:` grounding anchors in scaffold Markdown are unchanged; no scaffold edits are needed.
+- Graph output is unchanged by this release except for the TypeScript project isolation and duplicate-identity fixes, which add nodes and edges that previously aborted or were absent. The compiler extractor version advances, so the first `mex graph` after upgrading performs a full rebuild.
+
 ## [0.7.2] - 2026-08-20
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -30,7 +30,7 @@ mex crea un mapa de tu código, convierte lo que aprenden los agentes en Markdow
 
 Cada sesión de programación comienza con el contexto arquitectónico relevante, no con otro escaneo completo del repositorio.
 
-> **Nuevo en v0.7.2:** recuperación del grafo con código fuente en una sola llamada, flujos de TypeScript resueltos por el compilador, evidencia determinista y límites estrictos de salida.
+> **Nuevo en v0.7.3:** las construcciones del grafo mantienen un solo programa del compilador a la vez, los almacenes son entre un 36 y un 40 % más pequeños, `mex check` ya no reconstruye el grafo y `mex graph repair` recupera un almacén interrumpido sin reconstruirlo.
 
 💬 **Únete a la comunidad de mex en Discord** — comenta ideas, obtén ayuda, comparte tus opiniones y contribuye al proyecto.
 
@@ -250,6 +250,7 @@ Con el flujo antiguo `setup.sh`, ejecuta instalación, compilación y CLI en el 
 | `mex graph get <node-id...>` | Expande símbolos exactos |
 | `mex graph query <relation> <symbol>` | Consulta relaciones estructurales |
 | `mex graph ground` | Conecta una wiki anterior a 0.7 con el grafo |
+| `mex graph repair` | Recupera un almacén de grafo interrumpido sin reconstruirlo |
 | `mex impact <symbol\|file>` | Encuentra código y wiki afectados por un cambio |
 | `mex log <message>` | Registra una decisión, nota, riesgo o tarea |
 | `mex timeline` | Muestra eventos recientes |
@@ -295,7 +296,7 @@ El paquete MCP todavía no está publicado. Para desarrollo local:
 npm run build --workspace mex-mcp
 ```
 
-La publicación principal de v0.7.2 sigue siendo la CLI `mex-agent`.
+La publicación principal de v0.7.3 sigue siendo la CLI `mex-agent`.
 
 ## Modo de memoria del agente
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ mex maps your code, turns what agents learn into structured Markdown, and keeps 
 
 Every coding session starts with relevant architectural context instead of another full-repository scan.
 
-> **New in v0.7.2:** source-backed one-call graph retrieval with compiler-resolved TypeScript flows, deterministic evidence, and hard output budgets.
+> **New in v0.7.3:** graph builds hold one compiler program at a time, stores are 36-40% smaller, `mex check` no longer rebuilds the graph, and `mex graph repair` recovers an interrupted store without a rebuild.
 
 💬 **Join the mex community on Discord** — discuss ideas, get help, share feedback, and contribute to the project.
 
@@ -252,6 +252,7 @@ All commands run from the project root. Replace `mex` with `npx mex-agent` if it
 | `mex graph get <node-id...>` | Expand exact symbols from a retrieval result |
 | `mex graph query <relation> <symbol>` | Query structural code relationships |
 | `mex graph ground` | Connect an existing pre-0.7 wiki to the graph |
+| `mex graph repair` | Recover an interrupted graph store without a rebuild |
 | `mex impact <symbol\|file>` | Find code and wiki content affected by a change |
 | `mex log <message>` | Record a decision, note, risk, or todo |
 | `mex timeline` | Read recent project events |
@@ -299,7 +300,7 @@ The MCP package is not published yet. For local development, build it with:
 npm run build --workspace mex-mcp
 ```
 
-The primary v0.7.2 release remains the `mex-agent` CLI.
+The primary v0.7.3 release remains the `mex-agent` CLI.
 
 ## Agent memory mode
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -30,7 +30,7 @@ mex mapeia seu código, transforma o que os agentes aprendem em Markdown estrutu
 
 Cada sessão de programação começa com o contexto arquitetural relevante, e não com mais uma varredura completa do repositório.
 
-> **Novidade na v0.7.2:** recuperação do grafo com código-fonte em uma única chamada, fluxos de TypeScript resolvidos pelo compilador, evidência determinística e limites rígidos de saída.
+> **Novidade na v0.7.3:** as construções do grafo mantêm um programa do compilador por vez, os armazenamentos são 36-40% menores, o `mex check` não reconstrói mais o grafo e o `mex graph repair` recupera um armazenamento interrompido sem reconstruí-lo.
 
 💬 **Entre na comunidade do mex no Discord** — discuta ideias, peça ajuda, compartilhe feedback e contribua com o projeto.
 
@@ -250,6 +250,7 @@ Com o fluxo antigo `setup.sh`, execute instalação, build e CLI no mesmo ambien
 | `mex graph get <node-id...>` | Expande símbolos exatos |
 | `mex graph query <relation> <symbol>` | Consulta relações estruturais |
 | `mex graph ground` | Conecta uma wiki anterior à 0.7 ao grafo |
+| `mex graph repair` | Recupera um armazenamento de grafo interrompido sem reconstruí-lo |
 | `mex impact <symbol\|file>` | Encontra código e wiki afetados por uma mudança |
 | `mex log <message>` | Registra decisão, nota, risco ou tarefa |
 | `mex timeline` | Mostra eventos recentes |
@@ -295,7 +296,7 @@ O pacote MCP ainda não foi publicado. Para desenvolvimento local:
 npm run build --workspace mex-mcp
 ```
 
-O lançamento principal da v0.7.2 continua sendo a CLI `mex-agent`.
+O lançamento principal da v0.7.3 continua sendo a CLI `mex-agent`.
 
 ## Modo de memória do agente
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@ mex 为代码建立地图，把代理学到的知识整理成结构化 Markdown�
 
 每次编程会话都从相关的架构上下文开始，而不是重新扫描整个仓库。
 
-> **v0.7.2 新功能：** 一次调用即可获得带源码的图谱检索、由编译器解析的 TypeScript 执行流、确定性证据以及严格的输出预算。
+> **v0.7.3 新功能：** 图谱构建每次只保留一个编译器程序、存储体积缩小 36-40%、`mex check` 不再重建图谱，并且 `mex graph repair` 无需重建即可修复被中断的存储。
 
 💬 **加入 mex Discord 社区** — 讨论想法、获取帮助、分享反馈并参与项目贡献。
 
@@ -252,6 +252,7 @@ npm install -g mex-agent
 | `mex graph get <node-id...>` | 展开检索结果中的精确符号 |
 | `mex graph query <relation> <symbol>` | 查询结构化代码关系 |
 | `mex graph ground` | 将已有的 0.7 之前 Wiki 连接到图谱 |
+| `mex graph repair` | 无需重建即可恢复被中断的图谱存储 |
 | `mex impact <symbol\|file>` | 查找受代码变更影响的代码和 Wiki 内容 |
 | `mex log <message>` | 记录决策、笔记、风险或待办 |
 | `mex timeline` | 查看最近的项目事件 |
@@ -299,7 +300,7 @@ MCP 包尚未发布。本地开发时请运行：
 npm run build --workspace mex-mcp
 ```
 
-v0.7.2 的主要发布内容仍然是 `mex-agent` CLI。
+v0.7.3 的主要发布内容仍然是 `mex-agent` CLI。
 
 ## 代理记忆模式
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,68 +1,52 @@
-# mex 0.7.2 — Source-backed graph retrieval
+# mex 0.7.3 — Graph performance and recovery
 
-mex 0.7.2 makes the code graph useful as a first-response retrieval system rather than only a compact symbol manifest. `mex graph scope` now returns the most relevant source declarations and real execution flows under a hard token budget, so an agent can often answer from one graph call instead of repeatedly expanding node IDs or reopening files.
+mex 0.7.3 makes the code graph affordable to keep. 0.7.2 traded memory, build time, and disk for a compiler-backed graph and deferred the cleanup to a follow-up release. This is that release: `mex check` no longer rebuilds anything, graph builds hold one compiler program at a time, stores are roughly 36-40% smaller, and a graph left behind by an interrupted command can be repaired instead of rebuilt.
+
+It is a maintenance release. Retrieval behavior, the JSONL protocol, scaffold formats, and grounding anchors are unchanged.
 
 ## What changed
 
-- **Source-backed Scope by default.** Task queries return bounded `meta`, `source`, `flow`, and `summary` JSONL records. Primary declarations and trustworthy flows are admitted before optional context.
-- **Compiler-backed TypeScript graph.** The TypeScript compiler API adds resolved calls, imports, inheritance, containment, callback flow, and declaration-aware source regions. TypeScript 5.9.3 is therefore an exact runtime dependency.
-- **Evidence-aware retrieval.** Lexical search, source chunks, graph neighborhoods, compiler callsites, and declaration identity are fused without inventing edges. Displayed flows use stored edges with confidence at least 0.8 and remain bounded by hop, branch, work, and output-step limits.
-- **Honest status and budgets.** `ok`, `partial`, `degraded`, and `no-match` reflect whether mandatory answer evidence was returned. `truncated: true` may now mean only lower-priority optional evidence was omitted.
-- **Safer graph publication.** Parser/read failures preserve the previous graph, rebuilds are deterministic, and integrity checks cover extraction loss, duplicate or dangling rows, FTS drift, identity drift, invalid confidence, and suspicious production-to-test edges.
-- **Stronger evaluation.** Native Hono, TypeScript-compiler, MEX, and mixed-language holdouts validate files, exact source spans, flows, budgets, construction integrity, and deterministic rebuilds. Headless comparisons pin subject and command identity, constrain tools, support safe resume after provider limits, and blind-grade exact source declarations.
-- **Drift-check improvements.** This release also includes frontmatter completeness, stale-pattern checks, and safer tool-config synchronization from the latest `main` branch.
+- **`mex check` never stages the graph.** The grounding pass previously synchronized the graph whenever any source file's timestamp had moved, which in an actively edited repository meant nearly every run. Because a synchronize re-stages the whole corpus, a routine drift check silently paid a full rebuild's memory and wall-clock cost. `mex check` now opens the last published graph read-only and reports how far behind it is, leaving rebuilds to `mex graph`.
+- **One compiler program alive at a time.** TypeScript extraction held every discovered project's program and type checker simultaneously, so peak memory was the sum of all of them. Extraction is now a capture pass per project followed by a compiler-free finishing pass. Cross-project resolution already flowed through declaration locations that are stable across programs, so each program can be released as soon as its own files are captured.
+- **Smaller stores (schema v3).** The fingerprint and locality-sensitive-hashing tables were 40-50% of a typical store: a JSON text MinHash sketch per node, plus 32 index rows per node each repeating the full node id and a 64-character hexadecimal band hash, plus a secondary index over all of it. v3 stores the sketch as a 256-byte binary value, keys index rows on an integer reference, truncates band hashes to 64-bit integers, and uses the composite primary key as the only index.
+- **The semantic type-check pass is opt-in.** Parser health has always been computed from syntactic diagnostics, and reference resolution queries the type checker directly, so the full per-file semantic pass contributed diagnostic detail only. Its cost scales with how much of the dependency tree the compiler can resolve, which is why two checkouts of one repository on one machine could differ enormously in build time. Discovered projects are also configured with `skipLibCheck` and `noEmit`.
+- **`mex graph repair`.** An interrupted writer can leave a large uncheckpointed write-ahead log, which read-only commands then refuse to open, and the only previous remedy was a full rebuild. `mex graph repair` checkpoints the log and runs an integrity check in place, in seconds.
+- **A build survives a hostile file.** A source file that trips an internal assertion in the TypeScript compiler used to abort the entire build with nothing written. The affected project is now isolated and its files fall back to Tree-sitter extraction. Two same-identity declarations in one file are ordinal-disambiguated instead of aborting corpus staging.
+- **A real memory leak is fixed.** Tree-sitter parse trees live in the WebAssembly heap and are not reclaimed by the JavaScript garbage collector. They were never released, so every parsed file leaked for the lifetime of the process, and each file was parsed twice.
 
-## Agent workflow
+## Measurements
 
-For an unfamiliar task, start with:
+Paired builds of the same repositories before and after, producing identical node, edge, and fingerprint counts:
 
-```bash
-mex graph scope "trace the authentication flow"
-```
+| Repository | Peak build memory | Build wall clock | Store size |
+|---|---|---|---|
+| 3,254 files, 92 TypeScript projects | 5.17 GB → 2.11 GB | 448 s → 309 s | 700.1 MB → 451.1 MB |
+| 494 files, single project | unchanged (~1.2 GB) | 195 s → 189 s | 269.8 MB → 162.9 MB |
 
-Treat returned source as already read. If the summary is `ok`, answer from the returned evidence even when optional context was truncated. Use `mex graph get <node-id>` for an exact missing declaration, or follow `suggestedNextCommands` when the summary is `partial` or `degraded`. Fall back to Grep/Glob when the graph evidence does not clearly answer the task.
+Memory reduction scales with the number of TypeScript projects in a repository, because that is what was being held concurrently. Single-project repositories keep their previous peak and still get the smaller store. The fingerprint and LSH tables shrank by roughly 86% and are no longer the largest consumer in a store; `unresolved_refs` and the source-chunk full-text index now are.
 
-Exact structural commands remain available:
-
-```bash
-mex graph query where-defined authenticate
-mex graph query who-calls requireSession
-mex graph query what-calls createServer
-mex impact requireSession
-```
-
-## Benchmark snapshot
-
-A descriptive pilot ran 12 tasks across Hono and MEX once with a files-only search arm and once with the 0.7.2 candidate: 24 valid Claude Sonnet sessions in total.
-
-| Metric | Files baseline | 0.7.2 candidate | Change |
-|---|---:|---:|---:|
-| Blind-correct answers | 6/12 | 7/12 | +1 answer |
-| New tokens | 393,637 | 179,179 | **-54.5%** |
-| Processed tokens | 3,348,865 | 920,544 | **-72.5%** |
-| Estimated cost | $3.6973 | $1.6061 | **-56.6%** |
-| Mean latency | 45.62 s | 35.17 s | **-22.9%** |
-
-Candidate first responses returned 22/23 required source spans, every required Hono flow, and graph evidence for all 12 tasks.
-
-This is a small, one-repetition pilot. It compares the candidate with files-only search, not with the released `main` graph implementation, and individual task results—especially Hono schema retries—were noisy.
+Separately, a 39,312-file repository with 205 TypeScript projects and several thousand deliberately malformed fixture files now builds to completion for the first time, at 3.1 GB peak memory. Previous releases aborted on the first fixture that tripped a compiler assertion.
 
 ## Upgrade and compatibility
 
-mex 0.7.2 requires Node.js 22.5 or newer, unchanged from 0.7.1.
+mex 0.7.3 requires Node.js 22.5 or newer, unchanged from 0.7.2.
 
 ```bash
-npm install -g mex-agent@0.7.2
+npm install -g mex-agent@0.7.3
 ```
 
-Existing Markdown scaffolds remain valid. The graph schema has changed, so rebuild an existing graph once after upgrading:
+Existing Markdown scaffolds remain valid, and serialized `mh:64:` grounding anchors are unchanged.
+
+A schema-v2 store migrates to v3 losslessly the next time a writing command runs — `mex graph`, `mex sync`, or `mex graph ground`. No rebuild is required for the migration itself and existing groundings continue to resolve immediately. Read-only commands report the usual rebuild guidance until a writing command has run. Schema-v1 stores still need a one-time rebuild, unchanged from 0.7.2.
+
+The compiler extractor version advances in this release, so the first `mex graph` after upgrading performs a full rebuild. After that rebuild, graph content is unchanged apart from nodes and edges that previously aborted the build or were missing entirely.
+
+To recover a graph left behind by an interrupted build or check:
 
 ```bash
-mex graph
+mex graph repair
 ```
-
-Existing projects do not automatically receive updated agent instructions. Copy the new `## Code Graph` section from `templates/AGENTS.md` if you want source-backed one-call guidance in an already-created scaffold.
 
 ## Known tradeoff
 
-The compiler-backed graph stores substantially more nodes, edges, source chunks, import bindings, and integrity metadata than 0.7.1, so `.mex/graph.db` is larger. Build memory is not higher than the released baseline in paired Hono/TypeScript measurements, but storage and no-op/incremental rebuild performance remain follow-up work.
+Peak build memory is now bounded by the largest single TypeScript project rather than by the whole repository, which is a floor rather than a ceiling: a repository whose one project covers tens of thousands of files still needs that project in memory at once. Streaming extraction below that floor remains future work, as does incremental synchronization — `mex graph` still re-stages the full corpus for a single changed file, though `mex check` no longer triggers it. Within a store, `unresolved_refs` and the source-chunk full-text index are the remaining storage targets.

--- a/evaluate/graph/lib/integrity.mjs
+++ b/evaluate/graph/lib/integrity.mjs
@@ -72,11 +72,27 @@ const NORMALIZED_TABLES = [
     name: "node_fingerprints",
     columns: ["node_id", "minhash", "neighbors", "token_count"],
     order: ["node_id"],
+    // Schema v3 stores the sketch as a BLOB; hex() keeps the hashed projection
+    // textual and identical in meaning to the v2 JSON text, for both encodings.
+    sql: () => `SELECT "node_id", hex("minhash") AS "minhash", "neighbors", "token_count"
+      FROM "node_fingerprints" ORDER BY "node_id"`,
   },
   {
     name: "lsh_buckets",
     columns: ["band", "band_hash", "node_id"],
     order: ["band", "band_hash", "node_id"],
+    // Schema v3 keys bucket rows on an integer fingerprint ref rather than the
+    // node id. Join back to the owning node so the hashed content keeps meaning
+    // "which node sits in which band bucket", as it did under v2. The ref
+    // itself is deliberately NOT hashed: it is storage bookkeeping, not a
+    // semantic graph fact.
+    sql: (available) => (available.has("ref")
+      ? `SELECT buckets."band" AS "band", buckets."band_hash" AS "band_hash",
+           fingerprints."node_id" AS "node_id"
+         FROM "lsh_buckets" buckets
+         JOIN "node_fingerprints" fingerprints ON fingerprints."ref" = buckets."ref"
+         ORDER BY "band", "band_hash", "node_id"`
+      : null),
   },
 ];
 
@@ -130,6 +146,8 @@ function groupedCounts(db, table, column, where = null) {
 function normalizedRows(db, spec) {
   const available = tableColumns(db, spec.name);
   if (!available.size) return null;
+  const custom = spec.sql?.(available);
+  if (custom) return rows(db, custom);
   const columns = spec.columns.filter((column) => available.has(column));
   if (!columns.length) return [];
   const order = spec.order.filter((column) => available.has(column));

--- a/evaluate/graph/test/graph-eval.test.mjs
+++ b/evaluate/graph/test/graph-eval.test.mjs
@@ -126,7 +126,7 @@ test("v2 integrity hashing includes semantic metadata but ignores timestamps", (
   db.close();
 
   const first = inspectGraphDatabase(path, { nodesCreated: 1 });
-  assert.equal(first.schemaVersion, 2);
+  assert.equal(first.schemaVersion, 3);
   assert.deepEqual(first.parseStatusCounts, { partial: 1 });
   assert.equal(first.totalDiagnostics, 2);
   assert.equal(first.resolvedReferences, 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mex-agent",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mex-agent",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mex-agent",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Persistent project memory and deterministic local code graphs for AI coding agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -246,6 +246,20 @@ graphCommand
   });
 
 graphCommand
+  .command("repair")
+  .description("Checkpoint a stranded WAL and verify graph store integrity (no rebuild)")
+  .option("--root <dir>", "Project root (defaults to current directory)")
+  .action(async (opts) => {
+    try {
+      const { runGraphRepair } = await import("./graph/cli-graph.js");
+      process.exit(await runGraphRepair(opts.root));
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+  });
+
+graphCommand
   .command("ground")
   .description("Retro-ground an existing pre-0.7 scaffold using the code graph")
   .option("--dry-run", "Print the migration prompt without launching an agent")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -531,6 +531,7 @@ program
     console.log("  mex graph get <id...>                Expand source for node ids as JSONL");
     console.log("  mex graph ground                     Ground an existing pre-0.7 scaffold");
     console.log("  mex graph query <relation> <target>  Structural lookup as JSONL");
+    console.log("  mex graph repair                     Checkpoint a stranded WAL, verify integrity");
     console.log("  mex impact <symbol|file>              Blast radius as JSONL");
     console.log("  mex log <message>      Append a note/decision/risk/todo to the event log");
     console.log("  mex timeline           Show recent event log entries");

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -79,7 +79,16 @@ export async function runDriftCheck(
   let groundingRuntime: GroundingRuntime | null = null;
   if (hasGroundings || needsGroundingMigration) {
     try {
-      groundingRuntime = await (opts.groundingRuntimeLoader ?? loadGroundingRuntime)(config);
+      // Read-only: a drift check must never pay graph staging costs (#140).
+      // A stale graph degrades to a warning, not an in-process rebuild.
+      groundingRuntime = await (opts.groundingRuntimeLoader
+        ?? ((cfg) => loadGroundingRuntime(cfg, { readOnly: true })))(config);
+      if (groundingRuntime && (groundingRuntime.staleSourceFiles ?? 0) > 0) {
+        (opts.graphWarning ?? console.warn)(
+          `Code graph is ${groundingRuntime.staleSourceFiles} source file(s) behind; `
+          + "grounding checks use the last built graph. Run `mex graph` to refresh.",
+        );
+      }
       if (!groundingRuntime && !graphUpgradeNudgeShown) {
         graphUpgradeNudgeShown = true;
         (opts.graphWarning ?? console.warn)(

--- a/src/graph/cli-graph.ts
+++ b/src/graph/cli-graph.ts
@@ -38,3 +38,44 @@ export async function runGraph(options: GraphCommandOptions = {}): Promise<void>
     engine.close();
   }
 }
+
+/**
+ * Run `mex graph repair`: checkpoint any stranded WAL and verify store
+ * integrity — WITHOUT rebuilding. A killed writer (e.g. an interrupted check
+ * or build) can leave a large uncheckpointed WAL that read-only consumers then
+ * refuse to open; the WAL itself is not corrupt, so a clean writer-open plus
+ * `wal_checkpoint(TRUNCATE)` recovers the store in seconds (issue #140 obs 3).
+ * Deliberately avoids `openGraphDatabase`: repair must work on stores that
+ * schema/rebuild gating would refuse.
+ */
+export async function runGraphRepair(root?: string): Promise<number> {
+  const { existsSync, statSync } = await import("node:fs");
+  const { resolve } = await import("node:path");
+  const { openSqlite } = await import("./db/sqlite.js");
+  const dbPath = resolve(root ?? process.cwd(), ".mex", "graph.db");
+  if (!existsSync(dbPath)) {
+    console.error(`No graph store at ${dbPath}. Run \`mex graph\` to build one.`);
+    return 1;
+  }
+  const walPath = `${dbPath}-wal`;
+  const walBefore = existsSync(walPath) ? statSync(walPath).size : 0;
+  const db = openSqlite(dbPath);
+  try {
+    db.pragma("busy_timeout = 5000");
+    db.pragma("wal_checkpoint(TRUNCATE)");
+    const rows = db.prepare("PRAGMA integrity_check").all() as Array<{ integrity_check: string }>;
+    const verdict = rows.map((row) => row.integrity_check).join("; ") || "ok";
+    const walAfter = existsSync(walPath) ? statSync(walPath).size : 0;
+    const checkpointed = walBefore > walAfter
+      ? `checkpointed ${((walBefore - walAfter) / 1048576).toFixed(1)} MB of WAL`
+      : "no WAL data pending";
+    if (verdict === "ok") {
+      console.log(`Graph store healthy: ${checkpointed}; integrity ok. No rebuild needed.`);
+      return 0;
+    }
+    console.error(`Graph store integrity check failed: ${verdict}. Run \`mex graph\` to rebuild.`);
+    return 1;
+  } finally {
+    db.close();
+  }
+}

--- a/src/graph/db/database.ts
+++ b/src/graph/db/database.ts
@@ -17,10 +17,12 @@ import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
 import { dirname } from "node:path";
 import { schemaPath } from "../assets.js";
 import { GraphRebuildRequiredError } from "../errors.js";
+import { bandHashInts, encodeMinhash } from "../fingerprint.js";
+import type { Fingerprint } from "../reconcile.js";
 import { openSqlite, type SqliteDatabase } from "./sqlite.js";
 
 /** The schema version this build writes/expects (matches schema.sql's seed). */
-export const DB_SCHEMA_VERSION = 2;
+export const DB_SCHEMA_VERSION = 3;
 /** @deprecated Prefer the explicit DB_SCHEMA_VERSION name. */
 export const CURRENT_SCHEMA_VERSION = DB_SCHEMA_VERSION;
 
@@ -77,8 +79,9 @@ export function openGraphDatabase(
         `This mex build supports graph schema ${DB_SCHEMA_VERSION}, but the index uses ${current}.`,
       );
     }
-    if (current < DB_SCHEMA_VERSION) migrateV1ToV2(db, schema);
-    else db.exec(schema);
+    if (current < 2) migrateV1ToV2(db, schema);
+    if (current < 3) migrateV2ToV3(db);
+    db.exec(schema);
   }
 
   // Belt-and-suspenders: guarantee the version row exists even if the SQL seed
@@ -229,6 +232,73 @@ function migrateV1ToV2(db: SqliteDatabase, schema: string): void {
   // Creates all new tables and indexes after the old tables have the v2 columns.
   db.exec(schema);
   db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_unresolved_ref_key ON unresolved_refs(ref_key)");
-  writeSchemaVersion(db, DB_SCHEMA_VERSION);
+  writeSchemaVersion(db, 2);
   markGraphRebuildRequired(db, "schema-v1");
+}
+
+/**
+ * Schema v2 → v3: LOSSLESS storage re-encode of the fingerprint subsystem
+ * (issue #140 storage follow-up). The minhash JSON text becomes a 256-byte
+ * BLOB, LSH rows key on an INTEGER ref instead of repeating the TEXT node id,
+ * and band hashes truncate to int64 (a truncation collision merely adds an
+ * LSH candidate, which full minhash scoring rejects). Decoded fingerprints —
+ * and therefore every reconciler outcome — are identical, so the graph is NOT
+ * marked rebuild-required: existing groundings keep working immediately.
+ */
+function migrateV2ToV3(db: SqliteDatabase): void {
+  if (!tableExists(db, "node_fingerprints") || columns(db, "node_fingerprints").has("ref")) {
+    writeSchemaVersion(db, 3);
+    return;
+  }
+  db.transaction(() => {
+    db.exec(`CREATE TABLE node_fingerprints_v3 (
+      ref          INTEGER PRIMARY KEY,
+      node_id      TEXT NOT NULL UNIQUE REFERENCES nodes(id) ON DELETE CASCADE,
+      minhash      BLOB NOT NULL,
+      neighbors    TEXT NOT NULL,
+      token_count  INTEGER NOT NULL
+    )`);
+    const rows = db.prepare(
+      "SELECT node_id, minhash, neighbors, token_count FROM node_fingerprints ORDER BY node_id",
+    ).all() as Array<{ node_id: string; minhash: string; neighbors: string; token_count: number }>;
+    const insertFingerprint = db.prepare(
+      "INSERT INTO node_fingerprints_v3 (node_id, minhash, neighbors, token_count) VALUES (?, ?, ?, ?)",
+    );
+    const migrated: Array<{ node_id: string; fingerprint: Fingerprint }> = [];
+    for (const row of rows) {
+      // A row this build cannot decode was never usable by the reconciler;
+      // dropping it changes nothing observable.
+      try {
+        const fingerprint: Fingerprint = {
+          minhash: JSON.parse(row.minhash) as number[],
+          neighbors: JSON.parse(row.neighbors) as string[],
+          tokenCount: row.token_count,
+        };
+        insertFingerprint.run(row.node_id, encodeMinhash(fingerprint.minhash), row.neighbors, row.token_count);
+        migrated.push({ node_id: row.node_id, fingerprint });
+      } catch { /* skip undecodable legacy row */ }
+    }
+    db.exec("DROP TABLE lsh_buckets");
+    db.exec("DROP TABLE node_fingerprints");
+    db.exec("ALTER TABLE node_fingerprints_v3 RENAME TO node_fingerprints");
+    db.exec(`CREATE TABLE lsh_buckets (
+      band      INTEGER NOT NULL,
+      band_hash INTEGER NOT NULL,
+      ref       INTEGER NOT NULL REFERENCES node_fingerprints(ref) ON DELETE CASCADE,
+      PRIMARY KEY (band, band_hash, ref)
+    ) WITHOUT ROWID`);
+    const refByNode = new Map(
+      (db.prepare("SELECT ref, node_id FROM node_fingerprints").all() as Array<{ ref: number | bigint; node_id: string }>)
+        .map((row) => [row.node_id, typeof row.ref === "bigint" ? row.ref : BigInt(row.ref)]),
+    );
+    const insertBucket = db.prepare("INSERT INTO lsh_buckets (band, band_hash, ref) VALUES (?, ?, ?)");
+    for (const { node_id, fingerprint } of migrated) {
+      const ref = refByNode.get(node_id);
+      if (ref === undefined) continue;
+      try {
+        bandHashInts(fingerprint).forEach((bandHash, band) => insertBucket.run(band, bandHash, ref));
+      } catch { /* invalid legacy sketch: no LSH rows, same as being unmatchable before */ }
+    }
+  });
+  writeSchemaVersion(db, 3);
 }

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -294,7 +294,12 @@ async function stageCorpus(
   const compilerByPath = new Map(compiler.files.map((file) => [file.filePath, file]));
   const treeLanguages = [...new Set(discovered.map((file) => detectLanguage(file.relPath))
     .filter((language) => !COMPILER_LANGUAGES.has(language)))];
-  await loadGrammars(treeLanguages);
+  // Compiler-language files the compiler could not stage (e.g. a project whose
+  // program creation crashed) fall back to tree-sitter — load their grammars too.
+  const fallbackLanguages = [...new Set(discovered
+    .filter((file) => COMPILER_LANGUAGES.has(detectLanguage(file.relPath)) && !compilerByPath.has(file.relPath))
+    .map((file) => detectLanguage(file.relPath)))];
+  await loadGrammars([...treeLanguages, ...fallbackLanguages]);
 
   const files = discovered.map((file) => {
     const compilerFile = compilerByPath.get(file.relPath);

--- a/src/graph/engine-impl.ts
+++ b/src/graph/engine-impl.ts
@@ -27,6 +27,7 @@ import {
   TYPESCRIPT_COMPILER_EXTRACTOR_VERSION,
   TYPESCRIPT_COMPILER_VERSION,
   type CompilerExtractedNode,
+  type CompilerExtractionOptions,
   type CompilerExtractionResult,
   type CompilerFileExtraction,
 } from "./extraction/index.js";
@@ -63,6 +64,8 @@ export interface GraphEngineOptions {
   readOnly?: boolean;
   /** Injectable source-file access for embedders and deterministic fault tests. */
   sourceFileAccess?: Partial<GraphSourceFileAccess>;
+  /** Compiler extraction knobs (semantic diagnostics, program-crash fault tests). */
+  compilerExtraction?: CompilerExtractionOptions;
 }
 
 export interface GraphSourceFileAccess {
@@ -129,6 +132,7 @@ class GraphEngineImpl implements GraphEngine {
   private readonly dbPath: string;
   private readonly readOnly: boolean;
   private readonly sourceFileAccess: GraphSourceFileAccess;
+  private readonly compilerExtraction?: CompilerExtractionOptions;
   private db: SqliteDatabase | null = null;
   private store: GraphStore | null = null;
 
@@ -137,6 +141,7 @@ class GraphEngineImpl implements GraphEngine {
     this.dbPath = options.dbPath ?? resolve(this.rootDir, ".mex", "graph.db");
     this.readOnly = options.readOnly ?? false;
     this.sourceFileAccess = { ...NODE_SOURCE_FILE_ACCESS, ...options.sourceFileAccess };
+    this.compilerExtraction = options.compilerExtraction;
   }
 
   private getStore(allowRebuild = false): GraphStore {
@@ -151,7 +156,7 @@ class GraphEngineImpl implements GraphEngine {
     if (this.readOnly) throw new Error("A read-only graph engine cannot build an index.");
     const started = Date.now();
     const root = rootDir ? resolve(rootDir) : this.rootDir;
-    const staged = await stageCorpus(root, undefined, this.sourceFileAccess);
+    const staged = await stageCorpus(root, undefined, this.sourceFileAccess, this.compilerExtraction);
     const result = this.publish(staged);
     return { ...result, durationMs: Date.now() - started };
   }
@@ -172,7 +177,7 @@ class GraphEngineImpl implements GraphEngine {
 
     // Re-stage the whole semantic corpus. This makes an arbitrary sync sequence
     // converge to the same graph as a clean build and re-resolves cross-file refs.
-    const staged = await stageCorpus(this.rootDir, manifest, this.sourceFileAccess);
+    const staged = await stageCorpus(this.rootDir, manifest, this.sourceFileAccess, this.compilerExtraction);
     const stagedByPath = new Map(staged.files.map((file) => [file.record.path, file]));
     const unstagedExisting = changedSources.filter((file) => (
       !deletedChangedSources.has(file) && !stagedByPath.has(file)
@@ -286,11 +291,12 @@ async function stageCorpus(
   root: string,
   manifest = graphManifest(root),
   sourceFileAccess: GraphSourceFileAccess = NODE_SOURCE_FILE_ACCESS,
+  compilerExtraction?: CompilerExtractionOptions,
 ): Promise<StagedCorpus> {
   const discovered = discoverSourceFiles(root, sourceFileAccess);
   const compilerPaths = discovered.filter((file) => COMPILER_LANGUAGES.has(detectLanguage(file.relPath)))
     .map((file) => file.relPath);
-  const compiler = buildTypeScriptExtraction(root, compilerPaths);
+  const compiler = buildTypeScriptExtraction(root, compilerPaths, compilerExtraction);
   const compilerByPath = new Map(compiler.files.map((file) => [file.filePath, file]));
   const treeLanguages = [...new Set(discovered.map((file) => detectLanguage(file.relPath))
     .filter((language) => !COMPILER_LANGUAGES.has(language)))];

--- a/src/graph/extraction/compiler.ts
+++ b/src/graph/extraction/compiler.ts
@@ -21,7 +21,7 @@ import {
 } from "node:path";
 import ts from "typescript";
 
-export const TYPESCRIPT_COMPILER_EXTRACTOR_VERSION = "typescript-5.9-v1";
+export const TYPESCRIPT_COMPILER_EXTRACTOR_VERSION = "typescript-5.9-v2";
 export const TYPESCRIPT_COMPILER_VERSION = ts.version;
 
 export type CompilerSourceLanguage =
@@ -184,6 +184,16 @@ export interface CompilerExtractionResult {
 export interface CompilerExtractionOptions {
   /** Additional options used only by the inferred program. */
   inferredCompilerOptions?: ts.CompilerOptions;
+  /**
+   * Run the full per-file semantic type-check and record its diagnostics.
+   * Off by default: `parse_status` derives from syntactic diagnostics alone,
+   * and reference/signature extraction uses the checker lazily, so the full
+   * semantic pass only adds diagnostics detail — at a wall-clock/RSS cost that
+   * scales with the resolvable dependency surface (issue #140 observation 1/2).
+   */
+  semanticDiagnostics?: boolean;
+  /** Test seam: replaces `ts.createProgram` to exercise program-crash isolation. */
+  programFactory?: (options: ts.CreateProgramOptions) => ts.Program;
 }
 
 interface ParsedProject {
@@ -311,19 +321,36 @@ export function buildTypeScriptExtraction(
   const root = resolve(rootDir);
   const candidates = collectCandidates(root, candidateFiles);
   const parsedProjects = parseProjects(root, new Set(candidates));
-  const runtimeProjects: RuntimeProject[] = parsedProjects.map((project) => {
-    const program = ts.createProgram({
-      rootNames: project.parsed.fileNames,
-      options: project.parsed.options,
-      projectReferences: project.parsed.projectReferences,
-    });
-    return { ...project, program, checker: program.getTypeChecker() };
-  });
+  const createProgram = options.programFactory ?? ts.createProgram;
+  const runtimeProjects: RuntimeProject[] = [];
+  const poisonedFiles = new Set<string>();
+  for (const project of parsedProjects) {
+    // Program creation parses every root file; a single malformed source (e.g.
+    // a hostile test fixture) can hit a TS-internal assertion. Isolate the
+    // failure to this project so its files fall back to tree-sitter extraction
+    // instead of aborting the whole corpus (issue #140 follow-up finding).
+    try {
+      const program = createProgram({
+        rootNames: project.parsed.fileNames,
+        // Never type-check library .d.ts or emit: extraction only needs the
+        // checker's lazy symbol/type queries, not a full compile.
+        options: { ...project.parsed.options, skipLibCheck: true, noEmit: true },
+        projectReferences: project.parsed.projectReferences,
+      });
+      runtimeProjects.push({ ...project, program, checker: program.getTypeChecker() });
+    } catch {
+      for (const file of project.parsed.fileNames) poisonedFiles.add(normalizedAbsolute(file));
+    }
+  }
 
   const ownership = new Map<string, RuntimeProject>();
   for (const file of candidates) {
+    if (poisonedFiles.has(file)) continue;
     const owners = runtimeProjects
-      .filter((project) => project.program.getSourceFile(file) !== undefined)
+      .filter((project) => {
+        try { return project.program.getSourceFile(file) !== undefined; }
+        catch { return false; }
+      })
       .sort((left, right) => {
         const specificity = dirname(right.configPath).length - dirname(left.configPath).length;
         return specificity || left.configPath.localeCompare(right.configPath);
@@ -331,7 +358,9 @@ export function buildTypeScriptExtraction(
     if (owners[0]) ownership.set(file, owners[0]);
   }
 
-  const uncovered = candidates.filter((file) => !ownership.has(file));
+  // Files from a crashed project stay out of the inferred program too — the
+  // poison root file would crash it as well. They fall back to tree-sitter.
+  const uncovered = candidates.filter((file) => !ownership.has(file) && !poisonedFiles.has(file));
   let inferred: RuntimeProject | undefined;
   if (uncovered.length > 0) {
     const inferredOptions: ts.CompilerOptions = {
@@ -345,21 +374,25 @@ export function buildTypeScriptExtraction(
       target: ts.ScriptTarget.ES2022,
       ...options.inferredCompilerOptions,
     };
-    const program = ts.createProgram({ rootNames: uncovered, options: inferredOptions });
-    inferred = {
-      id: "inferred",
-      configPath: "",
-      parsed: {
-        options: inferredOptions,
-        fileNames: uncovered,
-        errors: [],
-      },
-      diagnostics: [],
-      program,
-      checker: program.getTypeChecker(),
-    };
-    runtimeProjects.push(inferred);
-    for (const file of uncovered) ownership.set(file, inferred);
+    try {
+      const program = createProgram({ rootNames: uncovered, options: inferredOptions });
+      inferred = {
+        id: "inferred",
+        configPath: "",
+        parsed: {
+          options: inferredOptions,
+          fileNames: uncovered,
+          errors: [],
+        },
+        diagnostics: [],
+        program,
+        checker: program.getTypeChecker(),
+      };
+      runtimeProjects.push(inferred);
+      for (const file of uncovered) ownership.set(file, inferred);
+    } catch {
+      // Poison among the uncovered roots: leave them all to tree-sitter.
+    }
   }
 
   const contexts: FileContext[] = [];
@@ -368,7 +401,7 @@ export function buildTypeScriptExtraction(
     const sourceFile = project?.program.getSourceFile(absoluteFile);
     if (!project || !sourceFile) continue;
     const filePath = relativePath(root, absoluteFile);
-    const { health, ranges } = sourceHealth(project.program, sourceFile);
+    const { health, ranges } = sourceHealth(project.program, sourceFile, options.semanticDiagnostics ?? false);
     const context: FileContext = {
       filePath,
       sourceFile,
@@ -1239,9 +1272,15 @@ function parameterIsInvoked(
   return invoked;
 }
 
-function sourceHealth(program: ts.Program, sourceFile: ts.SourceFile): { health: CompilerSourceHealth; ranges: ErrorRange[] } {
+function sourceHealth(
+  program: ts.Program,
+  sourceFile: ts.SourceFile,
+  semanticDiagnostics: boolean,
+): { health: CompilerSourceHealth; ranges: ErrorRange[] } {
   const syntactic = program.getSyntacticDiagnostics(sourceFile);
-  const semantic = program.getSemanticDiagnostics(sourceFile);
+  // The full semantic pass type-checks the whole file (and everything it can
+  // resolve). `status` never depends on it, so it is opt-in (issue #140).
+  const semantic = semanticDiagnostics ? program.getSemanticDiagnostics(sourceFile) : [];
   const ranges = diagnosticRanges(sourceFile.text, syntactic);
   const coveredBytes = ranges.reduce((total, range) => total + Buffer.byteLength(sourceFile.text.slice(range.start, range.end), "utf8"), 0);
   const totalBytes = Math.max(1, Buffer.byteLength(sourceFile.text, "utf8"));

--- a/src/graph/extraction/compiler.ts
+++ b/src/graph/extraction/compiler.ts
@@ -258,6 +258,86 @@ interface PendingReference extends Omit<CompilerReference, "id"> {
   identityHint: string;
 }
 
+// ── Sequential capture (issue #140: one program alive at a time) ─────────────
+//
+// Cross-project reference linkage flows through declaration-location STRINGS
+// (`declarationLocation`: absolute path + start offset + syntax kind), which
+// are identical across programs for the same file bytes. That is what already
+// made multi-program resolution work when every program was held concurrently —
+// and it is exactly what lets each project's program be RELEASED after a
+// capture pass: everything AST- or checker-derived (positions, texts, symbol
+// declaration locations, polymorphism, invocation proofs) is computed while
+// the program is alive, and only the string-keyed lookups into the corpus-wide
+// location→id map are deferred to a final, compiler-free finishing pass. Peak
+// memory becomes the largest single project instead of the sum of all of them.
+
+interface DeferredImportBinding {
+  binding: Omit<CompilerImportBinding, "targetId">;
+  /** Declaration locations of the imported symbol (alias-resolved). */
+  targetLocations: readonly string[];
+}
+
+type CapturedReference =
+  | { form: "final"; position: number; identityHint: string; reference: Omit<CompilerReference, "id"> }
+  | {
+      form: "import"; position: number; line: number; column: number; sourceId: string;
+      bindingId: string; moduleSpecifier: string; resolvedFilePath?: string;
+    }
+  | {
+      form: "call"; position: number; line: number; column: number; sourceId: string;
+      isNew: boolean; targetName: string; receiver?: string; polymorphic: boolean;
+      candidateLocations: readonly string[]; expressionText: string; signatureText?: string;
+    }
+  | {
+      form: "heritage"; position: number; line: number; column: number; sourceId: string;
+      isImplements: boolean; targetName: string; targetLocations: readonly string[];
+    }
+  | {
+      form: "identifier"; position: number; line: number; column: number; sourceId: string;
+      text: string; receiver?: string; targetLocations: readonly string[];
+    }
+  | {
+      form: "callback"; position: number; line: number; column: number;
+      calleeLocations: readonly string[]; callbackDraftId?: string;
+      callbackLocations: readonly string[]; parameterName: string; argumentIndex: number;
+      wiringSite: string; argumentText: string;
+    };
+
+/** Everything retained for a file once its project's program is released. */
+interface CapturedFile {
+  filePath: string;
+  language: CompilerSourceLanguage;
+  projectId: string;
+  health: CompilerSourceHealth;
+  nodes: CompilerExtractedNode[];
+  fileDraftId?: string;
+  bindings: DeferredImportBinding[];
+  captured: CapturedReference[];
+}
+
+/** Capture-time half of the old `idsForSymbol`: symbol → declaration locations. */
+function declarationLocationsForSymbol(
+  symbol: ts.Symbol | undefined,
+  checker: ts.TypeChecker,
+): string[] {
+  if (!symbol) return [];
+  const resolved = canonicalSymbol(symbol, checker);
+  return [...new Set((resolved.declarations ?? []).map(declarationLocation))];
+}
+
+/** Finish-time half: locations → the same sorted unique ids `idsForSymbol` produced. */
+function idsForLocations(
+  locations: readonly string[],
+  locationIds: ReadonlyMap<string, string>,
+): string[] {
+  const ids = new Set<string>();
+  for (const location of locations) {
+    const id = locationIds.get(location);
+    if (id) ids.add(id);
+  }
+  return [...ids].sort();
+}
+
 const SOURCE_EXTENSIONS = new Set([
   ".ts",
   ".tsx",
@@ -322,46 +402,126 @@ export function buildTypeScriptExtraction(
   const candidates = collectCandidates(root, candidateFiles);
   const parsedProjects = parseProjects(root, new Set(candidates));
   const createProgram = options.programFactory ?? ts.createProgram;
-  const runtimeProjects: RuntimeProject[] = [];
+  const semanticDiagnostics = options.semanticDiagnostics ?? false;
+
+  // Ownership priority: most specific config directory first, then path order —
+  // the identical comparator the previous probe-every-program-then-sort
+  // implementation applied per file. Processing projects in this global order
+  // lets each candidate be claimed greedily by the FIRST containing project
+  // (the same winner), without holding every program alive to compare.
+  const processingOrder = [...parsedProjects].sort((left, right) => {
+    const specificity = dirname(right.configPath).length - dirname(left.configPath).length;
+    return specificity || left.configPath.localeCompare(right.configPath);
+  });
+
+  const claimed = new Set<string>();
   const poisonedFiles = new Set<string>();
-  for (const project of parsedProjects) {
+  const crashedProjects = new Set<ParsedProject>();
+  const locationIds = new Map<string, string>();
+  const nodeById = new Map<string, CompilerExtractedNode>();
+  const capturedByFile = new Map<string, CapturedFile>();
+
+  // Stage one project's owned files while its program is alive; retain only
+  // plain data. Nothing stored here references the program, checker, or AST.
+  const processProject = (project: ParsedProject, program: ts.Program, owned: readonly string[]): void => {
+    const runtime: RuntimeProject = { ...project, program, checker: program.getTypeChecker() };
+    const contexts: FileContext[] = [];
+    for (const absoluteFile of owned) {
+      const sourceFile = program.getSourceFile(absoluteFile);
+      if (!sourceFile) continue;
+      const filePath = relativePath(root, absoluteFile);
+      const { health, ranges } = sourceHealth(program, sourceFile, semanticDiagnostics);
+      const context: FileContext = {
+        filePath,
+        sourceFile,
+        project: runtime,
+        language: languageForFile(filePath),
+        health,
+        errorRanges: ranges,
+        excludedDeclarationRanges: [],
+        drafts: [],
+        declarationDrafts: new Map(),
+        symbolDrafts: new Map(),
+        nodes: [],
+      };
+      if (health.status !== "failed") {
+        collectDrafts(context);
+        if (health.status === "partial" && context.drafts.length <= 1) {
+          health.status = "failed";
+          context.drafts = [];
+          context.fileDraft = undefined;
+          context.declarationDrafts.clear();
+          context.symbolDrafts.clear();
+        }
+      }
+      contexts.push(context);
+    }
+
+    assignCanonicalIdentities(contexts);
+    for (const context of contexts) {
+      for (const draft of context.drafts) {
+        if (!draft.id) continue;
+        for (const declaration of draft.declarations) {
+          locationIds.set(declarationLocation(declaration), draft.id);
+        }
+      }
+      context.nodes = materializeNodes(context);
+      for (const node of context.nodes) nodeById.set(node.id, node);
+    }
+    for (const context of contexts) {
+      const bindings = captureImportBindings(root, context);
+      capturedByFile.set(normalizedAbsolute(context.sourceFile.fileName), {
+        filePath: context.filePath,
+        language: context.language,
+        projectId: runtime.id,
+        health: context.health,
+        nodes: context.nodes,
+        fileDraftId: context.fileDraft?.id,
+        bindings,
+        captured: captureReferences(context, bindings),
+      });
+    }
+  };
+
+  for (const project of processingOrder) {
     // Program creation parses every root file; a single malformed source (e.g.
     // a hostile test fixture) can hit a TS-internal assertion. Isolate the
     // failure to this project so its files fall back to tree-sitter extraction
     // instead of aborting the whole corpus (issue #140 follow-up finding).
+    let program: ts.Program;
     try {
-      const program = createProgram({
+      program = createProgram({
         rootNames: project.parsed.fileNames,
         // Never type-check library .d.ts or emit: extraction only needs the
         // checker's lazy symbol/type queries, not a full compile.
         options: { ...project.parsed.options, skipLibCheck: true, noEmit: true },
         projectReferences: project.parsed.projectReferences,
       });
-      runtimeProjects.push({ ...project, program, checker: program.getTypeChecker() });
     } catch {
-      for (const file of project.parsed.fileNames) poisonedFiles.add(normalizedAbsolute(file));
+      crashedProjects.add(project);
+      // Poison only files no healthier, more specific project has already
+      // extracted — a crash cannot retroactively un-stage a good extraction.
+      for (const file of project.parsed.fileNames) {
+        const absolute = normalizedAbsolute(file);
+        if (!claimed.has(absolute)) poisonedFiles.add(absolute);
+      }
+      continue;
     }
-  }
-
-  const ownership = new Map<string, RuntimeProject>();
-  for (const file of candidates) {
-    if (poisonedFiles.has(file)) continue;
-    const owners = runtimeProjects
-      .filter((project) => {
-        try { return project.program.getSourceFile(file) !== undefined; }
-        catch { return false; }
-      })
-      .sort((left, right) => {
-        const specificity = dirname(right.configPath).length - dirname(left.configPath).length;
-        return specificity || left.configPath.localeCompare(right.configPath);
-      });
-    if (owners[0]) ownership.set(file, owners[0]);
+    const owned = candidates.filter((file) => {
+      if (claimed.has(file) || poisonedFiles.has(file)) return false;
+      try { return program.getSourceFile(file) !== undefined; }
+      catch { return false; }
+    });
+    for (const file of owned) claimed.add(file);
+    processProject(project, program, owned);
+    // program goes out of scope here — the peak-memory point of the old
+    // implementation (every program + checker alive simultaneously) is gone.
   }
 
   // Files from a crashed project stay out of the inferred program too — the
   // poison root file would crash it as well. They fall back to tree-sitter.
-  const uncovered = candidates.filter((file) => !ownership.has(file) && !poisonedFiles.has(file));
-  let inferred: RuntimeProject | undefined;
+  const uncovered = candidates.filter((file) => !claimed.has(file) && !poisonedFiles.has(file));
+  let inferredProject: ParsedProject | undefined;
   if (uncovered.length > 0) {
     const inferredOptions: ts.CompilerOptions = {
       allowJs: true,
@@ -376,7 +536,7 @@ export function buildTypeScriptExtraction(
     };
     try {
       const program = createProgram({ rootNames: uncovered, options: inferredOptions });
-      inferred = {
+      inferredProject = {
         id: "inferred",
         configPath: "",
         parsed: {
@@ -385,79 +545,45 @@ export function buildTypeScriptExtraction(
           errors: [],
         },
         diagnostics: [],
-        program,
-        checker: program.getTypeChecker(),
       };
-      runtimeProjects.push(inferred);
-      for (const file of uncovered) ownership.set(file, inferred);
+      processProject(inferredProject, program, uncovered);
     } catch {
       // Poison among the uncovered roots: leave them all to tree-sitter.
     }
   }
 
-  const contexts: FileContext[] = [];
+  // ── Finishing pass: compiler-free. Resolve deferred declaration locations
+  // against the now-complete corpus-wide location→id map, replaying exactly
+  // the id/status/candidate logic the old concurrent implementation applied.
+  const fileDraftIdByPath = new Map<string, string>();
+  for (const captured of capturedByFile.values()) {
+    if (captured.fileDraftId) fileDraftIdByPath.set(captured.filePath, captured.fileDraftId);
+  }
+
+  const files: CompilerFileExtraction[] = [];
   for (const absoluteFile of candidates) {
-    const project = ownership.get(absoluteFile);
-    const sourceFile = project?.program.getSourceFile(absoluteFile);
-    if (!project || !sourceFile) continue;
-    const filePath = relativePath(root, absoluteFile);
-    const { health, ranges } = sourceHealth(project.program, sourceFile, options.semanticDiagnostics ?? false);
-    const context: FileContext = {
-      filePath,
-      sourceFile,
-      project,
-      language: languageForFile(filePath),
-      health,
-      errorRanges: ranges,
-      excludedDeclarationRanges: [],
-      drafts: [],
-      declarationDrafts: new Map(),
-      symbolDrafts: new Map(),
-      nodes: [],
-    };
-    if (health.status !== "failed") {
-      collectDrafts(context);
-      if (health.status === "partial" && context.drafts.length <= 1) {
-        health.status = "failed";
-        context.drafts = [];
-        context.fileDraft = undefined;
-        context.declarationDrafts.clear();
-        context.symbolDrafts.clear();
-      }
-    }
-    contexts.push(context);
-  }
-
-  assignCanonicalIdentities(contexts);
-
-  const locationIds = new Map<string, string>();
-  const nodeById = new Map<string, CompilerExtractedNode>();
-  for (const context of contexts) {
-    for (const draft of context.drafts) {
-      if (!draft.id) continue;
-      for (const declaration of draft.declarations) {
-        locationIds.set(declarationLocation(declaration), draft.id);
-      }
-    }
-    context.nodes = materializeNodes(context);
-    for (const node of context.nodes) nodeById.set(node.id, node);
-  }
-
-  const files = contexts.map((context) => {
-    const importBindings = extractImportBindings(root, context, locationIds);
-    const references = extractReferences(context, contexts, locationIds, nodeById, importBindings);
-    return {
-      filePath: context.filePath,
-      language: context.language,
-      projectId: context.project.id,
-      health: context.health,
-      nodes: context.nodes,
+    const captured = capturedByFile.get(absoluteFile);
+    if (!captured) continue;
+    const importBindings: CompilerImportBinding[] = captured.bindings.map(({ binding, targetLocations }) => ({
+      ...binding,
+      targetId: idsForLocations(targetLocations, locationIds)[0],
+    }));
+    files.push({
+      filePath: captured.filePath,
+      language: captured.language,
+      projectId: captured.projectId,
+      health: captured.health,
+      nodes: captured.nodes,
       importBindings,
-      references,
-    } satisfies CompilerFileExtraction;
-  });
+      references: finishReferences(captured, importBindings, locationIds, nodeById, fileDraftIdByPath),
+    } satisfies CompilerFileExtraction);
+  }
 
-  const projectSummaries: DiscoveredTypeScriptProject[] = runtimeProjects.map((project) => ({
+  const summaryProjects: ParsedProject[] = [
+    ...parsedProjects.filter((project) => !crashedProjects.has(project)),
+    ...(inferredProject ? [inferredProject] : []),
+  ];
+  const projectSummaries: DiscoveredTypeScriptProject[] = summaryProjects.map((project) => ({
     id: project.id,
     configPath: project.configPath ? relativePath(root, project.configPath) : null,
     projectReferences: (project.parsed.projectReferences ?? [])
@@ -864,12 +990,16 @@ function materializeNodes(context: FileContext): CompilerExtractedNode[] {
     });
 }
 
-function extractImportBindings(
+/**
+ * Capture-time import extraction: identical to the old `extractImportBindings`
+ * except the imported symbol resolves to declaration LOCATIONS, not ids — the
+ * finishing pass maps them once every project has contributed to the map.
+ */
+function captureImportBindings(
   root: string,
   context: FileContext,
-  locationIds: ReadonlyMap<string, string>,
-): CompilerImportBinding[] {
-  const bindings: CompilerImportBinding[] = [];
+): DeferredImportBinding[] {
+  const bindings: DeferredImportBinding[] = [];
   const checker = context.project.checker;
   const options = context.project.program.getCompilerOptions();
   for (const statement of context.sourceFile.statements) {
@@ -886,24 +1016,25 @@ function extractImportBindings(
       flags: { isDefault?: boolean; isNamespace?: boolean; isTypeOnly?: boolean } = {},
     ): void => {
       const symbol = checker.getSymbolAtLocation(local);
-      const targetId = symbol ? idForSymbol(symbol, checker, locationIds) : undefined;
       const position = context.sourceFile.getLineAndCharacterOfPosition(local.getStart(context.sourceFile));
       const identity = [context.filePath, local.text, moduleSpecifier, importedName].join("\u0000");
       bindings.push({
-        id: `import:${sha256(identity).slice(0, 32)}`,
-        filePath: context.filePath,
-        localName: local.text,
-        importedName,
-        moduleSpecifier,
-        resolvedFilePath,
-        targetId,
-        isTypeOnly: Boolean(statement.importClause?.isTypeOnly || flags.isTypeOnly),
-        isNamespace: Boolean(flags.isNamespace),
-        isDefault: Boolean(flags.isDefault),
-        line: position.line,
-        column: position.character,
-        confidence: 1,
-        resolutionMethod: "typescript-import",
+        binding: {
+          id: `import:${sha256(identity).slice(0, 32)}`,
+          filePath: context.filePath,
+          localName: local.text,
+          importedName,
+          moduleSpecifier,
+          resolvedFilePath,
+          isTypeOnly: Boolean(statement.importClause?.isTypeOnly || flags.isTypeOnly),
+          isNamespace: Boolean(flags.isNamespace),
+          isDefault: Boolean(flags.isDefault),
+          line: position.line,
+          column: position.character,
+          confidence: 1,
+          resolutionMethod: "typescript-import",
+        },
+        targetLocations: declarationLocationsForSymbol(symbol, checker),
       });
     };
     const clause = statement.importClause;
@@ -917,85 +1048,240 @@ function extractImportBindings(
       }
     }
   }
-  return bindings.sort((left, right) => left.line - right.line || left.column - right.column || left.id.localeCompare(right.id));
+  return bindings.sort((left, right) => left.binding.line - right.binding.line
+    || left.binding.column - right.binding.column
+    || left.binding.id.localeCompare(right.binding.id));
 }
 
-function extractReferences(
+function captureReferences(
   context: FileContext,
-  contexts: readonly FileContext[],
-  locationIds: ReadonlyMap<string, string>,
-  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
-  importBindings: readonly CompilerImportBinding[],
-): CompilerReference[] {
+  importBindings: readonly DeferredImportBinding[],
+): CapturedReference[] {
   if (!context.fileDraft?.id) return [];
-  const pending: PendingReference[] = [];
-  const checker = context.project.checker;
-
-  const push = (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string): void => {
-    pending.push({ ...reference, position, identityHint });
-  };
+  const fileDraftId = context.fileDraft.id;
+  const captured: CapturedReference[] = [];
 
   // Structural containment is compiler-proven and never inferred by name.
   for (const draft of context.drafts) {
     if (!draft.id || !draft.container?.id) continue;
     const position = declarationStart(draft);
-    push({
-      sourceId: draft.container.id,
-      targetId: draft.id,
-      kind: "contains",
-      targetName: draft.name,
-      targetQualifiedName: draft.qualifiedName,
-      candidates: [draft.id],
-      status: "resolved",
-      confidence: 1,
-      resolutionMethod: "lexical-containment",
-      provenance: "typescript-compiler",
-      filePath: context.filePath,
-      line: lineColumn(context.sourceFile, position).line,
-      column: lineColumn(context.sourceFile, position).column,
-      evidence: { declarationRole: draft.declarationRole },
-    }, position, `contains:${draft.identityKey}`);
+    const point = lineColumn(context.sourceFile, position);
+    captured.push({
+      form: "final",
+      position,
+      identityHint: `contains:${draft.identityKey}`,
+      reference: {
+        sourceId: draft.container.id,
+        targetId: draft.id,
+        kind: "contains",
+        targetName: draft.name,
+        targetQualifiedName: draft.qualifiedName,
+        candidates: [draft.id],
+        status: "resolved",
+        confidence: 1,
+        resolutionMethod: "lexical-containment",
+        provenance: "typescript-compiler",
+        filePath: context.filePath,
+        line: point.line,
+        column: point.column,
+        evidence: { declarationRole: draft.declarationRole },
+      },
+    });
   }
 
-  for (const binding of importBindings) {
-    const resolvedFilePath = binding.resolvedFilePath;
-    const targetFileId = resolvedFilePath
-      ? contexts.find((entry) => entry.filePath === normalizeRelative(resolvedFilePath))?.fileDraft?.id
-      : undefined;
-    const targetId = targetFileId ?? binding.targetId;
-    push({
-      sourceId: context.fileDraft.id,
-      targetId,
-      kind: "imports",
-      targetName: binding.moduleSpecifier,
-      targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
-      candidates: targetId ? [targetId] : [],
-      status: targetId ? "resolved" : "unresolved",
-      confidence: targetId ? 1 : 0,
-      resolutionMethod: "typescript-import",
-      provenance: "typescript-compiler",
-      filePath: context.filePath,
+  for (const { binding } of importBindings) {
+    captured.push({
+      form: "import",
+      position: context.sourceFile.getPositionOfLineAndCharacter(binding.line, binding.column),
       line: binding.line,
       column: binding.column,
-      evidence: { importBindingId: binding.id, resolvedFilePath: binding.resolvedFilePath },
-    }, context.sourceFile.getPositionOfLineAndCharacter(binding.line, binding.column), `import:${binding.id}`);
+      sourceId: fileDraftId,
+      bindingId: binding.id,
+      moduleSpecifier: binding.moduleSpecifier,
+      resolvedFilePath: binding.resolvedFilePath,
+    });
   }
 
   const visit = (node: ts.Node): void => {
     const trusted = referenceSyntaxIsTrusted(node, context);
     if (trusted && (ts.isCallExpression(node) || ts.isNewExpression(node))) {
-      emitCallReference(node, context, locationIds, nodeById, push);
+      captureCallReference(node, context, captured);
       if (ts.isCallExpression(node)) {
-        emitCallbackReferences(node, context, locationIds, nodeById, push);
+        captureCallbackReferences(node, context, captured);
       }
     } else if (trusted && ts.isHeritageClause(node)) {
-      emitHeritageReferences(node, context, locationIds, nodeById, push);
+      captureHeritageReferences(node, context, captured);
     } else if (trusted && ts.isIdentifier(node) && shouldEmitIdentifierReference(node)) {
-      emitIdentifierReference(node, context, locationIds, nodeById, push);
+      captureIdentifierReference(node, context, captured);
     }
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(context.sourceFile, visit);
+  return captured;
+}
+
+/**
+ * Finishing pass for one file: compiler-free. Resolves the deferred
+ * declaration locations against the corpus-wide location→id map and replays
+ * exactly the id/status/candidate/skip logic the concurrent implementation
+ * applied at emission time, then the original sort → ordinal → hash tail.
+ */
+function finishReferences(
+  file: CapturedFile,
+  importBindings: readonly CompilerImportBinding[],
+  locationIds: ReadonlyMap<string, string>,
+  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
+  fileDraftIdByPath: ReadonlyMap<string, string>,
+): CompilerReference[] {
+  const bindingById = new Map(importBindings.map((binding) => [binding.id, binding]));
+  const pending: PendingReference[] = [];
+  for (const record of file.captured) {
+    switch (record.form) {
+      case "final": {
+        pending.push({ ...record.reference, position: record.position, identityHint: record.identityHint });
+        break;
+      }
+      case "import": {
+        const binding = bindingById.get(record.bindingId);
+        if (!binding) break;
+        const targetFileId = binding.resolvedFilePath
+          ? fileDraftIdByPath.get(normalizeRelative(binding.resolvedFilePath))
+          : undefined;
+        const targetId = targetFileId ?? binding.targetId;
+        pending.push({
+          sourceId: record.sourceId,
+          targetId,
+          kind: "imports",
+          targetName: record.moduleSpecifier,
+          targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+          candidates: targetId ? [targetId] : [],
+          status: targetId ? "resolved" : "unresolved",
+          confidence: targetId ? 1 : 0,
+          resolutionMethod: "typescript-import",
+          provenance: "typescript-compiler",
+          filePath: file.filePath,
+          line: record.line,
+          column: record.column,
+          evidence: { importBindingId: binding.id, resolvedFilePath: binding.resolvedFilePath },
+          position: record.position,
+          identityHint: `import:${binding.id}`,
+        });
+        break;
+      }
+      case "call": {
+        const candidates = idsForLocations(record.candidateLocations, locationIds);
+        const uniqueCandidate = !record.polymorphic && candidates.length === 1 ? candidates[0] : undefined;
+        const ambiguous = !uniqueCandidate && (candidates.length > 0 || record.polymorphic);
+        pending.push({
+          sourceId: record.sourceId,
+          targetId: uniqueCandidate,
+          kind: record.isNew ? "instantiates" : "calls",
+          targetName: record.targetName,
+          targetQualifiedName: uniqueCandidate ? nodeById.get(uniqueCandidate)?.qualifiedName : undefined,
+          receiver: record.receiver,
+          qualifier: record.receiver,
+          candidates,
+          status: uniqueCandidate ? "resolved" : ambiguous ? "ambiguous" : "unresolved",
+          confidence: uniqueCandidate ? 1 : ambiguous ? 0.75 : 0,
+          resolutionMethod: "typescript-signature",
+          provenance: "typescript-compiler",
+          filePath: file.filePath,
+          line: record.line,
+          column: record.column,
+          evidence: {
+            expression: record.expressionText,
+            signature: record.signatureText,
+            polymorphic: record.polymorphic,
+          },
+          position: record.position,
+          identityHint: `${record.targetName}:${record.receiver ?? ""}`,
+        });
+        break;
+      }
+      case "heritage": {
+        const targetId = idsForLocations(record.targetLocations, locationIds)[0];
+        pending.push({
+          sourceId: record.sourceId,
+          targetId,
+          kind: record.isImplements ? "implements" : "extends",
+          targetName: record.targetName,
+          targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+          candidates: targetId ? [targetId] : [],
+          status: targetId ? "resolved" : "unresolved",
+          confidence: targetId ? 1 : 0,
+          resolutionMethod: "typescript-heritage",
+          provenance: "typescript-compiler",
+          filePath: file.filePath,
+          line: record.line,
+          column: record.column,
+          evidence: { heritage: record.isImplements ? "implements" : "extends" },
+          position: record.position,
+          identityHint: record.targetName,
+        });
+        break;
+      }
+      case "identifier": {
+        const targetIds = idsForLocations(record.targetLocations, locationIds);
+        const targetId = targetIds.length === 1 ? targetIds[0] : undefined;
+        if (targetId === record.sourceId || targetIds.length === 0) break;
+        pending.push({
+          sourceId: record.sourceId,
+          targetId,
+          kind: "references",
+          targetName: record.text,
+          targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
+          receiver: record.receiver,
+          qualifier: record.receiver,
+          candidates: targetIds,
+          status: targetId ? "resolved" : "ambiguous",
+          confidence: targetId ? 1 : 0.75,
+          resolutionMethod: "typescript-symbol",
+          provenance: "typescript-compiler",
+          filePath: file.filePath,
+          line: record.line,
+          column: record.column,
+          evidence: { expression: record.text },
+          position: record.position,
+          identityHint: `${record.text}:${record.receiver ?? ""}`,
+        });
+        break;
+      }
+      case "callback": {
+        const calleeId = idsForLocations(record.calleeLocations, locationIds)[0];
+        if (!calleeId) break;
+        let callbackId = record.callbackDraftId;
+        if (!callbackId) {
+          const callbackIds = idsForLocations(record.callbackLocations, locationIds);
+          callbackId = callbackIds.length === 1 ? callbackIds[0] : undefined;
+        }
+        if (!callbackId) break;
+        pending.push({
+          sourceId: calleeId,
+          targetId: callbackId,
+          kind: "calls",
+          targetName: nodeById.get(callbackId)?.name ?? record.argumentText,
+          targetQualifiedName: nodeById.get(callbackId)?.qualifiedName,
+          candidates: [callbackId],
+          status: "resolved",
+          confidence: 0.85,
+          resolutionMethod: "typescript-callback-parameter",
+          provenance: "callback-synthesis",
+          filePath: file.filePath,
+          line: record.line,
+          column: record.column,
+          evidence: {
+            parameterName: record.parameterName,
+            argumentIndex: record.argumentIndex,
+            wiringSite: record.wiringSite,
+            callee: nodeById.get(calleeId)?.qualifiedName,
+          },
+          position: record.position,
+          identityHint: `callback:${calleeId}:${record.parameterName}:${record.argumentIndex}:${callbackId}`,
+        });
+        break;
+      }
+    }
+  }
 
   pending.sort((left, right) => left.position - right.position || left.kind.localeCompare(right.kind) || left.identityHint.localeCompare(right.identityHint));
   const occurrence = new Map<string, number>();
@@ -1010,12 +1296,10 @@ function extractReferences(
   });
 }
 
-function emitCallReference(
+function captureCallReference(
   node: ts.CallExpression | ts.NewExpression,
   context: FileContext,
-  locationIds: ReadonlyMap<string, string>,
-  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
-  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+  captured: CapturedReference[],
 ): void {
   const checker = context.project.checker;
   const expression = node.expression;
@@ -1026,18 +1310,18 @@ function emitCallReference(
     ? symbolForDeclaration(resolvedSignature.declaration, checker)
     : undefined;
   const expressionSymbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(expression) ? expression.name : expression);
-  const signatureTargets = idsForSymbol(signatureSymbol, checker, locationIds);
-  const expressionTargets = idsForSymbol(expressionSymbol, checker, locationIds);
   const callSignatures = checker.getTypeAtLocation(expression).getCallSignatures();
-  const candidates = [...new Set(callSignatures
+  const candidateLocations = [...new Set(callSignatures
     .map((signature) => signature.declaration ? symbolForDeclaration(signature.declaration, checker) : undefined)
-    .flatMap((symbol) => idsForSymbol(symbol, checker, locationIds))
-    .concat(signatureTargets, expressionTargets))].sort();
+    .flatMap((symbol) => declarationLocationsForSymbol(symbol, checker))
+    .concat(
+      declarationLocationsForSymbol(signatureSymbol, checker),
+      declarationLocationsForSymbol(expressionSymbol, checker),
+    ))];
   const polymorphic = ts.isPropertyAccessExpression(expression)
     && expression.expression.kind !== ts.SyntaxKind.ThisKeyword
     && expression.expression.kind !== ts.SyntaxKind.SuperKeyword
     && isPolymorphicReceiver(checker.getTypeAtLocation(expression.expression));
-  const uniqueCandidate = !polymorphic && candidates.length === 1 ? candidates[0] : undefined;
   const receiver = ts.isPropertyAccessExpression(expression) ? expression.expression.getText(context.sourceFile) : undefined;
   const targetName = ts.isPropertyAccessExpression(expression)
     ? expression.name.text
@@ -1048,119 +1332,88 @@ function emitCallReference(
     ? expression.name.getStart(context.sourceFile)
     : expression.getStart(context.sourceFile);
   const point = lineColumn(context.sourceFile, position);
-  const ambiguous = !uniqueCandidate && (candidates.length > 0 || polymorphic);
-  push({
-    sourceId,
-    targetId: uniqueCandidate,
-    kind: ts.isNewExpression(node) ? "instantiates" : "calls",
-    targetName,
-    targetQualifiedName: uniqueCandidate ? nodeById.get(uniqueCandidate)?.qualifiedName : undefined,
-    receiver,
-    qualifier: receiver,
-    candidates,
-    status: uniqueCandidate ? "resolved" : ambiguous ? "ambiguous" : "unresolved",
-    confidence: uniqueCandidate ? 1 : ambiguous ? 0.75 : 0,
-    resolutionMethod: "typescript-signature",
-    provenance: "typescript-compiler",
-    filePath: context.filePath,
+  captured.push({
+    form: "call",
+    position,
     line: point.line,
     column: point.column,
-    evidence: {
-      expression: expression.getText(context.sourceFile),
-      signature: resolvedSignature ? normalizeSignature(checker.signatureToString(resolvedSignature, node)) : undefined,
-      polymorphic,
-    },
-  }, position, `${targetName}:${receiver ?? ""}`);
+    sourceId,
+    isNew: ts.isNewExpression(node),
+    targetName,
+    receiver,
+    polymorphic,
+    candidateLocations,
+    expressionText: expression.getText(context.sourceFile),
+    signatureText: resolvedSignature ? normalizeSignature(checker.signatureToString(resolvedSignature, node)) : undefined,
+  });
 }
 
-function emitHeritageReferences(
+function captureHeritageReferences(
   clause: ts.HeritageClause,
   context: FileContext,
-  locationIds: ReadonlyMap<string, string>,
-  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
-  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+  captured: CapturedReference[],
 ): void {
   const sourceId = enclosingSourceId(clause.parent, context);
   if (!sourceId) return;
   const checker = context.project.checker;
   for (const type of clause.types) {
     const symbol = checker.getSymbolAtLocation(type.expression);
-    const targetId = idForSymbol(symbol, checker, locationIds);
     const targetName = type.expression.getText(context.sourceFile);
     const position = type.getStart(context.sourceFile);
     const point = lineColumn(context.sourceFile, position);
-    push({
-      sourceId,
-      targetId,
-      kind: clause.token === ts.SyntaxKind.ImplementsKeyword ? "implements" : "extends",
-      targetName,
-      targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
-      candidates: targetId ? [targetId] : [],
-      status: targetId ? "resolved" : "unresolved",
-      confidence: targetId ? 1 : 0,
-      resolutionMethod: "typescript-heritage",
-      provenance: "typescript-compiler",
-      filePath: context.filePath,
+    captured.push({
+      form: "heritage",
+      position,
       line: point.line,
       column: point.column,
-      evidence: { heritage: clause.token === ts.SyntaxKind.ImplementsKeyword ? "implements" : "extends" },
-    }, position, targetName);
+      sourceId,
+      isImplements: clause.token === ts.SyntaxKind.ImplementsKeyword,
+      targetName,
+      targetLocations: declarationLocationsForSymbol(symbol, checker),
+    });
   }
 }
 
-function emitIdentifierReference(
+function captureIdentifierReference(
   identifier: ts.Identifier,
   context: FileContext,
-  locationIds: ReadonlyMap<string, string>,
-  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
-  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+  captured: CapturedReference[],
 ): void {
   const checker = context.project.checker;
   const symbol = checker.getSymbolAtLocation(identifier);
-  const targetIds = idsForSymbol(symbol, checker, locationIds);
-  const targetId = targetIds.length === 1 ? targetIds[0] : undefined;
+  const targetLocations = declarationLocationsForSymbol(symbol, checker);
   const sourceId = enclosingSourceId(identifier, context);
-  if (!sourceId || targetId === sourceId || targetIds.length === 0) return;
+  if (!sourceId || targetLocations.length === 0) return;
   const position = identifier.getStart(context.sourceFile);
   const point = lineColumn(context.sourceFile, position);
   const parent = identifier.parent;
   const receiver = ts.isPropertyAccessExpression(parent) && parent.name === identifier
     ? parent.expression.getText(context.sourceFile)
     : undefined;
-  push({
-    sourceId,
-    targetId,
-    kind: "references",
-    targetName: identifier.text,
-    targetQualifiedName: targetId ? nodeById.get(targetId)?.qualifiedName : undefined,
-    receiver,
-    qualifier: receiver,
-    candidates: targetIds,
-    status: targetId ? "resolved" : "ambiguous",
-    confidence: targetId ? 1 : 0.75,
-    resolutionMethod: "typescript-symbol",
-    provenance: "typescript-compiler",
-    filePath: context.filePath,
+  captured.push({
+    form: "identifier",
+    position,
     line: point.line,
     column: point.column,
-    evidence: { expression: identifier.text },
-  }, position, `${identifier.text}:${receiver ?? ""}`);
+    sourceId,
+    text: identifier.text,
+    receiver,
+    targetLocations,
+  });
 }
 
-function emitCallbackReferences(
+function captureCallbackReferences(
   call: ts.CallExpression,
   context: FileContext,
-  locationIds: ReadonlyMap<string, string>,
-  nodeById: ReadonlyMap<string, CompilerExtractedNode>,
-  push: (reference: Omit<PendingReference, "position" | "identityHint">, position: number, identityHint: string) => void,
+  captured: CapturedReference[],
 ): void {
   const checker = context.project.checker;
   const signature = checker.getResolvedSignature(call);
   const declaration = signature?.getDeclaration();
   if (!declaration || !ts.isFunctionLike(declaration)) return;
   const calleeSymbol = symbolForDeclaration(declaration, checker);
-  const calleeId = idForSymbol(calleeSymbol, checker, locationIds);
-  if (!calleeId) return;
+  const calleeLocations = declarationLocationsForSymbol(calleeSymbol, checker);
+  if (calleeLocations.length === 0) return;
   const parameters = declaration.parameters;
   call.arguments.forEach((argument, index) => {
     const mapping = callbackParameterForArgument(parameters, index);
@@ -1171,38 +1424,30 @@ function emitCallbackReferences(
       mapping.restArgumentIndex,
     )) return;
     const { parameter } = mapping;
-    let callbackId: string | undefined;
+    let callbackDraftId: string | undefined;
+    let callbackLocations: string[] = [];
     if (ts.isArrowFunction(argument) || ts.isFunctionExpression(argument)) {
-      callbackId = context.declarationDrafts.get(argument)?.id;
+      callbackDraftId = context.declarationDrafts.get(argument)?.id;
+      if (!callbackDraftId) return;
     } else {
-      const callbackIds = idsForSymbol(checker.getSymbolAtLocation(argument), checker, locationIds);
-      callbackId = callbackIds.length === 1 ? callbackIds[0] : undefined;
+      callbackLocations = declarationLocationsForSymbol(checker.getSymbolAtLocation(argument), checker);
+      if (callbackLocations.length === 0) return;
     }
-    if (!callbackId) return;
     const position = argument.getStart(context.sourceFile);
     const point = lineColumn(context.sourceFile, position);
-    const parameterName = parameter.name.getText(declaration.getSourceFile());
-    push({
-      sourceId: calleeId,
-      targetId: callbackId,
-      kind: "calls",
-      targetName: nodeById.get(callbackId)?.name ?? argument.getText(context.sourceFile),
-      targetQualifiedName: nodeById.get(callbackId)?.qualifiedName,
-      candidates: [callbackId],
-      status: "resolved",
-      confidence: 0.85,
-      resolutionMethod: "typescript-callback-parameter",
-      provenance: "callback-synthesis",
-      filePath: context.filePath,
+    captured.push({
+      form: "callback",
+      position,
       line: point.line,
       column: point.column,
-      evidence: {
-        parameterName,
-        argumentIndex: index,
-        wiringSite: call.getText(context.sourceFile),
-        callee: nodeById.get(calleeId)?.qualifiedName,
-      },
-    }, position, `callback:${calleeId}:${parameterName}:${index}:${callbackId}`);
+      calleeLocations,
+      callbackDraftId,
+      callbackLocations,
+      parameterName: parameter.name.getText(declaration.getSourceFile()),
+      argumentIndex: index,
+      wiringSite: call.getText(context.sourceFile),
+      argumentText: argument.getText(context.sourceFile),
+    });
   });
 }
 
@@ -1373,29 +1618,6 @@ function closestDraft(node: ts.Node | undefined, context: FileContext): DraftNod
 
 function enclosingSourceId(node: ts.Node, context: FileContext): string | undefined {
   return closestDraft(node, context)?.id ?? context.fileDraft?.id;
-}
-
-function idForSymbol(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker,
-  locations: ReadonlyMap<string, string>,
-): string | undefined {
-  return idsForSymbol(symbol, checker, locations)[0];
-}
-
-function idsForSymbol(
-  symbol: ts.Symbol | undefined,
-  checker: ts.TypeChecker,
-  locations: ReadonlyMap<string, string>,
-): string[] {
-  if (!symbol) return [];
-  const resolved = canonicalSymbol(symbol, checker);
-  const ids = new Set<string>();
-  for (const declaration of resolved.declarations ?? []) {
-    const id = locations.get(declarationLocation(declaration));
-    if (id) ids.add(id);
-  }
-  return [...ids].sort();
 }
 
 function isPolymorphicReceiver(type: ts.Type): boolean {

--- a/src/graph/extraction/grammars.ts
+++ b/src/graph/extraction/grammars.ts
@@ -151,6 +151,17 @@ export function parse(source: string, language: Language): TSTree | null {
   return tree as unknown as TSTree;
 }
 
+/**
+ * Free a parsed tree's WASM-heap memory. web-tree-sitter trees are allocated in
+ * the Emscripten heap and are NOT reclaimed by JS GC (no FinalizationRegistry in
+ * 0.25) — every undeleted tree leaks for the life of the process, and the WASM
+ * heap never shrinks. This is the single boundary that widens the frozen TSTree
+ * back to the concrete web-tree-sitter Tree, mirroring the narrowing in `parse`.
+ */
+export function freeTree(tree: TSTree): void {
+  (tree as unknown as { delete(): void }).delete();
+}
+
 /** Free all cached parsers + reset the runtime flag (tests / teardown). */
 export function disposeParsers(): void {
   for (const parser of parserCache.values()) parser.delete();

--- a/src/graph/extraction/index.ts
+++ b/src/graph/extraction/index.ts
@@ -9,7 +9,7 @@
 
 import type { Language } from "../types.js";
 import type { ExtractedEdge, ExtractedNode, TSNode } from "./types.js";
-import { detectLanguage, parse } from "./grammars.js";
+import { detectLanguage, freeTree, parse } from "./grammars.js";
 import { getExtractor } from "./languages/index.js";
 
 export {
@@ -77,6 +77,21 @@ export function extractFile(
   if (!extractor) return null;
   const tree = parse(source, language);
   if (!tree) return null;
+  try {
+    return extractFromTree(tree, extractor, filePath, source, language);
+  } finally {
+    // Extractors return plain copied nodes/edges; nothing retains the tree.
+    freeTree(tree);
+  }
+}
+
+function extractFromTree(
+  tree: NonNullable<ReturnType<typeof parse>>,
+  extractor: NonNullable<ReturnType<typeof getExtractor>>,
+  filePath: string,
+  source: string,
+  language: Language,
+): FileExtraction {
   const health = treeHealth(tree.rootNode, source);
   if (health.status === "failed") return { language, nodes: [], edges: [], health };
   const extracted = extractor.extract(tree, filePath, source);
@@ -143,14 +158,18 @@ export function normalizedAstTokens(
   const tree = parse(source, detectLanguage(filePath));
   if (!tree) return new Map();
   const leaves: Array<{ line: number; endLine: number; type: string }> = [];
-  const visit = (node: TSNode): void => {
-    if (node.childCount === 0) {
-      leaves.push({ line: node.startPosition.row + 1, endLine: node.endPosition.row + 1, type: node.type });
-      return;
-    }
-    for (const child of node.children) visit(child);
-  };
-  visit(tree.rootNode);
+  try {
+    const visit = (node: TSNode): void => {
+      if (node.childCount === 0) {
+        leaves.push({ line: node.startPosition.row + 1, endLine: node.endPosition.row + 1, type: node.type });
+        return;
+      }
+      for (const child of node.children) visit(child);
+    };
+    visit(tree.rootNode);
+  } finally {
+    freeTree(tree);
+  }
   return new Map(ranges.map((range) => [
     range.id,
     leaves

--- a/src/graph/extraction/languages/typescript.ts
+++ b/src/graph/extraction/languages/typescript.ts
@@ -30,6 +30,7 @@ import type {
   TSTree,
 } from "../types.js";
 import {
+  canonicalNodeIdentity,
   generateNodeId,
   getChildByField,
   getNodeText,
@@ -55,6 +56,7 @@ const SKIP_RECEIVERS = new Set(["this", "super"]);
 class TsFamilyWalker {
   private readonly nodes: ExtractedNode[] = [];
   private readonly edges: ExtractedEdge[] = [];
+  private readonly identityOccurrences = new Map<string, number>();
   /** Ids of the enclosing scopes; the last element is the current parent. */
   private readonly scopeStack: string[] = [];
 
@@ -134,9 +136,17 @@ class TsFamilyWalker {
   ): string | null {
     if (!name) return null;
     const qualifiedName = this.qualify(name);
-    const id = generateNodeId(this.filePath, kind, name, qualifiedName, kind, extra?.signature);
+    // Same-file same-identity declarations (redeclarations, hostile fixtures)
+    // get an ordinal-disambiguated role, mirroring the python/rust extractors —
+    // without it a duplicate id aborts the whole staged corpus.
+    const baseIdentity = canonicalNodeIdentity(this.filePath, kind, qualifiedName, kind, extra?.signature);
+    const ordinal = this.identityOccurrences.get(baseIdentity) ?? 0;
+    this.identityOccurrences.set(baseIdentity, ordinal + 1);
+    const declarationRole = ordinal === 0 ? kind : `${kind}:ordinal:${ordinal}`;
+    const id = generateNodeId(this.filePath, kind, name, qualifiedName, declarationRole, extra?.signature);
     this.nodes.push({
       id,
+      identityKey: canonicalNodeIdentity(this.filePath, kind, qualifiedName, declarationRole, extra?.signature),
       kind,
       name,
       qualifiedName,

--- a/src/graph/fingerprint-store.ts
+++ b/src/graph/fingerprint-store.ts
@@ -1,5 +1,5 @@
 import type { GroundedSource } from "./grounding.js";
-import { bandHashes } from "./fingerprint.js";
+import { bandHashInts, decodeMinhash, encodeMinhash } from "./fingerprint.js";
 import type { Fingerprint } from "./reconcile.js";
 import type { SQLInputValue } from "node:sqlite";
 
@@ -14,7 +14,8 @@ export interface SqliteDatabase {
 
 interface FingerprintRow {
   node_id: string;
-  minhash: string;
+  /** BLOB (schema v3); a pre-migration TEXT JSON array is still decodable. */
+  minhash: Uint8Array | string;
   neighbors: string;
   token_count: number;
 }
@@ -44,39 +45,47 @@ export class FingerprintStore {
        ON CONFLICT(node_id) DO UPDATE SET minhash=excluded.minhash,
          neighbors=excluded.neighbors, token_count=excluded.token_count`,
     );
-    const bucketCount = bandHashes(ordered[0]!.fingerprint).length;
+    // ON CONFLICT DO UPDATE keeps the existing row, so `ref` is stable across
+    // re-upserts of the same node — stale LSH rows are deleted by ref below.
+    const selectRef = this.db.prepare(
+      "SELECT ref FROM node_fingerprints WHERE node_id = ?",
+    );
+    const bucketCount = bandHashInts(ordered[0]!.fingerprint).length;
     const insertBuckets = this.db.prepare(
-      `INSERT INTO lsh_buckets (band, band_hash, node_id) VALUES ${
+      `INSERT INTO lsh_buckets (band, band_hash, ref) VALUES ${
         Array.from({ length: bucketCount }, () => "(?, ?, ?)").join(", ")
       }`,
     );
 
     this.db.exec("SAVEPOINT mex_fingerprint_upsert_many");
     try {
-      // Delete prior buckets before inserting any replacements. Without a
-      // node_id-oriented LSH index, deleting once per node degenerates into a
-      // full-table scan for every fingerprint as this table grows. Chunked IN
-      // deletes scan the old table only a bounded number of times and produce
-      // the identical final rows (the last entry for a duplicate node wins).
+      // Delete prior buckets before inserting any replacements. Chunked IN
+      // deletes over the ref subquery scan the table a bounded number of times
+      // and produce the identical final rows (the last duplicate entry wins).
       const deleteChunkSize = 500;
       for (let offset = 0; offset < ordered.length; offset += deleteChunkSize) {
         const nodeIds = ordered.slice(offset, offset + deleteChunkSize).map((entry) => entry.nodeId);
         this.db.prepare(
-          `DELETE FROM lsh_buckets WHERE node_id IN (${nodeIds.map(() => "?").join(",")})`,
+          `DELETE FROM lsh_buckets WHERE ref IN (
+             SELECT ref FROM node_fingerprints WHERE node_id IN (${nodeIds.map(() => "?").join(",")})
+           )`,
         ).run(...nodeIds);
       }
       for (const { nodeId, fingerprint } of ordered) {
-        const buckets = bandHashes(fingerprint);
+        const buckets = bandHashInts(fingerprint);
         if (buckets.length !== bucketCount) {
           throw new Error(`Inconsistent fingerprint band count for ${nodeId}.`);
         }
         upsertFingerprint.run(
           nodeId,
-          JSON.stringify(fingerprint.minhash),
+          encodeMinhash(fingerprint.minhash),
           JSON.stringify(fingerprint.neighbors),
           fingerprint.tokenCount,
         );
-        insertBuckets.run(...buckets.flatMap((bandHash, band) => [band, bandHash, nodeId]));
+        const row = selectRef.get(nodeId) as { ref: number | bigint } | undefined;
+        if (!row) throw new Error(`Fingerprint upsert failed for ${nodeId}.`);
+        const ref = typeof row.ref === "bigint" ? row.ref : BigInt(row.ref);
+        insertBuckets.run(...buckets.flatMap((bandHash, band) => [band, bandHash, ref]));
       }
       this.db.exec("RELEASE mex_fingerprint_upsert_many");
     } catch (error) {
@@ -103,9 +112,12 @@ export class FingerprintStore {
   lookup(fingerprint: Fingerprint): Array<{ nodeId: string; fingerprint: Fingerprint }> {
     const candidates = new Set<string>();
     const lookup = this.db.prepare(
-      "SELECT node_id FROM lsh_buckets WHERE band = ? AND band_hash = ?",
+      `SELECT fingerprints.node_id AS node_id
+       FROM lsh_buckets buckets
+       JOIN node_fingerprints fingerprints ON fingerprints.ref = buckets.ref
+       WHERE buckets.band = ? AND buckets.band_hash = ?`,
     );
-    bandHashes(fingerprint).forEach((bandHash, band) => {
+    bandHashInts(fingerprint).forEach((bandHash, band) => {
       for (const row of lookup.all(band, bandHash) as Array<{ node_id: string }>) {
         candidates.add(row.node_id);
       }
@@ -160,7 +172,9 @@ export class FingerprintStore {
 
 function decodeRow(row: FingerprintRow): Fingerprint {
   return {
-    minhash: JSON.parse(row.minhash) as number[],
+    minhash: typeof row.minhash === "string"
+      ? JSON.parse(row.minhash) as number[]
+      : decodeMinhash(row.minhash),
     neighbors: JSON.parse(row.neighbors) as string[],
     tokenCount: row.token_count,
   };

--- a/src/graph/fingerprint.ts
+++ b/src/graph/fingerprint.ts
@@ -111,6 +111,45 @@ export function bandHashes(fingerprint: Fingerprint): string[] {
   });
 }
 
+/**
+ * Schema-v3 LSH band hashes: the first 8 bytes of the same per-band sha256
+ * that {@link bandHashes} hex-encodes, as a signed 64-bit integer for compact
+ * INTEGER storage. Derivation input is identical, so two fingerprints share an
+ * int64 band hash exactly when they share the hex band hash (modulo a ~2^-64
+ * truncation collision, which merely adds one LSH candidate that full minhash
+ * scoring then rejects — it can never remove or reorder a true candidate).
+ */
+export function bandHashInts(fingerprint: Fingerprint): bigint[] {
+  assertFingerprint(fingerprint);
+  if (BANDS * ROWS !== K) {
+    throw new Error(`Invalid LSH configuration: ${BANDS} * ${ROWS} !== ${K}`);
+  }
+  return Array.from({ length: BANDS }, (_, band) => {
+    const start = band * ROWS;
+    return createHash("sha256")
+      .update(JSON.stringify(fingerprint.minhash.slice(start, start + ROWS)))
+      .digest()
+      .readBigInt64BE(0);
+  });
+}
+
+/** Encode a K=64 uint32 minhash as a 256-byte big-endian BLOB (schema v3). */
+export function encodeMinhash(minhash: readonly number[]): Buffer {
+  const buffer = Buffer.allocUnsafe(minhash.length * 4);
+  minhash.forEach((value, index) => buffer.writeUInt32BE(value, index * 4));
+  return buffer;
+}
+
+/** Decode a schema-v3 minhash BLOB back to the uint32 array it encodes. */
+export function decodeMinhash(blob: Uint8Array): number[] {
+  const buffer = Buffer.isBuffer(blob) ? blob : Buffer.from(blob.buffer, blob.byteOffset, blob.byteLength);
+  const values: number[] = [];
+  for (let offset = 0; offset + 4 <= buffer.length; offset += 4) {
+    values.push(buffer.readUInt32BE(offset));
+  }
+  return values;
+}
+
 function assertFingerprint(value: unknown): asserts value is Fingerprint {
   if (!value || typeof value !== "object") throw new Error("Invalid fingerprint");
   const candidate = value as Partial<Fingerprint>;

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -23,7 +23,20 @@ export interface GroundingRuntime {
   fingerprints: FingerprintStore;
   /** Pre-sync fingerprints for inline ids that may disappear during a rename. */
   anchorFingerprints: ReadonlyMap<string, Fingerprint>;
+  /** Source files that changed since the graph was last built (read-only loads). */
+  staleSourceFiles?: number;
   close(): void;
+}
+
+export interface LoadGroundingRuntimeOptions {
+  /**
+   * Open the last published graph without synchronizing it. `mex check` MUST
+   * use this: synchronizing re-stages the whole corpus in-process (TypeScript
+   * programs included), which turned a drift check into a full rebuild's worth
+   * of wall clock and RSS (issue #140 observation 2). Read-only consumers see
+   * `staleSourceFiles` instead and report staleness rather than paying it.
+   */
+  readOnly?: boolean;
 }
 
 export interface GroundingBaselineCaptureResult {
@@ -37,19 +50,25 @@ export interface GroundingBaselineCaptureOptions {
   warn?: (message: string) => void;
 }
 
-export async function loadGroundingRuntime(config: MexConfig): Promise<GroundingRuntime | null> {
+export async function loadGroundingRuntime(
+  config: MexConfig,
+  options: LoadGroundingRuntimeOptions = {},
+): Promise<GroundingRuntime | null> {
   const dbPath = resolve(config.projectRoot, ".mex", "graph.db");
   if (!existsSync(dbPath)) return null;
-  const graph = createGraphEngine({ rootDir: config.projectRoot, dbPath });
+  const readOnly = options.readOnly ?? false;
+  const graph = createGraphEngine({ rootDir: config.projectRoot, dbPath, readOnly });
   let db: SqliteDatabase | null = null;
   try {
-    db = openGraphDatabase(dbPath);
+    db = openGraphDatabase(dbPath, { readOnly });
     const fingerprints = new FingerprintStore(db);
     const anchorFingerprints = snapshotAnchorFingerprints(config, fingerprints);
     const changed = findChangedSourceFiles(config.projectRoot, db);
-    // sync also checks the persisted compiler/config/grammar manifest, so it
-    // must run even when source mtimes are unchanged.
-    await graph.sync(changed);
+    if (!readOnly) {
+      // sync also checks the persisted compiler/config/grammar manifest, so it
+      // must run even when source mtimes are unchanged.
+      await graph.sync(changed);
+    }
     const reconciler = new MinHashReconciler(fingerprints);
     const checkerReconciler: Reconciler & GroundingReconcilerCapabilities = {
       reconcile: (nodeId, baseline) => reconciler.reconcile(nodeId, baseline),
@@ -62,6 +81,7 @@ export async function loadGroundingRuntime(config: MexConfig): Promise<Grounding
       checker: createGroundingChecker(graph, checkerReconciler),
       fingerprints,
       anchorFingerprints,
+      staleSourceFiles: readOnly ? changed.length : 0,
       close: () => { graph.close(); db?.close(); db = null; },
     };
   } catch (error) {

--- a/src/graph/schema.sql
+++ b/src/graph/schema.sql
@@ -40,7 +40,7 @@ CREATE TABLE IF NOT EXISTS schema_versions (
 );
 
 INSERT OR IGNORE INTO schema_versions (version, applied_at, description)
-VALUES (2, strftime('%s', 'now') * 1000, 'Trustworthy graph identity, health, references, aliases, and source chunks');
+VALUES (3, strftime('%s', 'now') * 1000, 'Compact fingerprint/LSH encoding: BLOB minhash, int64 band hashes, integer refs');
 
 -- =============================================================================
 -- Core tables (ported from CodeGraph — kept as-is except node.body_hash)
@@ -283,22 +283,33 @@ CREATE TABLE IF NOT EXISTS project_metadata (
 -- Per-node fingerprint: a MinHash sketch of the node's normalized-AST trigrams
 -- plus its caller/callee neighborhood. Survives rename/move (which the
 -- line-independent id does NOT), enabling reconciliation.
+-- Schema v3 re-encode (issue #140 storage follow-up): the v2 encoding stored
+-- the minhash as a JSON text array (~600 B where 256 B of BLOB suffice) and
+-- 32 LSH rows per node each repeating the full TEXT node id and a 64-char hex
+-- band hash, doubled again by idx_lsh — together ~40-50% of every graph store.
+-- v3 stores the sketch as a 256-byte big-endian BLOB, keys LSH rows by a
+-- stable INTEGER ref, truncates band hashes to their first 8 bytes as int64
+-- (collisions merely add an LSH candidate, which full minhash scoring then
+-- rejects), and makes the primary key serve as the only index. The decoded
+-- Fingerprint values and every reconciler outcome are unchanged.
 CREATE TABLE IF NOT EXISTS node_fingerprints (
-    node_id      TEXT PRIMARY KEY REFERENCES nodes(id) ON DELETE CASCADE,
-    minhash      TEXT NOT NULL,   -- JSON array of K=64 uint32 (spec §4: K)
-    neighbors    TEXT NOT NULL,   -- JSON array of caller+callee Tier-1 ids (sorted)
+    ref          INTEGER PRIMARY KEY, -- rowid alias: stable under VACUUM
+    node_id      TEXT NOT NULL UNIQUE REFERENCES nodes(id) ON DELETE CASCADE,
+    minhash      BLOB NOT NULL,  -- K=64 uint32 values, big-endian (spec §4: K)
+    neighbors    TEXT NOT NULL,  -- JSON array of caller+callee Tier-1 ids (sorted)
     token_count  INTEGER NOT NULL -- < ~MIN_TOKENS (30) => don't trust the fingerprint
 );
 
 -- LSH banding index over `node_fingerprints.minhash`. Each fingerprint is split
 -- into BANDS=32 bands of ROWS=2 rows; `LSH_lookup` fetches candidate node ids
--- that share a band hash with the query fingerprint (spec §4 step 2).
+-- that share a band hash with the query fingerprint (spec §4 step 2). The
+-- composite primary key IS the lookup index — no secondary index needed.
 CREATE TABLE IF NOT EXISTS lsh_buckets (
-    band      INTEGER NOT NULL,   -- 0..BANDS-1 (0..31)
-    band_hash TEXT NOT NULL,
-    node_id   TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE
-);
-CREATE INDEX IF NOT EXISTS idx_lsh ON lsh_buckets(band, band_hash);
+    band      INTEGER NOT NULL,  -- 0..BANDS-1 (0..31)
+    band_hash INTEGER NOT NULL,  -- first 8 bytes of the band's sha256, as int64
+    ref       INTEGER NOT NULL REFERENCES node_fingerprints(ref) ON DELETE CASCADE,
+    PRIMARY KEY (band, band_hash, ref)
+) WITHOUT ROWID;
 
 -- =============================================================================
 -- Grounding baseline  (NET-NEW — spec §3, §5, §6.  ours.)

--- a/test/graph-140-fixes.test.ts
+++ b/test/graph-140-fixes.test.ts
@@ -50,6 +50,11 @@ afterEach(() => {
 describe("compiler program-crash isolation (#140 follow-up)", () => {
   it("completes the build via tree-sitter when every TS program creation asserts", async () => {
     const { root, dbPath } = fixture("mex-140-isolation-");
+    // Hostile-fixture shape from the TypeScript repo: duplicate same-identity
+    // declarations in one file must ordinal-disambiguate, not abort staging.
+    writeFileSync(join(root, "src", "dupes.ts"),
+      "export function duplicated(): number { return 1; }\n"
+      + "export function duplicated(): number { return 2; }\n");
     const engine = createGraphEngine({
       rootDir: root,
       compilerExtraction: {
@@ -67,6 +72,10 @@ describe("compiler program-crash isolation (#140 follow-up)", () => {
       ).get() as { n: number };
       // The function still exists in the graph — extracted by tree-sitter.
       expect(row.n).toBeGreaterThan(0);
+      const dupes = db.prepare(
+        "SELECT COUNT(*) AS n FROM nodes WHERE file_path = 'src/dupes.ts' AND kind = 'function'",
+      ).get() as { n: number };
+      expect(dupes.n).toBe(2);
     } finally {
       db.close();
     }

--- a/test/graph-140-fixes.test.ts
+++ b/test/graph-140-fixes.test.ts
@@ -1,0 +1,152 @@
+// Regression coverage for the issue #140 fix set:
+//  1. a crashing TypeScript program (TS-internal assertion) must not abort the
+//     whole graph build — affected files fall back to tree-sitter extraction;
+//  2. `mex check` opens the graph read-only: no staging, no store writes, and
+//     staleness is reported instead of silently rebuilt;
+//  3. `mex graph repair` recovers a stranded WAL (killed writer) in place.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MexConfig } from "../src/types.js";
+import { createGraphEngine } from "../src/graph/engine-impl.js";
+import { openSqlite } from "../src/graph/db/sqlite.js";
+import { loadGroundingRuntime } from "../src/graph/runtime.js";
+import { runGraphRepair } from "../src/graph/cli-graph.js";
+
+const roots: string[] = [];
+
+function fixture(prefix: string): { root: string; source: string; config: MexConfig; dbPath: string } {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  roots.push(root);
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, ".mex"), { recursive: true });
+  writeFileSync(join(root, ".mex", "ROUTER.md"), "# Router\n");
+  const source = join(root, "src", "checkout.ts");
+  writeFileSync(source, `
+export function calculateCheckoutTotal(items: number[]): number {
+  const subtotal = items.reduce((sum, item) => sum + item, 0);
+  const shipping = subtotal >= 100 ? 0 : 12;
+  return subtotal + shipping;
+}
+`);
+  return {
+    root,
+    source,
+    config: { projectRoot: root, scaffoldRoot: join(root, ".mex"), aiTools: [] },
+    dbPath: join(root, ".mex", "graph.db"),
+  };
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* Windows file locks */ }
+  }
+});
+
+describe("compiler program-crash isolation (#140 follow-up)", () => {
+  it("completes the build via tree-sitter when every TS program creation asserts", async () => {
+    const { root, dbPath } = fixture("mex-140-isolation-");
+    const engine = createGraphEngine({
+      rootDir: root,
+      compilerExtraction: {
+        programFactory: () => { throw new Error("Debug Failure. False expression."); },
+      },
+    });
+    const result = await engine.build();
+    engine.close();
+
+    expect(result.filesIndexed).toBeGreaterThan(0);
+    const db = openSqlite(dbPath, { readOnly: true });
+    try {
+      const row = db.prepare(
+        "SELECT COUNT(*) AS n FROM nodes WHERE file_path = 'src/checkout.ts' AND kind = 'function'",
+      ).get() as { n: number };
+      // The function still exists in the graph — extracted by tree-sitter.
+      expect(row.n).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("read-only grounding runtime (#140 observation 2)", () => {
+  it("never writes the store and reports staleness instead of staging", async () => {
+    const { root, source, config, dbPath } = fixture("mex-140-readonly-");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+    const before = createHash("sha256").update(readFileSync(dbPath)).digest("hex");
+
+    const fresh = await loadGroundingRuntime(config, { readOnly: true });
+    expect(fresh).not.toBeNull();
+    expect(fresh!.staleSourceFiles).toBe(0);
+    fresh!.close();
+
+    writeFileSync(source, readFileSync(source, "utf-8").replace(": 12", ": 15"));
+    const stale = await loadGroundingRuntime(config, { readOnly: true });
+    expect(stale!.staleSourceFiles).toBe(1);
+    stale!.close();
+
+    const after = createHash("sha256").update(readFileSync(dbPath)).digest("hex");
+    expect(after).toBe(before);
+  });
+});
+
+describe("mex graph repair (#140 observation 3)", () => {
+  it("checkpoints a stranded WAL from a killed writer without rebuilding", async () => {
+    const { root, dbPath } = fixture("mex-140-repair-");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+
+    // Simulate a killed writer: a child process writes under WAL with
+    // auto-checkpoint disabled and dies without closing the connection.
+    const strand = spawnSync(process.execPath, ["-e", `
+      const { DatabaseSync } = require("node:sqlite");
+      const db = new DatabaseSync(process.argv[1]);
+      db.exec("PRAGMA journal_mode = WAL");
+      db.exec("PRAGMA wal_autocheckpoint = 0");
+      db.prepare(
+        "INSERT INTO project_metadata (key, value, updated_at) VALUES (?, ?, ?) " +
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+      ).run("stranded_marker", "1", Date.now());
+      process.kill(process.pid, "SIGKILL");
+    `, dbPath], { encoding: "utf-8" });
+    expect(strand.status).not.toBe(0);
+    const walPath = `${dbPath}-wal`;
+    expect(existsSync(walPath) && statSync(walPath).size > 0).toBe(true);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      expect(await runGraphRepair(root)).toBe(0);
+      expect(log.mock.calls.flat().join("\n")).toContain("integrity ok");
+    } finally {
+      log.mockRestore();
+    }
+    // The WAL is checkpointed and truncated; the write it held survived.
+    expect(!existsSync(walPath) || statSync(walPath).size === 0).toBe(true);
+    const db = openSqlite(dbPath, { readOnly: true });
+    try {
+      const row = db.prepare("SELECT value FROM project_metadata WHERE key = 'stranded_marker'").get() as
+        | { value: string } | undefined;
+      expect(row?.value).toBe("1");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("returns 1 when no graph store exists", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-140-norepair-"));
+    roots.push(root);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(await runGraphRepair(root)).toBe(1);
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/test/graph-140-fixes.test.ts
+++ b/test/graph-140-fixes.test.ts
@@ -70,7 +70,7 @@ describe("compiler program-crash isolation (#140 follow-up)", () => {
     } finally {
       db.close();
     }
-  });
+  }, 30_000);
 });
 
 describe("read-only grounding runtime (#140 observation 2)", () => {
@@ -93,7 +93,7 @@ describe("read-only grounding runtime (#140 observation 2)", () => {
 
     const after = createHash("sha256").update(readFileSync(dbPath)).digest("hex");
     expect(after).toBe(before);
-  });
+  }, 30_000);
 });
 
 describe("mex graph repair (#140 observation 3)", () => {
@@ -137,7 +137,7 @@ describe("mex graph repair (#140 observation 3)", () => {
     } finally {
       db.close();
     }
-  });
+  }, 30_000);
 
   it("returns 1 when no graph store exists", async () => {
     const root = mkdtempSync(join(tmpdir(), "mex-140-norepair-"));

--- a/test/graph-140-fixes.test.ts
+++ b/test/graph-140-fixes.test.ts
@@ -159,3 +159,66 @@ describe("mex graph repair (#140 observation 3)", () => {
     }
   });
 });
+
+describe("schema v3 fingerprint re-encode (#140 storage follow-up)", () => {
+  it("migrates a v2-encoded store losslessly without marking rebuild-required", async () => {
+    const { root, dbPath } = fixture("mex-140-v3-migrate-");
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    engine.close();
+
+    const { FingerprintStore } = await import("../src/graph/fingerprint-store.js");
+    const { bandHashes, decodeMinhash } = await import("../src/graph/fingerprint.js");
+    const { openGraphDatabase, readSchemaVersion, graphRequiresRebuild, DB_SCHEMA_VERSION } =
+      await import("../src/graph/db/database.js");
+
+    // Snapshot the real fingerprints, then hand-downgrade the store to the
+    // exact v2 encoding: JSON minhash text, TEXT node ids in lsh_buckets,
+    // 64-char hex band hashes, idx_lsh, and a version-2 row.
+    const db = openSqlite(dbPath);
+    const rows = db.prepare("SELECT node_id, minhash, neighbors, token_count FROM node_fingerprints").all() as
+      Array<{ node_id: string; minhash: Uint8Array; neighbors: string; token_count: number }>;
+    expect(rows.length).toBeGreaterThan(0);
+    const reference = new Map(rows.map((row) => [row.node_id, {
+      minhash: decodeMinhash(row.minhash),
+      neighbors: JSON.parse(row.neighbors) as string[],
+      tokenCount: row.token_count,
+    }]));
+    db.exec(`CREATE TABLE nf_old (
+      node_id TEXT PRIMARY KEY REFERENCES nodes(id) ON DELETE CASCADE,
+      minhash TEXT NOT NULL, neighbors TEXT NOT NULL, token_count INTEGER NOT NULL)`);
+    const insertOld = db.prepare("INSERT INTO nf_old VALUES (?, ?, ?, ?)");
+    for (const row of rows) {
+      insertOld.run(row.node_id, JSON.stringify(decodeMinhash(row.minhash)), row.neighbors, row.token_count);
+    }
+    db.exec("DROP TABLE lsh_buckets");
+    db.exec("DROP TABLE node_fingerprints");
+    db.exec("ALTER TABLE nf_old RENAME TO node_fingerprints");
+    db.exec(`CREATE TABLE lsh_buckets (
+      band INTEGER NOT NULL, band_hash TEXT NOT NULL,
+      node_id TEXT NOT NULL REFERENCES nodes(id) ON DELETE CASCADE)`);
+    db.exec("CREATE INDEX idx_lsh ON lsh_buckets(band, band_hash)");
+    const insertBucket = db.prepare("INSERT INTO lsh_buckets VALUES (?, ?, ?)");
+    for (const [nodeId, fingerprint] of reference) {
+      bandHashes(fingerprint).forEach((hash, band) => insertBucket.run(band, hash, nodeId));
+    }
+    db.exec("DELETE FROM schema_versions");
+    db.prepare("INSERT INTO schema_versions (version, applied_at, description) VALUES (2, 0, 'v2 fixture')").run();
+    db.close();
+
+    // A writer open migrates in place; the graph must stay ready (lossless).
+    const migrated = openGraphDatabase(dbPath);
+    try {
+      expect(readSchemaVersion(migrated)).toBe(DB_SCHEMA_VERSION);
+      expect(graphRequiresRebuild(migrated)).toBe(false);
+      const store = new FingerprintStore(migrated);
+      for (const [nodeId, fingerprint] of reference) {
+        expect(store.get(nodeId)).toEqual(fingerprint);
+        const hits = store.lookup(fingerprint).map((entry) => entry.nodeId);
+        expect(hits).toContain(nodeId);
+      }
+    } finally {
+      migrated.close();
+    }
+  }, 30_000);
+});

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -117,7 +117,7 @@ describe("code-graph grounding integration", () => {
     expect(persistedContent).toContain(`mex://${persisted[0].node}`);
     report = await runDriftCheck(config);
     expect(report.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toHaveLength(0);
-  }, 10_000);
+  }, 30_000);
 
   it("keeps legacy checks running when the graph engine fails to load", async () => {
     const { scaffold, config } = fixture();

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -57,6 +57,9 @@ describe("code-graph grounding integration", () => {
       "subtotal > 1000 ? 0 : 75",
       "Math.max(0, 75 - subtotal * 0.05)",
     ));
+    // check reads the last published graph (read-only, #140); refresh it the
+    // way `mex graph` would before expecting drift against the new body.
+    await loadGroundingRuntime(config).then((refresh) => refresh?.close());
     let report = await runDriftCheck(config);
     expect(report.issues.filter((issue) => issue.code === "GROUNDING_DRIFT")).toHaveLength(1);
 

--- a/test/graph-migration.test.ts
+++ b/test/graph-migration.test.ts
@@ -116,6 +116,8 @@ describe("pre-0.7 graph grounding migration", () => {
     const source = join(root, "src", "checkout.ts");
     writeFileSync(source, readFileSync(source, "utf-8")
       .replace("subtotal >= 100 ? 0 : 12", "subtotal >= 125 ? 0 : 15"));
+    // check reads the last published graph (read-only, #140); refresh first.
+    await loadGroundingRuntime(config).then((refresh) => refresh?.close());
     const drift = await runDriftCheck(config);
     expect(drift.issues).toContainEqual(expect.objectContaining({
       code: "GROUNDING_DRIFT",

--- a/test/graph-migration.test.ts
+++ b/test/graph-migration.test.ts
@@ -123,7 +123,7 @@ describe("pre-0.7 graph grounding migration", () => {
       code: "GROUNDING_DRIFT",
       file: ".mex/patterns/checkout.md",
     }));
-  });
+  }, 30_000);
 
   it("requires a built graph", async () => {
     const { config } = fixture();

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -97,6 +97,8 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
 
     writeFileSync(join(sourceDir, "checkout.ts"), readFileSync(join(sourceDir, "checkout.ts"), "utf-8")
       .replace("subtotal >= 100 ? 0 : 12", "subtotal >= 125 ? 0 : 15"));
+    // check reads the last published graph (read-only, #140); refresh first.
+    await loadGroundingRuntime(config).then((refresh) => refresh?.close());
     const drift = await runDriftCheck(config);
     expect(drift.issues).toContainEqual(expect.objectContaining({
       code: "GROUNDING_DRIFT",

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -131,5 +131,5 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
     );
     expect(result).toEqual({ captured: 0, skipped: 1 });
     expect(warnings).toContainEqual(expect.stringContaining("function:missing"));
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
## What

Graph performance and recovery work for 0.7.3, addressing the field report in #140.

- **`mex check` no longer stages the graph.** The grounding pass synchronized the graph whenever any source file's mtime moved — in an active repo, effectively every run — and a synchronize re-stages the whole corpus. A routine drift check was silently paying a full rebuild's memory and wall clock. It now opens the last published graph read-only and reports how many source files it is behind.
- **One TypeScript compiler program alive at a time.** Extraction held every discovered project's `Program` + `TypeChecker` concurrently, so peak memory was the sum of all of them. Restructured into a capture pass per project plus a compiler-free finishing pass; cross-project resolution already flowed through declaration-location strings that are stable across programs, so each program is released once its own files are captured.
- **Schema v3: compact fingerprint/LSH encoding.** BLOB minhash instead of JSON text, integer fingerprint refs instead of repeated TEXT node ids, int64 band hashes, and the composite primary key as the only index (`idx_lsh` removed). Lossless v2→v3 migration on any writer open, no rebuild required.
- **`mex graph repair`.** Checkpoints a stranded WAL from a killed writer and runs `integrity_check` in place, breaking the "verifying the store requires a completing check, and any killed check re-dirties it" loop.
- **Per-file semantic type-checking is now opt-in**, and discovered projects are forced to `skipLibCheck` / `noEmit`.
- **Two robustness bugs found while fixing the above:** a TS-internal parser assertion from one malformed file aborted the entire build (now isolated per project, with tree-sitter fallback); two same-identity declarations in one TS/JS file aborted corpus staging on a duplicate node id (now ordinal-disambiguated, matching the existing Python/Rust extractors).
- **A real memory leak:** web-tree-sitter parse trees live in the WASM heap and are never reclaimed by JS GC. They were never `delete()`d, and each file was parsed twice.

Also includes the 0.7.3 release commit: version bump, CHANGELOG, RELEASE_NOTES, and README updates (all four translations).

### Measured

Paired builds producing identical node/edge/fingerprint counts:

| Repository | Peak build RSS | Build wall clock | Store size |
|---|---|---|---|
| 3,254 files, 92 TS projects | 5.17 GB → 2.11 GB | 448 s → 309 s | 700.1 MB → 451.1 MB |
| 494 files, single project | unchanged (~1.2 GB) | 195 s → 189 s | 269.8 MB → 162.9 MB |

Memory reduction scales with the number of TS projects, since that is what was held concurrently; single-project repos keep their previous peak and still get the smaller store. Fingerprint + LSH tables shrank ~86% and are no longer the largest consumer in a store.

Separately, a 39,312-file repository with 205 TS projects and thousands of deliberately malformed fixture files now builds to completion for the first time on any mex version, at 3.1 GB peak RSS.

## Why

Refs #140.

That report has four observations. This PR addresses three of them and leaves the fourth to in-flight work, so it is deliberately **not** marked as closing the issue:

| # | Observation | Status here |
|---|---|---|
| 1 | ~40× rebuild wall-clock variance across OS users on one machine | Root cause addressed — per-file `getSemanticDiagnostics` is the environment-sensitive cost (it scales with the resolvable dependency surface, which differs per user), now opt-in, plus forced `skipLibCheck` |
| 2 | `check` ballooning to ~12 GB RSS | Fixed — `check` no longer stages at all |
| 3 | No repair path short of a full rebuild | Fixed — `mex graph repair` |
| 4 | Staleness gating removes `impact` in practice | **Not addressed here** — belongs to the freshness/recovery work in #134; duplicating it would collide |

The reporter's secondary ask ("thoughts on a memory ceiling or streaming mode") is partially addressed by the sequential program release. Peak build memory is now bounded by the largest single TS project rather than the whole repository; going below that floor would need streaming extraction, which is future work.

0.7.2's own CHANGELOG deferred exactly this work: *"Incremental/no-op rebuild and storage optimization are deferred to a follow-up release."* Storage optimization lands here. Incremental rebuild does not — `mex graph` still re-stages the full corpus for a single changed file, though `check` no longer triggers it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Docs
- [ ] CI/Tooling

`mex graph repair` is a new subcommand, but the release is maintenance work; retrieval behavior, the JSONL protocol, scaffold formats, and grounding anchors are unchanged.

## How to test

1. **Check no longer rebuilds.** In a project with a built graph, touch any source file, then run `mex check`. It returns immediately, prints a "Code graph is N source file(s) behind" notice, and leaves `.mex/graph.db` byte-identical. On `main`, the same sequence re-stages the corpus.
2. **Repair.** Kill a `mex graph` mid-build (or use the test's SIGKILL harness) to strand a WAL, then run `mex graph repair`. It reports `integrity ok` and truncates the WAL without a rebuild.
3. **Store size.** Build a graph on a mid-size TS repo on `main`, note `.mex/graph.db`; rebuild on this branch and compare. Expect roughly 36-40% smaller with identical `SELECT COUNT(*)` on `nodes`, `edges`, `node_fingerprints`, and `lsh_buckets`.
4. **Memory.** On a repo with many `tsconfig*.json` files, watch peak RSS during `mex graph` before and after.
5. **Crash isolation.** Build a graph over a corpus containing a file that trips a TS parser assertion (TypeScript's own test fixtures work). On `main` the build aborts with `Debug Failure. False expression.`; here it completes with those files extracted by tree-sitter.
6. **Migration.** Build a graph on `main`, switch to this branch, run `mex graph ground` or `mex sync`. The v2 store migrates to v3 in place; existing groundings keep resolving and no rebuild is demanded.

## Checklist

- [x] Tests pass (`npm test`)
- [x] No breaking changes (or documented below)
- [x] Tested locally with a real project

Tested against six real repositories from 90 to 39,312 source files, including paired before/after builds and two identical repeat builds to confirm determinism.

**Compatibility notes** (also in CHANGELOG under Compatibility):

- Schema-v2 stores migrate to v3 losslessly on the next writer open (`mex graph`, `mex sync`, `mex graph ground`); no rebuild required, existing groundings keep resolving. Read-only commands report the usual rebuild guidance until that migration runs.
- Schema-v1 stores still need a one-time rebuild, unchanged from 0.7.2.
- The compiler extractor version advances (`typescript-5.9-v1` → `typescript-5.9-v2`), so the first `mex graph` after upgrading performs a full rebuild.
- Serialized `mh:64:` grounding anchors in scaffold Markdown are unchanged; no scaffold edits needed.

**Known local test noise:** five failures reproduce identically on a clean `main` checkout on this Windows machine (two `findConfig` cases hitting the documented temp-dir-under-`$HOME` hermeticity issue, a `cli-agent` EPERM teardown, and two full-build tests exceeding the 5 s default budget under parallel load). They are not introduced by this branch; CI on Linux is the arbiter.

## Code-graph changes

- [x] This PR targets `main`
- [x] A linked issue agrees on the bounded extractor/resolver scope
- [x] The change follows the frozen `LanguageExtractor` or `FrameworkResolver` interface
- [x] A focused fixture and assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered
- [ ] No graph identity, reconciliation, schema, or drift-semantics changes are included, or a `core / discuss-first` issue is linked above

**On the last two boxes — flagging rather than ticking:**

- No new grammar, extension mapping, extractor, or resolver is added, so that box is not applicable rather than done. Existing TS/JS grammars are now *loaded* in one additional case: compiler-language files the compiler could not stage, so the new fallback can extract them.
- **This PR does change the schema and drift semantics, deliberately, and both are core to #140.** Schema v2→v3 is a storage re-encode with a lossless in-place migration; decoded fingerprints, `bandHashes` semantics, and every reconciler MOVED/AMBIGUOUS/GONE outcome are unchanged. The drift-semantics change is that `mex check` reads the graph instead of synchronizing it, which is the fix for observation 2 — grounding checker outcomes themselves are untouched, but a check now evaluates against the last published graph and says so. Identity and reconciliation are otherwise unchanged, with one exception: the TS/JS tree extractor now ordinal-disambiguates duplicate same-identity declarations in a file. Ordinal 0 keeps ids byte-identical, so only previously-impossible builds are affected. Happy to split any of these out or open a `core / discuss-first` issue if a maintainer prefers that route.

New tests in `test/graph-140-fixes.test.ts` cover crash isolation with tree-sitter fallback and duplicate-identity ordinals, the read-only runtime (store hash byte-identical after a check, staleness counted), repair against a genuinely SIGKILL-stranded WAL, and a v2→v3 migration round trip that hand-encodes a real store back to v2 and asserts identical fingerprints and LSH hits afterward.
