### PR TITLE
test(release): confirm noisy runtime regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-performance-${{ github.run_attempt }}
-          path: test-results/release-benchmark/report.json
+          path: test-results/release-benchmark/
           if-no-files-found: ignore
           retention-days: 14

--- a/docs/design/release-performance-baseline.md
+++ b/docs/design/release-performance-baseline.md
@@ -58,8 +58,22 @@ budget environment: Ubuntu 24.04, x64, and the pinned Node 22 patch release in
 machine variance into a release failure. Node 24 remains in the ordinary CI
 compatibility matrix, outside performance enforcement.
 
+Deterministic failures remain immediate: built-asset bytes, outbound requests,
+database-to-input ratios, and any unknown runtime metric never receive a retry.
+The read and maintenance nonmutation contracts likewise remain ordinary hard
+tests. A first pass containing only wall-clock, RSS, CPU, or browser-heap
+breaches triggers one independent full benchmark pass on the same pinned
+runner and exact repository HEAD. CI fails a noisy metric only when that exact
+metric breaches again; unrelated one-off breaches across the two passes are
+retained in `runtimeConfirmation` but are not treated as a confirmed regression.
+The final `runtimeViolations` list contains only immediate or confirmed failures.
+Operational benchmark failures are never retried as budget noise. Enforcement
+exits 0 for a pass, 1 for a budget failure, and 2 when a pass cannot produce a
+valid bounded report.
+
 The dedicated `release-performance` CI job installs Chromium on the pinned
-runner, enforces the budgets, and retains the report. Runtime candidates in
+runner, enforces the budgets, and retains the final report plus both attempt
+reports when confirmation was required. Runtime candidates in
 that report are `ceil(p95 * 1.15)` independently for each fixture profile,
 route, read, and maintenance operation. The committed values are copied exactly
 from the first healthy retained pinned report; its enforcing rerun must pass

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eval:compare": "node evaluate/compare/index.mjs",
     "eval:compare:test": "node --test evaluate/compare/test/*.test.mjs",
     "benchmark:graph-status": "npm run build && node scripts/benchmark-graph-status.mjs",
-    "benchmark:release": "npm run build && node scripts/release-benchmark/run.mjs --output test-results/release-benchmark/report.json",
+    "benchmark:release": "npm run build && node scripts/release-benchmark/enforce.mjs --output test-results/release-benchmark/report.json",
     "typecheck": "npm run typecheck --workspace @mex/hub-contracts && tsc --noEmit && npm run typecheck --workspace @mex/hub-web",
     "prepare": "npm run build"
   },

--- a/scripts/release-benchmark/enforce.mjs
+++ b/scripts/release-benchmark/enforce.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, parse, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateRuntimeConfirmation } from "./runtime-confirmation.mjs";
+
+const scriptRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptRoot, "../..");
+const runnerPath = join(scriptRoot, "run.mjs");
+const DEFAULT_REPORT_PATH = join(repositoryRoot, "test-results", "release-benchmark", "report.json");
+const MAX_REPORT_BYTES = 2 * 1024 * 1024;
+
+if (process.argv[1] !== undefined
+  && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  if (options.help) {
+    process.stdout.write([
+      "Usage: node scripts/release-benchmark/enforce.mjs [--output <path>] [--assets-only]",
+      "",
+      "Runtime budgets are enforced only when MEX_ENFORCE_RELEASE_BUDGETS=1.",
+      "Noisy runtime-only breaches receive one independent confirmation pass.",
+      "Deterministic contract breaches and operational failures never receive a retry.",
+      "",
+    ].join("\n"));
+    process.exitCode = 0;
+  } else if (process.env.MEX_ENFORCE_RELEASE_BUDGETS !== "1" || options.assetsOnly) {
+    process.exitCode = runPass(options.output, process.argv.slice(2), true).status ?? 2;
+  } else {
+    process.exitCode = enforceWithConfirmation(options.output ?? DEFAULT_REPORT_PATH);
+  }
+}
+
+export function enforceWithConfirmation(outputPath, dependencies = {}) {
+  const executePass = dependencies.executePass ?? runPass;
+  const resolveRepositoryHead = dependencies.resolveRepositoryHead ?? readRepositoryHead;
+  const emitReport = dependencies.emitReport ?? ((serialized) => process.stdout.write(serialized));
+  const resolvedOutput = resolve(outputPath);
+  const firstPath = attemptPath(resolvedOutput, 1);
+  const secondPath = attemptPath(resolvedOutput, 2);
+  for (const path of [resolvedOutput, firstPath, secondPath]) rmSync(path, { force: true });
+  const repositoryHead = resolveRepositoryHead();
+  if (repositoryHead === null) return 2;
+
+  const firstResult = executePass(firstPath, ["--output", firstPath]);
+  const firstReport = readPassReport(firstPath, firstResult);
+  if (firstReport === null) return 2;
+
+  if (firstReport.budgetEvaluation.assetViolations.length > 0) {
+    writeFinalReport(resolvedOutput, firstReport, confirmationRecord(
+      "skipped_immediate_failure",
+      firstReport.budgetEvaluation.runtimeViolations,
+      [],
+      [],
+      repositoryHead,
+    ), undefined, undefined, emitReport);
+    rmSync(firstPath, { force: true });
+    return 1;
+  }
+
+  const initialDecision = evaluateRuntimeConfirmation(
+    firstReport.budgetEvaluation.runtimeViolations,
+  );
+  if (!initialDecision.retryRequired) {
+    writeFinalReport(resolvedOutput, firstReport, confirmationRecord(
+      initialDecision.status,
+      firstReport.budgetEvaluation.runtimeViolations,
+      [],
+      initialDecision.confirmed,
+      repositoryHead,
+    ), initialDecision.finalViolations, undefined, emitReport);
+    rmSync(firstPath, { force: true });
+    return initialDecision.finalViolations.length === 0 ? 0 : 1;
+  }
+
+  process.stderr.write(
+    "Only noisy runtime budgets breached; running one independent pinned confirmation pass.\n",
+  );
+  if (resolveRepositoryHead() !== repositoryHead) {
+    writeFinalReport(resolvedOutput, firstReport, confirmationRecord(
+      "operational_failure",
+      firstReport.budgetEvaluation.runtimeViolations,
+      [],
+      [],
+      repositoryHead,
+    ), undefined, undefined, emitReport);
+    process.stderr.write("Repository HEAD changed before the confirmation pass.\n");
+    return 2;
+  }
+  const secondResult = executePass(secondPath, ["--output", secondPath]);
+  const secondReport = readPassReport(secondPath, secondResult);
+  if (secondReport === null) {
+    writeFinalReport(resolvedOutput, firstReport, confirmationRecord(
+      "operational_failure",
+      firstReport.budgetEvaluation.runtimeViolations,
+      [],
+      [],
+      repositoryHead,
+    ), undefined, undefined, emitReport);
+    return 2;
+  }
+  if (resolveRepositoryHead() !== repositoryHead) {
+    writeFinalReport(resolvedOutput, secondReport, confirmationRecord(
+      "operational_failure",
+      firstReport.budgetEvaluation.runtimeViolations,
+      secondReport.budgetEvaluation.runtimeViolations,
+      [],
+      repositoryHead,
+    ), secondReport.budgetEvaluation.runtimeViolations, false, emitReport);
+    process.stderr.write("Repository HEAD changed during the confirmation pass.\n");
+    return 2;
+  }
+
+  const decision = evaluateRuntimeConfirmation(
+    firstReport.budgetEvaluation.runtimeViolations,
+    secondReport.budgetEvaluation.runtimeViolations,
+  );
+  const secondAssetViolations = secondReport.budgetEvaluation.assetViolations;
+  const passed = secondAssetViolations.length === 0 && decision.finalViolations.length === 0;
+  writeFinalReport(resolvedOutput, secondReport, confirmationRecord(
+    passed ? "passed" : "failed",
+    firstReport.budgetEvaluation.runtimeViolations,
+    secondReport.budgetEvaluation.runtimeViolations,
+    decision.confirmed,
+    repositoryHead,
+  ), decision.finalViolations, passed, emitReport);
+  return passed ? 0 : 1;
+}
+
+function runPass(outputPath, args, showStdout = false) {
+  const runnerArgs = outputPath === undefined ? args : replaceOutputArgument(args, outputPath);
+  const result = spawnSync(process.execPath, [runnerPath, ...runnerArgs], {
+    cwd: repositoryRoot,
+    env: process.env,
+    stdio: ["inherit", showStdout ? "inherit" : "ignore", "inherit"],
+  });
+  return { status: result.status, signal: result.signal };
+}
+
+function readPassReport(path, result) {
+  if ((result.status !== 0 && result.status !== 1) || result.signal !== null || !existsSync(path)) {
+    process.stderr.write("Release benchmark pass failed before producing a budget report.\n");
+    return null;
+  }
+  try {
+    if (statSync(path).size > MAX_REPORT_BYTES) throw new Error("report too large");
+    const report = JSON.parse(readFileSync(path, "utf8"));
+    if (report?.schemaVersion !== 1
+      || !Array.isArray(report?.budgetEvaluation?.assetViolations)
+      || !Array.isArray(report?.budgetEvaluation?.runtimeViolations)
+      || report.budgetEvaluation.assetViolations.length > 200
+      || report.budgetEvaluation.runtimeViolations.length > 200
+      || report.budgetEvaluation.passed !== (result.status === 0)) {
+      throw new Error("invalid report shape");
+    }
+    return report;
+  } catch {
+    process.stderr.write("Release benchmark pass produced an invalid budget report.\n");
+    return null;
+  }
+}
+
+function writeFinalReport(path, report, confirmation, runtimeViolations, passed, emitReport) {
+  const finalReport = structuredClone(report);
+  finalReport.budgetEvaluation.runtimeConfirmation = confirmation;
+  if (runtimeViolations !== undefined) {
+    finalReport.budgetEvaluation.runtimeViolations = runtimeViolations;
+  }
+  finalReport.budgetEvaluation.passed = passed ?? (
+    finalReport.budgetEvaluation.assetViolations.length === 0
+    && finalReport.budgetEvaluation.runtimeViolations.length === 0
+  );
+  const serialized = `${JSON.stringify(finalReport, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_REPORT_BYTES) {
+    throw new Error(`Release benchmark report exceeded ${MAX_REPORT_BYTES} bytes.`);
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, serialized, "utf8");
+  emitReport(serialized);
+}
+
+function confirmationRecord(
+  status,
+  firstPassViolations,
+  secondPassViolations,
+  confirmedViolations,
+  repositoryHead,
+) {
+  return {
+    status,
+    repositoryHead,
+    firstPassViolations: firstPassViolations.slice(0, 200),
+    secondPassViolations: secondPassViolations.slice(0, 200),
+    confirmedViolations: confirmedViolations.slice(0, 200),
+  };
+}
+
+function readRepositoryHead() {
+  const result = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const head = result.stdout?.trim();
+  if (result.status !== 0 || !/^[0-9a-f]{40}$/u.test(head)) {
+    process.stderr.write("Release benchmark could not resolve the repository HEAD.\n");
+    return null;
+  }
+  return head;
+}
+
+function attemptPath(outputPath, attempt) {
+  const parts = parse(outputPath);
+  return join(parts.dir, `${parts.name}.attempt-${attempt}${parts.ext || ".json"}`);
+}
+
+function replaceOutputArgument(args, outputPath) {
+  const outputArgs = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--output") {
+      index += 1;
+      continue;
+    }
+    outputArgs.push(args[index]);
+  }
+  outputArgs.push("--output", outputPath);
+  return outputArgs;
+}
+
+function parseArguments(args) {
+  const parsed = { assetsOnly: false, help: false, output: undefined };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--assets-only") parsed.assetsOnly = true;
+    else if (argument === "--help" || argument === "-h") parsed.help = true;
+    else if (argument === "--output") {
+      const output = args[index + 1];
+      if (!output || output.startsWith("-")) throw new Error("--output requires a path.");
+      parsed.output = output;
+      index += 1;
+    } else throw new Error(`Unknown release benchmark option: ${argument}`);
+  }
+  return parsed;
+}

--- a/scripts/release-benchmark/release-benchmark.test.js
+++ b/scripts/release-benchmark/release-benchmark.test.js
@@ -24,10 +24,17 @@ import {
   RELEASE_FIXTURE_PROFILES,
 } from "./fixtures.mjs";
 import { startHub } from "./hub.mjs";
+import { enforceWithConfirmation } from "./enforce.mjs";
 import { candidateRuntimeBudgets, evaluateRuntimeBudgets } from "./runtime-budgets.mjs";
+import {
+  classifyRuntimeViolations,
+  evaluateRuntimeConfirmation,
+} from "./runtime-confirmation.mjs";
 import { assetBudgetCandidate, runtimeBudgetCandidate, summarize } from "./statistics.mjs";
 
 const budgets = JSON.parse(readFileSync(new URL("./budgets.json", import.meta.url), "utf8"));
+const packageJson = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8"));
+const reportSchema = JSON.parse(readFileSync(new URL("./report.schema.json", import.meta.url), "utf8"));
 
 describe("release benchmark contract", () => {
   it("locks the sample counts and deterministic route budget surface", () => {
@@ -60,6 +67,16 @@ describe("release benchmark contract", () => {
       runtimeFormula: "ceil(measured p95 * 1.15)",
       assetFormula: "ceil(built bytes * 1.05)",
     });
+    expect(packageJson.scripts["benchmark:release"]).toContain(
+      "scripts/release-benchmark/enforce.mjs",
+    );
+    expect(reportSchema.$defs.runtimeConfirmation.properties.status.enum).toEqual([
+      "not_required",
+      "skipped_immediate_failure",
+      "passed",
+      "failed",
+      "operational_failure",
+    ]);
   });
 
   it("uses nearest-rank p95 and rejects the wrong sample count", () => {
@@ -134,6 +151,228 @@ describe("release benchmark contract", () => {
       budget: 99,
       reason: "budget_exceeded",
     });
+  });
+
+  it("retries only noisy runtime metrics and requires the same metric twice", () => {
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    const activity = runtimeViolation("runtime.apiLatencyMs.medium.activity");
+    const initial = evaluateRuntimeConfirmation([knowledge]);
+    expect(initial).toMatchObject({ retryRequired: true, status: "required" });
+
+    expect(evaluateRuntimeConfirmation([knowledge], [activity])).toMatchObject({
+      retryRequired: false,
+      status: "passed",
+      finalViolations: [],
+    });
+    expect(evaluateRuntimeConfirmation([knowledge], [knowledge])).toMatchObject({
+      retryRequired: false,
+      status: "failed",
+      finalViolations: [knowledge],
+      confirmed: [knowledge],
+    });
+  });
+
+  it("keeps database ratios, outbound requests, and unknown metrics immediate", () => {
+    const noisy = [
+      "runtime.coldHubReadyMs.small",
+      "runtime.idleRssBytes.small",
+      "runtime.idleCpuMs.small",
+      "runtime.apiLatencyMs.small.search",
+      "runtime.maintenanceMs.small.graph_refresh",
+      "runtime.maintenancePeakRssBytes.small.graph_refresh",
+      "runtime.browserHeapBytes.small.home",
+    ].map(runtimeViolation);
+    const database = runtimeViolation("runtime.databaseToInputRatio.small.graph");
+    const outbound = runtimeViolation("runtime.outboundRequestCount.small");
+    const unknown = runtimeViolation("runtime.apiLatencyMs.unknown.future");
+    expect(classifyRuntimeViolations([...noisy, database, outbound, unknown])).toEqual({
+      confirmable: noisy,
+      immediate: [database, outbound, unknown],
+    });
+    expect(evaluateRuntimeConfirmation([noisy[0], database])).toMatchObject({
+      retryRequired: false,
+      status: "skipped_immediate_failure",
+      finalViolations: [database],
+    });
+  });
+
+  it("does not retry a clean first pass and emits a consistent final report", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-clean-"));
+    try {
+      const result = runConfirmationHarness(root, [benchmarkPass()]);
+      expect(result.exitCode).toBe(0);
+      expect(result.calls).toBe(1);
+      expect(result.report.budgetEvaluation).toMatchObject({
+        assetViolations: [],
+        runtimeViolations: [],
+        passed: true,
+        runtimeConfirmation: {
+          status: "not_required",
+          repositoryHead: "a".repeat(40),
+          firstPassViolations: [],
+          secondPassViolations: [],
+          confirmedViolations: [],
+        },
+      });
+      expect(existsSync(join(root, "report.attempt-1.json"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("passes different noisy metrics across attempts and retains both raw reports", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-different-"));
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    const activity = runtimeViolation("runtime.apiLatencyMs.medium.activity");
+    try {
+      const result = runConfirmationHarness(root, [
+        benchmarkPass({ runtimeViolations: [knowledge] }),
+        benchmarkPass({ runtimeViolations: [activity] }),
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(result.calls).toBe(2);
+      expect(result.report.budgetEvaluation).toEqual({
+        assetViolations: [],
+        runtimeViolations: [],
+        passed: true,
+        runtimeConfirmation: {
+          status: "passed",
+          repositoryHead: "a".repeat(40),
+          firstPassViolations: [knowledge],
+          secondPassViolations: [activity],
+          confirmedViolations: [],
+        },
+      });
+      expect(readRawAttempt(root, 1).budgetEvaluation.runtimeViolations).toEqual([knowledge]);
+      expect(readRawAttempt(root, 2).budgetEvaluation.runtimeViolations).toEqual([activity]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when the same noisy metric breaches twice", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-same-"));
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    try {
+      const result = runConfirmationHarness(root, [
+        benchmarkPass({ runtimeViolations: [knowledge] }),
+        benchmarkPass({ runtimeViolations: [knowledge] }),
+      ]);
+      expect(result.exitCode).toBe(1);
+      expect(result.calls).toBe(2);
+      expect(result.report.budgetEvaluation).toMatchObject({
+        runtimeViolations: [knowledge],
+        passed: false,
+        runtimeConfirmation: {
+          status: "failed",
+          firstPassViolations: [knowledge],
+          secondPassViolations: [knowledge],
+          confirmedViolations: [knowledge],
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails hard violations on either attempt without treating them as noise", () => {
+    const graphRatio = runtimeViolation("runtime.databaseToInputRatio.small.graph");
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    const asset = runtimeViolation("assets.routes.home.jsBytes");
+    for (const scenario of [
+      {
+        name: "first-runtime",
+        passes: [benchmarkPass({ runtimeViolations: [graphRatio] })],
+        calls: 1,
+        finalRuntime: [graphRatio],
+      },
+      {
+        name: "first-asset",
+        passes: [benchmarkPass({ assetViolations: [asset] })],
+        calls: 1,
+        finalRuntime: [],
+      },
+      {
+        name: "second-runtime",
+        passes: [
+          benchmarkPass({ runtimeViolations: [knowledge] }),
+          benchmarkPass({ runtimeViolations: [graphRatio] }),
+        ],
+        calls: 2,
+        finalRuntime: [graphRatio],
+      },
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), `mex-release-confirm-${scenario.name}-`));
+      try {
+        const result = runConfirmationHarness(root, scenario.passes);
+        expect(result.exitCode).toBe(1);
+        expect(result.calls).toBe(scenario.calls);
+        expect(result.report.budgetEvaluation.passed).toBe(false);
+        expect(result.report.budgetEvaluation.runtimeViolations).toEqual(scenario.finalRuntime);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("uses exit 2 for unusable child reports", () => {
+    for (const pass of [null, "invalid", "oversized", "signaled", "inconsistent"]) {
+      const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-invalid-first-"));
+      try {
+        const result = runConfirmationHarness(root, [pass]);
+        expect(result.exitCode).toBe(2);
+        expect(result.calls).toBe(1);
+        expect(result.report).toBeUndefined();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+
+    const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-missing-second-"));
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    try {
+      const result = runConfirmationHarness(root, [
+        benchmarkPass({ runtimeViolations: [knowledge] }),
+        null,
+      ]);
+      expect(result.exitCode).toBe(2);
+      expect(result.calls).toBe(2);
+      expect(result.report.budgetEvaluation).toMatchObject({
+        runtimeViolations: [knowledge],
+        passed: false,
+        runtimeConfirmation: {
+          status: "operational_failure",
+          firstPassViolations: [knowledge],
+          secondPassViolations: [],
+          confirmedViolations: [],
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("uses exit 2 if repository HEAD changes between or during attempts", () => {
+    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    for (const heads of [
+      ["a".repeat(40), "b".repeat(40)],
+      ["a".repeat(40), "a".repeat(40), "b".repeat(40)],
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-head-change-"));
+      try {
+        const result = runConfirmationHarness(root, [
+          benchmarkPass({ runtimeViolations: [knowledge] }),
+          benchmarkPass(),
+        ], { heads });
+        expect(result.exitCode).toBe(2);
+        expect(result.report.budgetEvaluation).toMatchObject({
+          passed: false,
+          runtimeConfirmation: { status: "operational_failure" },
+        });
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
   });
 
   it("counts Graph configuration files in the indexed-input denominator", () => {
@@ -265,6 +504,65 @@ function runtimeProfile(value) {
       wiki: { ratio: value },
     },
   };
+}
+
+function runtimeViolation(metric) {
+  return { metric, measured: 101, budget: 100, reason: "budget_exceeded" };
+}
+
+function benchmarkPass({ assetViolations = [], runtimeViolations = [] } = {}) {
+  return {
+    schemaVersion: 1,
+    budgetEvaluation: {
+      assetViolations,
+      runtimeViolations,
+      passed: assetViolations.length === 0 && runtimeViolations.length === 0,
+    },
+  };
+}
+
+function runConfirmationHarness(root, passes, options = {}) {
+  let calls = 0;
+  let headReads = 0;
+  const output = join(root, "report.json");
+  const exitCode = enforceWithConfirmation(output, {
+    executePass(path) {
+      const pass = passes[calls];
+      calls += 1;
+      if (pass === null) return { status: 1, signal: null };
+      if (pass === "invalid") {
+        writeFileSync(path, "not-json\n");
+        return { status: 1, signal: null };
+      }
+      if (pass === "oversized") {
+        writeFileSync(path, "x".repeat((2 * 1024 * 1024) + 1));
+        return { status: 1, signal: null };
+      }
+      if (pass === "signaled") return { status: null, signal: "SIGTERM" };
+      if (pass === "inconsistent") {
+        writeFileSync(path, `${JSON.stringify(benchmarkPass())}\n`);
+        return { status: 1, signal: null };
+      }
+      writeFileSync(path, `${JSON.stringify(pass)}\n`);
+      return { status: pass.budgetEvaluation.passed ? 0 : 1, signal: null };
+    },
+    resolveRepositoryHead() {
+      const heads = options.heads ?? ["a".repeat(40)];
+      const head = heads[Math.min(headReads, heads.length - 1)];
+      headReads += 1;
+      return head;
+    },
+    emitReport: () => undefined,
+  });
+  return {
+    calls,
+    exitCode,
+    report: existsSync(output) ? JSON.parse(readFileSync(output, "utf8")) : undefined,
+  };
+}
+
+function readRawAttempt(root, attempt) {
+  return JSON.parse(readFileSync(join(root, `report.attempt-${attempt}.json`), "utf8"));
 }
 
 function writeMinimalReleaseFixture(root) {

--- a/scripts/release-benchmark/report.schema.json
+++ b/scripts/release-benchmark/report.schema.json
@@ -29,6 +29,7 @@
       "properties": {
         "assetViolations": { "$ref": "#/$defs/violations" },
         "runtimeViolations": { "$ref": "#/$defs/violations" },
+        "runtimeConfirmation": { "$ref": "#/$defs/runtimeConfirmation" },
         "passed": { "type": "boolean" }
       }
     },
@@ -275,6 +276,20 @@
           "budget": { "type": ["number", "null"] },
           "reason": { "type": "string", "maxLength": 100 }
         }
+      }
+    },
+    "runtimeConfirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "repositoryHead", "firstPassViolations", "secondPassViolations", "confirmedViolations"],
+      "properties": {
+        "status": {
+          "enum": ["not_required", "skipped_immediate_failure", "passed", "failed", "operational_failure"]
+        },
+        "repositoryHead": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "firstPassViolations": { "$ref": "#/$defs/violations" },
+        "secondPassViolations": { "$ref": "#/$defs/violations" },
+        "confirmedViolations": { "$ref": "#/$defs/violations" }
       }
     }
   }

--- a/scripts/release-benchmark/runtime-confirmation.mjs
+++ b/scripts/release-benchmark/runtime-confirmation.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+
+const budgets = JSON.parse(readFileSync(new URL("./budgets.json", import.meta.url), "utf8"));
+const CONFIRMABLE_RUNTIME_METRICS = confirmableRuntimeMetrics(budgets.runtime);
+
+const MAX_VIOLATIONS = 200;
+
+export function classifyRuntimeViolations(violations) {
+  const confirmable = [];
+  const immediate = [];
+  for (const violation of violations.slice(0, MAX_VIOLATIONS)) {
+    const destination = isConfirmableRuntimeMetric(violation.metric)
+      ? confirmable
+      : immediate;
+    destination.push(violation);
+  }
+  return { confirmable, immediate };
+}
+
+export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViolations) {
+  const first = classifyRuntimeViolations(firstPassViolations);
+  if (first.immediate.length > 0) {
+    return {
+      retryRequired: false,
+      status: "skipped_immediate_failure",
+      finalViolations: first.immediate,
+      first,
+      second: { confirmable: [], immediate: [] },
+      confirmed: [],
+    };
+  }
+  if (first.confirmable.length === 0) {
+    return {
+      retryRequired: false,
+      status: "not_required",
+      finalViolations: [],
+      first,
+      second: { confirmable: [], immediate: [] },
+      confirmed: [],
+    };
+  }
+  if (secondPassViolations === undefined) {
+    return {
+      retryRequired: true,
+      status: "required",
+      finalViolations: [],
+      first,
+      second: { confirmable: [], immediate: [] },
+      confirmed: [],
+    };
+  }
+
+  const second = classifyRuntimeViolations(secondPassViolations);
+  const firstMetrics = new Set(first.confirmable.map((violation) => violation.metric));
+  const confirmed = second.confirmable.filter((violation) => firstMetrics.has(violation.metric));
+  const finalViolations = [...second.immediate, ...confirmed].slice(0, MAX_VIOLATIONS);
+  return {
+    retryRequired: false,
+    status: finalViolations.length === 0 ? "passed" : "failed",
+    finalViolations,
+    first,
+    second,
+    confirmed,
+  };
+}
+
+function isConfirmableRuntimeMetric(metric) {
+  return typeof metric === "string" && CONFIRMABLE_RUNTIME_METRICS.has(metric);
+}
+
+function confirmableRuntimeMetrics(runtimeBudgets) {
+  const metrics = new Set();
+  for (const name of ["coldHubReadyMs", "idleRssBytes", "idleCpuMs"]) {
+    for (const profile of Object.keys(runtimeBudgets[name] ?? {})) {
+      metrics.add(`runtime.${name}.${profile}`);
+    }
+  }
+  for (const name of [
+    "apiLatencyMs",
+    "maintenanceMs",
+    "maintenancePeakRssBytes",
+    "browserHeapBytes",
+  ]) {
+    for (const [profile, entries] of Object.entries(runtimeBudgets[name] ?? {})) {
+      for (const metric of Object.keys(entries)) {
+        metrics.add(`runtime.${name}.${profile}.${metric}`);
+      }
+    }
+  }
+  return metrics;
+}


### PR DESCRIPTION
## Summary

- require a second pinned benchmark pass before a noisy runtime metric blocks CI
- fail only runtime metrics that breach in both consecutive attempts
- keep asset bytes, outbound requests, database ratios, unknown metrics, and operational failures immediate
- preserve both raw attempt reports and a bounded final confirmation decision

## Why

The exact Checkpoint B tree passed the PR performance run and failed nine minutes later after merge on five runtime-only overruns of 0.4–14 ms. With ten samples, nearest-rank p95 is the maximum sample, so one runner outlier can fail a metric. This keeps all numeric budgets unchanged while distinguishing repeatable regressions from one-off runner jitter.

## Verification

- release benchmark contract: 16/16
- production build and `benchmark:release -- --assets-only`
- report schema validation
- syntax checks for both new scripts
- independent P0/P1 review: clear
- `git diff --check`

## Scope locks

- targets `integration/human-team-memory-v1`
- version remains `0.7.2`
- no product code, package exports, numeric budgets, release, publish, deployment, tag, Docker, or `main` changes
