### PR TITLE
test(release): distinguish material runtime regressions

### DIFF
--- a/docs/design/release-performance-baseline.md
+++ b/docs/design/release-performance-baseline.md
@@ -64,12 +64,29 @@ The read and maintenance nonmutation contracts likewise remain ordinary hard
 tests. A first pass containing only wall-clock, RSS, CPU, or browser-heap
 breaches triggers one independent full benchmark pass on the same pinned
 runner and exact repository HEAD. CI fails a noisy metric only when that exact
-metric breaches again; unrelated one-off breaches across the two passes are
-retained in `runtimeConfirmation` but are not treated as a confirmed regression.
-The final `runtimeViolations` list contains only immediate or confirmed failures.
-Operational benchmark failures are never retried as budget noise. Enforcement
-exits 0 for a pass, 1 for a budget failure, and 2 when a pass cannot produce a
-valid bounded report.
+metric breaches again and both measurements exceed its material threshold. The
+committed p95 budgets remain the raw alert/crossing line and are not
+recalibrated. For each exact metric key, the blocking threshold is
+`budget + max(15% of budget, minimum excess)`:
+
+| Runtime category | Minimum excess |
+| --- | ---: |
+| API latency | 15 ms |
+| Cold readiness | 100 ms |
+| Maintenance elapsed time | 50 ms |
+| Idle CPU | 25 ms |
+| Idle and maintenance peak RSS | 32 MiB |
+| Browser heap | 2 MiB |
+
+Crossings from both attempts remain bounded in `firstPassViolations` and
+`secondPassViolations`. Repeated exact keys remain in `confirmedViolations`.
+`advisoryAssessments` records one-off crossings and repeated crossings where
+either measurement is at or below the material threshold;
+`materialAssessments` records only repeated crossings where both measurements
+are strictly above it. The final `runtimeViolations` list contains only those
+material crossings plus immediate hard failures. Operational benchmark failures
+are never retried as budget noise. Enforcement exits 0 for a pass, 1 for a
+budget failure, and 2 when a pass cannot produce a valid bounded report.
 
 The dedicated `release-performance` CI job installs Chromium on the pinned
 runner, enforces the budgets, and retains the final report plus both attempt

--- a/scripts/release-benchmark/enforce.mjs
+++ b/scripts/release-benchmark/enforce.mjs
@@ -31,7 +31,7 @@ function main() {
       "Usage: node scripts/release-benchmark/enforce.mjs [--output <path>] [--assets-only]",
       "",
       "Runtime budgets are enforced only when MEX_ENFORCE_RELEASE_BUDGETS=1.",
-      "Noisy runtime-only breaches receive one independent confirmation pass.",
+      "Noisy runtime-only breaches receive one materiality-aware confirmation pass.",
       "Deterministic contract breaches and operational failures never receive a retry.",
       "",
     ].join("\n"));
@@ -80,6 +80,8 @@ export function enforceWithConfirmation(outputPath, dependencies = {}) {
       [],
       initialDecision.confirmed,
       repositoryHead,
+      initialDecision.advisoryAssessments,
+      initialDecision.materialAssessments,
     ), initialDecision.finalViolations, undefined, emitReport);
     rmSync(firstPath, { force: true });
     return initialDecision.finalViolations.length === 0 ? 0 : 1;
@@ -135,6 +137,8 @@ export function enforceWithConfirmation(outputPath, dependencies = {}) {
     secondReport.budgetEvaluation.runtimeViolations,
     decision.confirmed,
     repositoryHead,
+    decision.advisoryAssessments,
+    decision.materialAssessments,
   ), decision.finalViolations, passed, emitReport);
   return passed ? 0 : 1;
 }
@@ -197,6 +201,8 @@ function confirmationRecord(
   secondPassViolations,
   confirmedViolations,
   repositoryHead,
+  advisoryAssessments = [],
+  materialAssessments = [],
 ) {
   return {
     status,
@@ -204,6 +210,8 @@ function confirmationRecord(
     firstPassViolations: firstPassViolations.slice(0, 200),
     secondPassViolations: secondPassViolations.slice(0, 200),
     confirmedViolations: confirmedViolations.slice(0, 200),
+    advisoryAssessments: advisoryAssessments.slice(0, 400),
+    materialAssessments: materialAssessments.slice(0, 200),
   };
 }
 

--- a/scripts/release-benchmark/release-benchmark.test.js
+++ b/scripts/release-benchmark/release-benchmark.test.js
@@ -10,6 +10,8 @@ import {
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import { describe, expect, it } from "vitest";
 import { assertNoForbiddenWorkbench, evaluateAssetBudgets } from "./assets.mjs";
 import {
@@ -29,6 +31,7 @@ import { candidateRuntimeBudgets, evaluateRuntimeBudgets } from "./runtime-budge
 import {
   classifyRuntimeViolations,
   evaluateRuntimeConfirmation,
+  runtimeMaterialityPolicy,
 } from "./runtime-confirmation.mjs";
 import { assetBudgetCandidate, runtimeBudgetCandidate, summarize } from "./statistics.mjs";
 
@@ -77,6 +80,10 @@ describe("release benchmark contract", () => {
       "failed",
       "operational_failure",
     ]);
+    expect(reportSchema.$defs.runtimeConfirmation.required).not.toContain("advisoryAssessments");
+    expect(reportSchema.$defs.runtimeConfirmation.required).not.toContain("materialAssessments");
+    expect(reportSchema.$defs.runtimeConfirmation.properties).toHaveProperty("advisoryAssessments");
+    expect(reportSchema.$defs.runtimeConfirmation.properties).toHaveProperty("materialAssessments");
   });
 
   it("uses nearest-rank p95 and rejects the wrong sample count", () => {
@@ -90,6 +97,76 @@ describe("release benchmark contract", () => {
     expect(() => summarize([1, 2, 3, 4], 5)).toThrow(/exactly 5 samples/u);
     expect(runtimeBudgetCandidate(100.01)).toBe(116);
     expect(assetBudgetCandidate(100.01)).toBe(106);
+  });
+
+  it("strictly validates advisory and material final benchmark reports", () => {
+    const ajv = new Ajv2020({ strict: true });
+    addFormats(ajv);
+    const validate = ajv.compile(reportSchema);
+    const metric = "runtime.apiLatencyMs.small.code";
+    const legacyReport = representativeReleaseReport({
+      runtimeViolations: [],
+      passed: true,
+      confirmation: {
+        status: "passed",
+        repositoryHead: "a".repeat(40),
+        firstPassViolations: [],
+        secondPassViolations: [],
+        confirmedViolations: [],
+      },
+    });
+    expect(validate(legacyReport), JSON.stringify(validate.errors)).toBe(true);
+
+    const firstAdvisory = runtimeViolation(metric, 53);
+    const secondAdvisory = runtimeViolation(metric, 58);
+    const advisoryAssessment = materialityAssessment({
+      classification: "advisory",
+      reason: "below_material_threshold",
+      firstMeasured: 53,
+      secondMeasured: 58,
+    });
+    const advisoryReport = representativeReleaseReport({
+      runtimeViolations: [],
+      passed: true,
+      confirmation: {
+        status: "passed",
+        repositoryHead: "a".repeat(40),
+        firstPassViolations: [firstAdvisory],
+        secondPassViolations: [secondAdvisory],
+        confirmedViolations: [secondAdvisory],
+        advisoryAssessments: [advisoryAssessment],
+        materialAssessments: [],
+      },
+    });
+    expect(validate(advisoryReport), JSON.stringify(validate.errors)).toBe(true);
+
+    const firstMaterial = runtimeViolation(metric, 67);
+    const secondMaterial = runtimeViolation(metric, 70);
+    const materialAssessment = materialityAssessment({
+      classification: "material",
+      reason: "repeated_material_threshold",
+      firstMeasured: 67,
+      secondMeasured: 70,
+    });
+    const materialReport = representativeReleaseReport({
+      runtimeViolations: [secondMaterial],
+      passed: false,
+      confirmation: {
+        status: "failed",
+        repositoryHead: "a".repeat(40),
+        firstPassViolations: [firstMaterial],
+        secondPassViolations: [secondMaterial],
+        confirmedViolations: [secondMaterial],
+        advisoryAssessments: [],
+        materialAssessments: [materialAssessment],
+      },
+    });
+    expect(validate(materialReport), JSON.stringify(validate.errors)).toBe(true);
+
+    materialReport.budgetEvaluation.runtimeConfirmation.materialAssessments = [
+      advisoryAssessment,
+    ];
+    expect(validate(materialReport)).toBe(false);
   });
 
   it("fails deterministic asset bytes above the committed golden", () => {
@@ -153,7 +230,7 @@ describe("release benchmark contract", () => {
     });
   });
 
-  it("retries only noisy runtime metrics and requires the same metric twice", () => {
+  it("retries noisy crossings but blocks only repeated material crossings", () => {
     const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
     const activity = runtimeViolation("runtime.apiLatencyMs.medium.activity");
     const initial = evaluateRuntimeConfirmation([knowledge]);
@@ -166,10 +243,106 @@ describe("release benchmark contract", () => {
     });
     expect(evaluateRuntimeConfirmation([knowledge], [knowledge])).toMatchObject({
       retryRequired: false,
-      status: "failed",
-      finalViolations: [knowledge],
+      status: "passed",
+      finalViolations: [],
       confirmed: [knowledge],
+      advisoryAssessments: [{
+        metric: knowledge.metric,
+        classification: "advisory",
+        reason: "below_material_threshold",
+      }],
+      materialAssessments: [],
     });
+  });
+
+  it("applies every exact category policy and rejects unknown exact keys", () => {
+    const policyCases = [
+      ["runtime.coldHubReadyMs.small", "cold_readiness_ms", 100, 1082.15],
+      ["runtime.idleRssBytes.small", "rss_bytes", 32 * 1024 * 1024, 239304704],
+      ["runtime.idleCpuMs.large", "idle_cpu_ms", 25, 37],
+      ["runtime.apiLatencyMs.small.code", "api_latency_ms", 15, 66],
+      ["runtime.maintenanceMs.small.wiki_rebuild", "maintenance_ms", 50, 231],
+      ["runtime.maintenancePeakRssBytes.small.graph_refresh", "rss_bytes", 32 * 1024 * 1024, 541235558.4],
+      ["runtime.browserHeapBytes.small.home", "browser_heap_bytes", 2 * 1024 * 1024, 6692746],
+    ];
+    for (const [metric, category, minimumExcess, materialThreshold] of policyCases) {
+      const policy = runtimeMaterialityPolicy(metric);
+      expect(policy).toEqual({
+        budget: committedRuntimeBudget(metric),
+        category,
+        minimumExcess,
+        materialThreshold,
+      });
+      expect(evaluateRuntimeConfirmation(
+        [runtimeViolation(metric, policy.materialThreshold + 1)],
+        [runtimeViolation(metric, policy.materialThreshold + 2)],
+      )).toMatchObject({ status: "failed", materialAssessments: [{ metric }] });
+      expect(evaluateRuntimeConfirmation(
+        [runtimeViolation(metric, policy.materialThreshold)],
+        [runtimeViolation(metric, policy.materialThreshold + 2)],
+      )).toMatchObject({ status: "passed", materialAssessments: [] });
+    }
+
+    const exactMetrics = committedConfirmableRuntimeMetrics();
+    expect(exactMetrics).toHaveLength(90);
+    for (const metric of exactMetrics) {
+      expect(runtimeMaterialityPolicy(metric)).not.toBeNull();
+      const violation = runtimeViolation(metric);
+      expect(classifyRuntimeViolations([violation])).toEqual({
+        confirmable: [violation],
+        immediate: [],
+      });
+    }
+    expect(runtimeMaterialityPolicy("runtime.apiLatencyMs.unknown.future")).toBeNull();
+  });
+
+  it("keeps small repeated API crossings advisory and blocks material ones", () => {
+    const metric = "runtime.apiLatencyMs.small.code";
+    const advisory = evaluateRuntimeConfirmation(
+      [runtimeViolation(metric, 53)],
+      [runtimeViolation(metric, 58)],
+    );
+    expect(advisory).toMatchObject({
+      status: "passed",
+      finalViolations: [],
+      advisoryAssessments: [{
+        metric,
+        budget: 51,
+        minimumExcess: 15,
+        materialThreshold: 66,
+        firstMeasured: 53,
+        secondMeasured: 58,
+        classification: "advisory",
+        reason: "below_material_threshold",
+      }],
+      materialAssessments: [],
+    });
+
+    const material = evaluateRuntimeConfirmation(
+      [runtimeViolation(metric, 67)],
+      [runtimeViolation(metric, 70)],
+    );
+    expect(material).toMatchObject({
+      status: "failed",
+      finalViolations: [runtimeViolation(metric, 70)],
+      materialAssessments: [{
+        metric,
+        budget: 51,
+        materialThreshold: 66,
+        firstMeasured: 67,
+        secondMeasured: 70,
+        classification: "material",
+        reason: "repeated_material_threshold",
+      }],
+    });
+    expect(evaluateRuntimeConfirmation(
+      [runtimeViolation(metric, 67)],
+      [runtimeViolation(metric, 60)],
+    )).toMatchObject({ status: "passed", finalViolations: [] });
+    expect(evaluateRuntimeConfirmation(
+      [runtimeViolation(metric, 66)],
+      [runtimeViolation(metric, 70)],
+    )).toMatchObject({ status: "passed", finalViolations: [] });
   });
 
   it("keeps database ratios, outbound requests, and unknown metrics immediate", () => {
@@ -181,18 +354,27 @@ describe("release benchmark contract", () => {
       "runtime.maintenanceMs.small.graph_refresh",
       "runtime.maintenancePeakRssBytes.small.graph_refresh",
       "runtime.browserHeapBytes.small.home",
-    ].map(runtimeViolation);
+    ].map((metric) => runtimeViolation(metric));
     const database = runtimeViolation("runtime.databaseToInputRatio.small.graph");
     const outbound = runtimeViolation("runtime.outboundRequestCount.small");
     const unknown = runtimeViolation("runtime.apiLatencyMs.unknown.future");
-    expect(classifyRuntimeViolations([...noisy, database, outbound, unknown])).toEqual({
+    const mismatchedBudget = runtimeViolation("runtime.apiLatencyMs.small.code", 70, 52);
+    expect(classifyRuntimeViolations([
+      ...noisy,
+      database,
+      outbound,
+      unknown,
+      mismatchedBudget,
+    ])).toEqual({
       confirmable: noisy,
-      immediate: [database, outbound, unknown],
+      immediate: [database, outbound, unknown, mismatchedBudget],
     });
     expect(evaluateRuntimeConfirmation([noisy[0], database])).toMatchObject({
       retryRequired: false,
       status: "skipped_immediate_failure",
       finalViolations: [database],
+      advisoryAssessments: [{ metric: noisy[0].metric, reason: "not_repeated" }],
+      materialAssessments: [],
     });
   });
 
@@ -212,6 +394,8 @@ describe("release benchmark contract", () => {
           firstPassViolations: [],
           secondPassViolations: [],
           confirmedViolations: [],
+          advisoryAssessments: [],
+          materialAssessments: [],
         },
       });
       expect(existsSync(join(root, "report.attempt-1.json"))).toBe(false);
@@ -231,7 +415,7 @@ describe("release benchmark contract", () => {
       ]);
       expect(result.exitCode).toBe(0);
       expect(result.calls).toBe(2);
-      expect(result.report.budgetEvaluation).toEqual({
+      expect(result.report.budgetEvaluation).toMatchObject({
         assetViolations: [],
         runtimeViolations: [],
         passed: true,
@@ -241,6 +425,11 @@ describe("release benchmark contract", () => {
           firstPassViolations: [knowledge],
           secondPassViolations: [activity],
           confirmedViolations: [],
+          advisoryAssessments: [
+            { metric: knowledge.metric, reason: "not_repeated" },
+            { metric: activity.metric, reason: "not_repeated" },
+          ],
+          materialAssessments: [],
         },
       });
       expect(readRawAttempt(root, 1).budgetEvaluation.runtimeViolations).toEqual([knowledge]);
@@ -250,26 +439,66 @@ describe("release benchmark contract", () => {
     }
   });
 
-  it("fails when the same noisy metric breaches twice", () => {
+  it("fails when the same noisy metric is material in both attempts", () => {
     const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-same-"));
-    const knowledge = runtimeViolation("runtime.apiLatencyMs.medium.knowledge");
+    const metric = "runtime.apiLatencyMs.small.code";
+    const first = runtimeViolation(metric, 67);
+    const second = runtimeViolation(metric, 70);
     try {
       const result = runConfirmationHarness(root, [
-        benchmarkPass({ runtimeViolations: [knowledge] }),
-        benchmarkPass({ runtimeViolations: [knowledge] }),
+        benchmarkPass({ runtimeViolations: [first] }),
+        benchmarkPass({ runtimeViolations: [second] }),
       ]);
       expect(result.exitCode).toBe(1);
       expect(result.calls).toBe(2);
       expect(result.report.budgetEvaluation).toMatchObject({
-        runtimeViolations: [knowledge],
+        runtimeViolations: [second],
         passed: false,
         runtimeConfirmation: {
           status: "failed",
-          firstPassViolations: [knowledge],
-          secondPassViolations: [knowledge],
-          confirmedViolations: [knowledge],
+          firstPassViolations: [first],
+          secondPassViolations: [second],
+          confirmedViolations: [second],
+          advisoryAssessments: [],
+          materialAssessments: [{ metric, classification: "material" }],
         },
       });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits repeated nonmaterial crossings as advisory in the final report", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-confirm-advisory-"));
+    const metric = "runtime.apiLatencyMs.small.code";
+    const first = runtimeViolation(metric, 53);
+    const second = runtimeViolation(metric, 58);
+    try {
+      const result = runConfirmationHarness(root, [
+        benchmarkPass({ runtimeViolations: [first] }),
+        benchmarkPass({ runtimeViolations: [second] }),
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(result.report.budgetEvaluation).toMatchObject({
+        runtimeViolations: [],
+        passed: true,
+        runtimeConfirmation: {
+          status: "passed",
+          firstPassViolations: [first],
+          secondPassViolations: [second],
+          confirmedViolations: [second],
+          advisoryAssessments: [{
+            metric,
+            classification: "advisory",
+            reason: "below_material_threshold",
+            firstMeasured: 53,
+            secondMeasured: 58,
+          }],
+          materialAssessments: [],
+        },
+      });
+      expect(readRawAttempt(root, 1).budgetEvaluation.runtimeViolations).toEqual([first]);
+      expect(readRawAttempt(root, 2).budgetEvaluation.runtimeViolations).toEqual([second]);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -506,8 +735,78 @@ function runtimeProfile(value) {
   };
 }
 
-function runtimeViolation(metric) {
-  return { metric, measured: 101, budget: 100, reason: "budget_exceeded" };
+function runtimeViolation(metric, measured, budget) {
+  const committedBudget = runtimeMaterialityPolicy(metric)?.budget ?? 100;
+  return {
+    metric,
+    measured: measured ?? committedBudget + 1,
+    budget: budget ?? committedBudget,
+    reason: "budget_exceeded",
+  };
+}
+
+function materialityAssessment(overrides) {
+  return {
+    metric: "runtime.apiLatencyMs.small.code",
+    category: "api_latency_ms",
+    budget: 51,
+    relativeExcessRatio: 0.15,
+    minimumExcess: 15,
+    materialThreshold: 66,
+    ...overrides,
+  };
+}
+
+function representativeReleaseReport({ runtimeViolations, passed, confirmation }) {
+  const assetGroup = { jsBytes: 0, cssBytes: 0, fontBytes: 0, files: [] };
+  return {
+    schemaVersion: 1,
+    benchmark: "mex-release-performance",
+    generatedAt: "2026-08-27T00:00:00.000Z",
+    environment: {},
+    configuration: {},
+    assets: {
+      initial: assetGroup,
+      routes: Object.fromEntries(RELEASE_ROUTE_KEYS.map((route) => [route, assetGroup])),
+      largestJsChunk: {},
+      budgetCandidates: {},
+      violations: [],
+    },
+    profiles: {},
+    budgetEvaluation: {
+      assetViolations: [],
+      runtimeViolations,
+      runtimeConfirmation: confirmation,
+      passed,
+    },
+    budgetCandidates: {},
+  };
+}
+
+function committedRuntimeBudget(metric) {
+  return runtimeMaterialityPolicy(metric)?.budget;
+}
+
+function committedConfirmableRuntimeMetrics() {
+  const metrics = [];
+  for (const name of ["coldHubReadyMs", "idleRssBytes", "idleCpuMs"]) {
+    for (const profile of Object.keys(budgets.runtime[name])) {
+      metrics.push(`runtime.${name}.${profile}`);
+    }
+  }
+  for (const name of [
+    "apiLatencyMs",
+    "maintenanceMs",
+    "maintenancePeakRssBytes",
+    "browserHeapBytes",
+  ]) {
+    for (const [profile, entries] of Object.entries(budgets.runtime[name])) {
+      for (const metric of Object.keys(entries)) {
+        metrics.push(`runtime.${name}.${profile}.${metric}`);
+      }
+    }
+  }
+  return metrics;
 }
 
 function benchmarkPass({ assetViolations = [], runtimeViolations = [] } = {}) {

--- a/scripts/release-benchmark/report.schema.json
+++ b/scripts/release-benchmark/report.schema.json
@@ -289,7 +289,60 @@
         "repositoryHead": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
         "firstPassViolations": { "$ref": "#/$defs/violations" },
         "secondPassViolations": { "$ref": "#/$defs/violations" },
-        "confirmedViolations": { "$ref": "#/$defs/violations" }
+        "confirmedViolations": { "$ref": "#/$defs/violations" },
+        "advisoryAssessments": { "$ref": "#/$defs/advisoryAssessments" },
+        "materialAssessments": { "$ref": "#/$defs/materialAssessments" }
+      }
+    },
+    "advisoryAssessments": {
+      "type": "array",
+      "maxItems": 400,
+      "items": {
+        "allOf": [
+          { "$ref": "#/$defs/materialityAssessment" },
+          {
+            "type": "object",
+            "properties": {
+              "classification": { "const": "advisory" },
+              "reason": { "enum": ["not_repeated", "below_material_threshold"] }
+            }
+          }
+        ]
+      }
+    },
+    "materialAssessments": {
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "allOf": [
+          { "$ref": "#/$defs/materialityAssessment" },
+          {
+            "type": "object",
+            "properties": {
+              "classification": { "const": "material" },
+              "reason": { "const": "repeated_material_threshold" }
+            }
+          }
+        ]
+      }
+    },
+    "materialityAssessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "category", "classification", "reason", "budget", "relativeExcessRatio", "minimumExcess", "materialThreshold", "firstMeasured", "secondMeasured"],
+      "properties": {
+        "metric": { "type": "string", "maxLength": 256 },
+        "category": {
+          "enum": ["api_latency_ms", "cold_readiness_ms", "maintenance_ms", "idle_cpu_ms", "rss_bytes", "browser_heap_bytes"]
+        },
+        "classification": { "enum": ["advisory", "material"] },
+        "reason": { "enum": ["not_repeated", "below_material_threshold", "repeated_material_threshold"] },
+        "budget": { "$ref": "#/$defs/number" },
+        "relativeExcessRatio": { "const": 0.15 },
+        "minimumExcess": { "$ref": "#/$defs/number" },
+        "materialThreshold": { "$ref": "#/$defs/number" },
+        "firstMeasured": { "type": ["number", "null"], "minimum": 0 },
+        "secondMeasured": { "type": ["number", "null"], "minimum": 0 }
       }
     }
   }

--- a/scripts/release-benchmark/runtime-confirmation.mjs
+++ b/scripts/release-benchmark/runtime-confirmation.mjs
@@ -1,15 +1,16 @@
 import { readFileSync } from "node:fs";
 
 const budgets = JSON.parse(readFileSync(new URL("./budgets.json", import.meta.url), "utf8"));
-const CONFIRMABLE_RUNTIME_METRICS = confirmableRuntimeMetrics(budgets.runtime);
-
 const MAX_VIOLATIONS = 200;
+const RELATIVE_EXCESS_RATIO = 0.15;
+const MIB = 1024 * 1024;
+const RUNTIME_MATERIALITY_POLICIES = runtimeMaterialityPolicies(budgets.runtime);
 
 export function classifyRuntimeViolations(violations) {
   const confirmable = [];
   const immediate = [];
   for (const violation of violations.slice(0, MAX_VIOLATIONS)) {
-    const destination = isConfirmableRuntimeMetric(violation.metric)
+    const destination = isConfirmableRuntimeViolation(violation)
       ? confirmable
       : immediate;
     destination.push(violation);
@@ -20,6 +21,7 @@ export function classifyRuntimeViolations(violations) {
 export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViolations) {
   const first = classifyRuntimeViolations(firstPassViolations);
   if (first.immediate.length > 0) {
+    const advisoryAssessments = assessMateriality(first.confirmable, []);
     return {
       retryRequired: false,
       status: "skipped_immediate_failure",
@@ -27,6 +29,8 @@ export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViola
       first,
       second: { confirmable: [], immediate: [] },
       confirmed: [],
+      advisoryAssessments,
+      materialAssessments: [],
     };
   }
   if (first.confirmable.length === 0) {
@@ -37,6 +41,8 @@ export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViola
       first,
       second: { confirmable: [], immediate: [] },
       confirmed: [],
+      advisoryAssessments: [],
+      materialAssessments: [],
     };
   }
   if (secondPassViolations === undefined) {
@@ -47,13 +53,20 @@ export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViola
       first,
       second: { confirmable: [], immediate: [] },
       confirmed: [],
+      advisoryAssessments: [],
+      materialAssessments: [],
     };
   }
 
   const second = classifyRuntimeViolations(secondPassViolations);
   const firstMetrics = new Set(first.confirmable.map((violation) => violation.metric));
   const confirmed = second.confirmable.filter((violation) => firstMetrics.has(violation.metric));
-  const finalViolations = [...second.immediate, ...confirmed].slice(0, MAX_VIOLATIONS);
+  const assessments = assessMateriality(first.confirmable, second.confirmable);
+  const advisoryAssessments = assessments.filter((assessment) => assessment.classification === "advisory");
+  const materialAssessments = assessments.filter((assessment) => assessment.classification === "material");
+  const materialMetrics = new Set(materialAssessments.map((assessment) => assessment.metric));
+  const materialViolations = confirmed.filter((violation) => materialMetrics.has(violation.metric));
+  const finalViolations = [...second.immediate, ...materialViolations].slice(0, MAX_VIOLATIONS);
   return {
     retryRequired: false,
     status: finalViolations.length === 0 ? "passed" : "failed",
@@ -61,31 +74,124 @@ export function evaluateRuntimeConfirmation(firstPassViolations, secondPassViola
     first,
     second,
     confirmed,
+    advisoryAssessments,
+    materialAssessments,
   };
 }
 
-function isConfirmableRuntimeMetric(metric) {
-  return typeof metric === "string" && CONFIRMABLE_RUNTIME_METRICS.has(metric);
+export function runtimeMaterialityPolicy(metric) {
+  const policy = RUNTIME_MATERIALITY_POLICIES.get(metric);
+  return policy === undefined ? null : { ...policy };
 }
 
-function confirmableRuntimeMetrics(runtimeBudgets) {
-  const metrics = new Set();
-  for (const name of ["coldHubReadyMs", "idleRssBytes", "idleCpuMs"]) {
-    for (const profile of Object.keys(runtimeBudgets[name] ?? {})) {
-      metrics.add(`runtime.${name}.${profile}`);
+function isConfirmableRuntimeViolation(violation) {
+  const policy = RUNTIME_MATERIALITY_POLICIES.get(violation?.metric);
+  return policy !== undefined
+    && violation.reason === "budget_exceeded"
+    && violation.budget === policy.budget
+    && Number.isFinite(violation.measured)
+    && violation.measured > policy.budget;
+}
+
+function assessMateriality(firstViolations, secondViolations) {
+  const firstByMetric = new Map(firstViolations.map((violation) => [violation.metric, violation]));
+  const secondByMetric = new Map(secondViolations.map((violation) => [violation.metric, violation]));
+  const metrics = [...firstByMetric.keys()];
+  for (const metric of secondByMetric.keys()) {
+    if (!firstByMetric.has(metric)) metrics.push(metric);
+  }
+  return metrics.slice(0, MAX_VIOLATIONS * 2).map((metric) => {
+    const first = firstByMetric.get(metric);
+    const second = secondByMetric.get(metric);
+    const policy = RUNTIME_MATERIALITY_POLICIES.get(metric);
+    const repeated = first !== undefined && second !== undefined;
+    const material = repeated
+      && first.measured > policy.materialThreshold
+      && second.measured > policy.materialThreshold;
+    return {
+      metric,
+      category: policy.category,
+      classification: material ? "material" : "advisory",
+      reason: !repeated
+        ? "not_repeated"
+        : material
+          ? "repeated_material_threshold"
+          : "below_material_threshold",
+      budget: policy.budget,
+      relativeExcessRatio: RELATIVE_EXCESS_RATIO,
+      minimumExcess: policy.minimumExcess,
+      materialThreshold: policy.materialThreshold,
+      firstMeasured: first?.measured ?? null,
+      secondMeasured: second?.measured ?? null,
+    };
+  });
+}
+
+function runtimeMaterialityPolicies(runtimeBudgets) {
+  const policies = new Map();
+  addProfilePolicies(policies, runtimeBudgets.coldHubReadyMs, {
+    category: "cold_readiness_ms",
+    metricName: "coldHubReadyMs",
+    minimumExcess: 100,
+  });
+  addProfilePolicies(policies, runtimeBudgets.idleRssBytes, {
+    category: "rss_bytes",
+    metricName: "idleRssBytes",
+    minimumExcess: 32 * MIB,
+  });
+  addProfilePolicies(policies, runtimeBudgets.idleCpuMs, {
+    category: "idle_cpu_ms",
+    metricName: "idleCpuMs",
+    minimumExcess: 25,
+  });
+  addNestedPolicies(policies, runtimeBudgets.apiLatencyMs, {
+    category: "api_latency_ms",
+    metricName: "apiLatencyMs",
+    minimumExcess: 15,
+  });
+  addNestedPolicies(policies, runtimeBudgets.maintenanceMs, {
+    category: "maintenance_ms",
+    metricName: "maintenanceMs",
+    minimumExcess: 50,
+  });
+  addNestedPolicies(policies, runtimeBudgets.maintenancePeakRssBytes, {
+    category: "rss_bytes",
+    metricName: "maintenancePeakRssBytes",
+    minimumExcess: 32 * MIB,
+  });
+  addNestedPolicies(policies, runtimeBudgets.browserHeapBytes, {
+    category: "browser_heap_bytes",
+    metricName: "browserHeapBytes",
+    minimumExcess: 2 * MIB,
+  });
+  return policies;
+}
+
+function addProfilePolicies(policies, budgetsForMetric, definition) {
+  for (const [profile, budget] of Object.entries(budgetsForMetric ?? {})) {
+    addPolicy(policies, `runtime.${definition.metricName}.${profile}`, budget, definition);
+  }
+}
+
+function addNestedPolicies(policies, budgetsForMetric, definition) {
+  for (const [profile, entries] of Object.entries(budgetsForMetric ?? {})) {
+    for (const [name, budget] of Object.entries(entries)) {
+      addPolicy(
+        policies,
+        `runtime.${definition.metricName}.${profile}.${name}`,
+        budget,
+        definition,
+      );
     }
   }
-  for (const name of [
-    "apiLatencyMs",
-    "maintenanceMs",
-    "maintenancePeakRssBytes",
-    "browserHeapBytes",
-  ]) {
-    for (const [profile, entries] of Object.entries(runtimeBudgets[name] ?? {})) {
-      for (const metric of Object.keys(entries)) {
-        metrics.add(`runtime.${name}.${profile}.${metric}`);
-      }
-    }
-  }
-  return metrics;
+}
+
+function addPolicy(policies, metric, budget, definition) {
+  const minimumExcess = definition.minimumExcess;
+  policies.set(metric, Object.freeze({
+    budget,
+    category: definition.category,
+    minimumExcess,
+    materialThreshold: budget + Math.max(budget * RELATIVE_EXCESS_RATIO, minimumExcess),
+  }));
 }


### PR DESCRIPTION
## Summary

- keep calibrated runtime budgets as raw alert lines
- block runtime regressions only when the same exact metric repeats across both pinned attempts and both readings clear a category-specific materiality band
- retain bounded raw attempts, advisories, and material assessments in the report
- keep assets, outbound requests, database ratios, unknown metrics, schema/environment failures, and operational failures immediate

## Motivation

Post-merge integration at 17db600 repeated only one runtime crossing: Code read latency measured 53.171 ms and 57.571 ms against a 51 ms alert line. No deterministic invariant or asset budget failed. This change records that crossing as advisory while still failing a material 67/70 ms regression for the same metric.

## Verification

- focused release benchmark contract: 20/20
- strict Ajv 2020 schema compilation and v1 compatibility
- all 90 exact runtime keys and category boundaries covered
- full production build plus assets-only benchmark passed
- git diff --check
- independent P0/P1 review clear

## Boundaries

- target: integration/human-team-memory-v1
- version remains 0.7.2
- no numeric budget, product, package-export, release, deployment, tag, publish, or main-branch changes
