### PR TITLE
fix(grounding): commit the body hash to Markdown, and make the reads that use it agree

### DIFF
--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -14,7 +14,7 @@ edges:
     condition: when setting up the dev environment or running the project for the first time
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-08-29
+last_updated: 2026-09-01
 ---
 
 # Session Bootstrap
@@ -49,6 +49,13 @@ Then read this file fully before doing anything else in this session.
   rewriting schema-v1 history.
 - Versioned graph snapshot provenance and read-only freshness inspection gate
   grounding in check, doctor, and dashboard flows without implicit graph sync.
+- Grounding carries its change signal in Markdown: `grounds_to[].bodyHash` is
+  optional and additive, written by the capture and MOVED-repair passes from the
+  graph's own hash, and backfilled for existing scaffolds on the next capture.
+  The `_mex_grounded_source` row remains as a cache of that canonical value. The
+  drift checker prefers the committed hash, falls back to the cache for a
+  grounding authored before the field, and resolves the `grounds_to` key path so
+  migrated scaffolds under `mex.grounds_to` are checked rather than skipped.
 - Explicit graph status, refresh, and isolated rebuild/recovery commands preserve
   the last trustworthy index behind one cross-process maintenance lease.
 - Targeted graph get/query/impact consumers use one provenance-bound immutable
@@ -149,6 +156,10 @@ Then read this file fully before doing anything else in this session.
   appear only when a stable status observation makes the requested operation
   safe; migration-required or unstable Wiki observations never fabricate a
   repair action.
+- The Wiki CLI's `serviceOptions` carries no code graph, so `wiki validate`
+  cannot resolve a grounding and `wiki migrate`'s body-hash backfill never runs.
+  Both degrade silently rather than failing; the validate notice now reports
+  that the pass had no graph instead of asserting the checkout has none.
 
 ## Routing Table
 

--- a/.mex/patterns/INDEX.md
+++ b/.mex/patterns/INDEX.md
@@ -10,3 +10,4 @@ Lookup table for project-specific pattern files.
 | [`release-performance-gate.md`](release-performance-gate.md) | Changing, calibrating, or diagnosing the pinned release resource budgets |
 | [`secure-local-project-hub.md`](secure-local-project-hub.md) | Adding a loopback Hub route, API contract, browser session, or explicit local job |
 | [`safe-graph-snapshot-evolution.md`](safe-graph-snapshot-evolution.md) | Changing graph indexing, freshness inspection, or recovery without publishing mixed or unsafe snapshots |
+| [`durable-change-signal.md`](durable-change-signal.md) | Adding or changing a drift baseline, or any value that answers "has this changed?" |

--- a/.mex/patterns/durable-change-signal.md
+++ b/.mex/patterns/durable-change-signal.md
@@ -1,0 +1,95 @@
+---
+name: durable-change-signal
+description: Keep the value that answers "has this changed?" in Git, not in a disposable index, and make every reader consult the same key path.
+triggers:
+  - "drift baseline"
+  - "body hash"
+  - "grounding change signal"
+  - "disposable index"
+  - "grounds_to key path"
+edges:
+  - target: "../context/architecture.md"
+    condition: "when changing what a drift check compares against"
+  - target: "safe-graph-snapshot-evolution.md"
+    condition: "when the value also lives in the graph database"
+  - target: "../context/conventions.md"
+    condition: "when verifying the change"
+grounds_to: []
+last_updated: 2026-09-01
+---
+
+# Durable Change Signal
+
+## Context
+
+`.mex/graph.db` and `.mex/wiki.db` are derived, gitignored, and disposable by
+invariant: `mex graph rebuild` is offered in the Hub as a routine repair, and a
+teammate who clones never receives either file. Anything held only there is gone
+the moment a user takes the repair the product recommends.
+
+That is correct for an index and wrong for a baseline. A drift check answers
+"has this code changed since we wrote this down?", and the value it compares
+against is a claim made at a point in time. Re-derive it during a rebuild and
+you compare current against current: the drift silently disappears, nothing
+warns, and the scaffold keeps reporting clean.
+
+Two distinct kinds of value, and the difference decides where each one lives:
+
+- **Identity** — the fingerprint. Answers "where did this symbol go?" It is
+  deliberately insensitive to an edited constant or a renamed local. Never use
+  it to answer "did this change?"
+- **Change** — the body hash. Answers "is this still the code we described?"
+  Canonical because it is committed in Markdown and reviewable in a pull
+  request.
+
+## Steps
+
+1. Decide which kind of value you are adding. If it is a claim about a moment
+   in time, it belongs in Markdown. If it is a re-derivable lookup, the index is
+   the right home.
+2. Add the field to the shared type in `src/types.ts` as **optional**. Every
+   scaffold in the world lacks it, and a required field turns each of them into
+   a parse error. Mirror the wiki lane's key name and placement so both writers
+   produce one shape rather than two conventions.
+3. Populate it at every write site, from a value the graph produced. Never let a
+   caller supply one — a hash an agent can invent is not evidence.
+4. **Change the readers in the same commit.** A field nothing reads is inert,
+   and a fix that ships only the write half looks complete and does nothing.
+   Grep for every consumer of the old source of truth before you start.
+5. Read the key through `extractGroundings`, never `frontmatter.grounds_to`
+   directly. A pre-wiki scaffold keeps the key at the root; once `wiki migrate`
+   adopts the file as an entity, section 13.4 moves it under the `mex` map.
+   Reading the root key directly finds nothing on a migrated scaffold, the loop
+   runs zero times, and the check reports clean. Writer and reader must resolve
+   the path the same way or they will disagree silently.
+6. Keep the index copy and say in a comment that it is now a **cache of a
+   canonical value**, not a second store of a fact. Otherwise the next reader
+   deletes it as a duplicate — and it often carries something Markdown has no
+   business holding, such as the body text a drift review needs for a diff.
+7. Backfill, never re-baseline. Write the value when it is absent, or when an
+   authorized caller is deliberately re-pointing the record at current code. A
+   value that merely **differs** is the finding; overwriting it erases the
+   evidence and reports fresh on the next run.
+
+## Verify
+
+- Delete the index, rebuild it, then edit the grounded code. The check must
+  still fire. This is the whole point, and it is the only test that proves it.
+- A record written before the field existed must still parse, still validate,
+  still warn, and still behave exactly as it did against a live index.
+- Confirm the new tests actually fail on the pre-fix tree. Restore the source
+  files from the base commit and re-run; a test that passes both ways is a
+  backward-compatibility pin, not a proof of the fix, and should be labelled as
+  one.
+- Run the check against a real migrated scaffold, not only a synthetic fixture.
+  Both key paths and both populations only appear there.
+
+## Gotchas
+
+- A command that reports success is not evidence it wrote anything. A capture
+  pass printed "16 captured, 0 skipped" while writing nothing durable.
+- `serviceOptions` in the wiki CLI carries no code graph, so `wiki validate` and
+  `wiki migrate` degrade silently rather than failing. Check what a command
+  actually receives before believing a message about what it found.
+- A diagnostic that names a cause nobody checked costs more than no diagnostic.
+  If a flag has two causes, carry the discriminator rather than asserting one.

--- a/src/drift/checkers/grounding.ts
+++ b/src/drift/checkers/grounding.ts
@@ -33,7 +33,21 @@ export function makeGroundingChecker(
       const current = graph.getNode(grounding.node);
       const baselineSource = capabilities.getGroundedSource?.(scaffoldFile, grounding.node) ?? null;
       if (current) {
-        if (baselineSource && current.bodyHash !== baselineSource.bodyHash) {
+        // **The committed hash wins, and the cached one is only a fallback.**
+        //
+        // `_mex_grounded_source` lives in `.mex/graph.db`, which is gitignored
+        // and disposable by invariant — `mex graph rebuild` is offered as a
+        // routine repair. Reading the baseline only from there meant a rebuild
+        // silently ended drift detection for every grounding in the scaffold:
+        // `baselineSource` came back null, this branch reported nothing, and
+        // the grounding went on looking healthy forever. A teammate who cloned
+        // never had a baseline in the first place.
+        //
+        // So prefer `grounding.bodyHash`, which is in Git. The cache still
+        // answers for a grounding authored before that field existed, which is
+        // exactly the pre-existing behaviour and no worse than it was.
+        const baselineBodyHash = grounding.bodyHash ?? baselineSource?.bodyHash;
+        if (baselineBodyHash !== undefined && current.bodyHash !== baselineBodyHash) {
           issues.push(issue("GROUNDING_DRIFT", "warning", source,
             `Grounded node body changed: ${grounding.node}`));
         }

--- a/src/drift/checkers/grounding.ts
+++ b/src/drift/checkers/grounding.ts
@@ -5,7 +5,7 @@ import { deserializeFingerprint, serializeFingerprint } from "../../graph/finger
 import type { GraphEngine } from "../../graph/engine.js";
 import type { GroundedSource, GroundingChecker } from "../../graph/grounding.js";
 import type { Fingerprint, Reconciler } from "../../graph/reconcile.js";
-import { findMexAnchors } from "../../markdown.js";
+import { extractGroundings, findMexAnchors } from "../../markdown.js";
 
 interface GroundingReconcilerCapabilities {
   getGroundedSource?(scaffoldFile: string, nodeId: string): GroundedSource | null;
@@ -28,7 +28,27 @@ export function makeGroundingChecker(
     const scaffoldFile = relative(projectRoot, filePath).replaceAll("\\", "/");
     const issues: DriftIssue[] = [];
 
-    for (const grounding of frontmatter?.grounds_to ?? []) {
+    let content: string | null;
+    try { content = readFileSync(filePath, "utf-8"); } catch { content = null; }
+
+    // **Read through `extractGroundings`, which knows both key paths.**
+    //
+    // A pre-wiki scaffold keeps `grounds_to` at the frontmatter root. Once
+    // `wiki migrate` adopts a file as an entity, §13.4 moves the key under the
+    // `mex` map — and reading the root key directly, as this did, then finds
+    // nothing. The loop ran zero times and the checker reported no grounding
+    // issues at all: not stale, not missing, not gone. Measured on a migrated
+    // scaffold with a fresh graph and four groundings in one file, `mex check`
+    // returned zero `GROUNDING_*` codes of any kind.
+    //
+    // That is silent, and it is worse than a false positive, because a
+    // scaffold that checks clean is one nobody looks at. `extractGroundings`
+    // resolves the key path the same way the writer does, so the two ends
+    // agree; the frontmatter value is the fallback for a file that cannot be
+    // re-read here, which is the only case the old path still covers.
+    const declared = content === null ? (frontmatter?.grounds_to ?? []) : extractGroundings(content);
+
+    for (const grounding of declared) {
       if (!isGrounding(grounding)) continue;
       const current = graph.getNode(grounding.node);
       const baselineSource = capabilities.getGroundedSource?.(scaffoldFile, grounding.node) ?? null;
@@ -71,8 +91,7 @@ export function makeGroundingChecker(
       }
     }
 
-    let content: string;
-    try { content = readFileSync(filePath, "utf-8"); } catch { return issues; }
+    if (content === null) return issues;
     for (const anchor of findMexAnchors(content)) {
       if (graph.getNode(anchor.nodeId)) continue;
       const baselineSource = capabilities.getGroundedSource?.(scaffoldFile, anchor.nodeId) ?? null;

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -24,7 +24,7 @@ import {
   type GroundingRuntime,
   type ReadOnlyGroundingRuntimeResult,
 } from "../graph/runtime.js";
-import { findMexAnchors } from "../markdown.js";
+import { extractGroundings, findMexAnchors } from "../markdown.js";
 import type { GraphStatus } from "../team/contracts/graph.js";
 
 let graphUpgradeNudgeShown = false;
@@ -109,10 +109,15 @@ export async function runDriftCheckWithGraphStatus(
   const pendingGroundingIssues: DriftIssue[] = [];
   const pendingGroundingIssueCounts: Array<[string, number]> = [];
   const usesInjectedGroundingRuntime = opts.groundingRuntimeLoader !== undefined;
+  // Read the key the same way the checker and the writer do. Asking only for a
+  // root `grounds_to` missed every migrated scaffold, where §13.4 has moved the
+  // key under the `mex` map — so `groundingRelevant` came out false, the
+  // grounding runtime was never opened, and the checker that would have found
+  // the groundings was never constructed. `extractGroundings` resolves the path.
   const hasGroundings = scaffoldFiles.some((filePath) => {
-    const groundsTo = parseFrontmatter(filePath)?.grounds_to;
-    if (Array.isArray(groundsTo) && groundsTo.length > 0) return true;
-    try { return findMexAnchors(readFileSync(filePath, "utf-8")).length > 0; } catch { return false; }
+    let content: string;
+    try { content = readFileSync(filePath, "utf-8"); } catch { return false; }
+    return extractGroundings(content).length > 0 || findMexAnchors(content).length > 0;
   });
   const needsGroundingMigration = !hasGroundings && scaffoldFiles.some(isPopulatedGroundingCandidate);
   const groundingRelevant = hasGroundings || needsGroundingMigration;

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -261,6 +261,22 @@ export function findChangedSourceFiles(projectRoot: string, db: SqliteDatabase):
   return [...new Set(changed)].sort();
 }
 
+/**
+ * Move a grounding's body hash onto the node it was just rebound to.
+ *
+ * Only called on a confirmed rebind, where identity has already been
+ * re-established by fingerprint and the entity now points at a different node.
+ * The old hash describes a symbol this grounding no longer names, so carrying
+ * it forward would report drift on every rename — a symbol's name is part of
+ * its body. Dropping the key instead would be worse: the grounding would fall
+ * back to the structural comparator and stop detecting content drift for good.
+ *
+ * A node the graph cannot produce a hash for leaves the grounding as it was.
+ */
+function rebindBodyHash(grounding: Grounding, bodyHash: string | null): void {
+  if (bodyHash !== null) grounding.bodyHash = bodyHash;
+}
+
 /** Persist only high-confidence MOVED repairs. AMBIGUOUS/GONE remain for the agent. */
 export function persistMovedGroundings(
   config: MexConfig,
@@ -281,7 +297,7 @@ export function persistMovedGroundings(
         grounding.node = aliasedNode.id;
         const fingerprint = runtime.reconciler.getFingerprint(aliasedNode.id);
         if (fingerprint) grounding.fingerprint = serializeFingerprint(fingerprint);
-        saveCurrentBaseline(config, scaffoldFile, grounding.node, grounding.fingerprint, runtime);
+        rebindBodyHash(grounding, saveCurrentBaseline(config, scaffoldFile, grounding.node, grounding.fingerprint, runtime));
         runtime.fingerprints.deleteGroundedSource(scaffoldFile, oldId);
         dirty = true;
         moved += 1;
@@ -297,7 +313,7 @@ export function persistMovedGroundings(
       grounding.node = resolution.nodeId;
       const fingerprint = runtime.reconciler.getFingerprint(resolution.nodeId);
       if (fingerprint) grounding.fingerprint = serializeFingerprint(fingerprint);
-      saveCurrentBaseline(config, scaffoldFile, grounding.node, grounding.fingerprint, runtime);
+      rebindBodyHash(grounding, saveCurrentBaseline(config, scaffoldFile, grounding.node, grounding.fingerprint, runtime));
       runtime.fingerprints.deleteGroundedSource(scaffoldFile, oldId);
       dirty = true;
       moved += 1;
@@ -427,6 +443,7 @@ export function refreshGroundingBaselines(
     ]);
     for (const nodeId of nodeIds) {
       const grounding = groundingByNode.get(nodeId);
+      let rebaselined = false;
       const fingerprint = runtime.reconciler.getFingerprint(nodeId);
       if (!fingerprint || !runtime.graph.getNode(nodeId)) {
         skipped += 1;
@@ -441,13 +458,34 @@ export function refreshGroundingBaselines(
           continue;
         }
         grounding.fingerprint = serialized;
+        rebaselined = true;
         dirty = true;
       }
-      if (saveCurrentBaseline(config, scaffoldFile, nodeId, serialized, runtime)) {
-        captured += 1;
-      } else {
+      const bodyHash = saveCurrentBaseline(config, scaffoldFile, nodeId, serialized, runtime);
+      if (bodyHash === null) {
         skipped += 1;
         options.warn?.(`Skipped grounding baseline for non-body node ${nodeId} in ${scaffoldFile}.`);
+        continue;
+      }
+      captured += 1;
+
+      // Commit the change signal alongside the identity signal, so it survives
+      // a `graph rebuild` and travels to a teammate who clones. Two cases only:
+      //
+      //  - **backfill**, when Markdown carries no hash at all. This asserts
+      //    nothing new — the `_mex_grounded_source` row written a line above
+      //    already records exactly this value, from exactly this moment. It
+      //    only makes it durable.
+      //  - **re-baseline**, when the fingerprint was just updated under an
+      //    explicit `updateFingerprints`. The grounding is being re-pointed at
+      //    the current code by an authorized caller, so both signals move.
+      //
+      // A hash that is merely *different* is left alone, deliberately. That
+      // difference is drift — it is the finding — and quietly overwriting it
+      // here would erase the evidence and report `fresh` on the next run.
+      if (grounding && (grounding.bodyHash === undefined || rebaselined) && grounding.bodyHash !== bodyHash) {
+        grounding.bodyHash = bodyHash;
+        dirty = true;
       }
     }
     if (dirty) writeFileSync(filePath, writeGroundings(content, groundings), "utf-8");
@@ -473,15 +511,30 @@ export function groundingPromptContext(
   };
 }
 
+/**
+ * Cache the node's current body beside its hash, and hand the hash back.
+ *
+ * The row it writes into `_mex_grounded_source` is a **cache of a canonical
+ * value, not a second store of a fact.** `.mex/graph.db` is gitignored and
+ * disposable by invariant — `mex graph rebuild` is offered as a routine repair
+ * — so anything held only here is gone on the next rebuild and never reaches a
+ * teammate who clones. The durable copy of `bodyHash` is the one the callers
+ * write into the Markdown grounding, which is why this returns it rather than a
+ * bare boolean. Keep the row: it also carries the body *text*, which drift
+ * review needs for a diff and Markdown has no business holding.
+ *
+ * Returns the body hash on success, or null for a node the graph does not hold
+ * or that has no body — the same condition the boolean used to report.
+ */
 function saveCurrentBaseline(
   config: MexConfig,
   scaffoldFile: string,
   nodeId: string,
   fingerprint: string,
   runtime: GroundingRuntime,
-): boolean {
+): string | null {
   const node = runtime.graph.getNode(nodeId);
-  if (!node?.bodyHash) return false;
+  if (!node?.bodyHash) return null;
   const source: GroundedSource = {
     scaffoldFile,
     nodeId: node.id,
@@ -490,7 +543,7 @@ function saveCurrentBaseline(
     fingerprint,
   };
   runtime.fingerprints.saveGroundedSource(source);
-  return true;
+  return node.bodyHash;
 }
 
 function readNodeBody(root: string, filePath: string, startLine: number, endLine: number): string {

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -443,7 +443,6 @@ export function refreshGroundingBaselines(
     ]);
     for (const nodeId of nodeIds) {
       const grounding = groundingByNode.get(nodeId);
-      let rebaselined = false;
       const fingerprint = runtime.reconciler.getFingerprint(nodeId);
       if (!fingerprint || !runtime.graph.getNode(nodeId)) {
         skipped += 1;
@@ -458,7 +457,6 @@ export function refreshGroundingBaselines(
           continue;
         }
         grounding.fingerprint = serialized;
-        rebaselined = true;
         dirty = true;
       }
       const bodyHash = saveCurrentBaseline(config, scaffoldFile, nodeId, serialized, runtime);
@@ -476,14 +474,26 @@ export function refreshGroundingBaselines(
       //    nothing new — the `_mex_grounded_source` row written a line above
       //    already records exactly this value, from exactly this moment. It
       //    only makes it durable.
-      //  - **re-baseline**, when the fingerprint was just updated under an
-      //    explicit `updateFingerprints`. The grounding is being re-pointed at
-      //    the current code by an authorized caller, so both signals move.
+      //  - **re-baseline**, when the caller has not forbidden updates. That is
+      //    the post-authoring routine `mex sync` runs after an agent repairs
+      //    the prose: the entity now describes the current code, so the
+      //    baseline has to move with it or drift never clears.
       //
-      // A hash that is merely *different* is left alone, deliberately. That
-      // difference is drift — it is the finding — and quietly overwriting it
-      // here would erase the evidence and report `fresh` on the next run.
-      if (grounding && (grounding.bodyHash === undefined || rebaselined) && grounding.bodyHash !== bodyHash) {
+      // `updateFingerprints === false` — what `mex ground` and setup pass — is
+      // the read-only posture, and there a hash that merely *differs* is left
+      // alone. That difference is drift, it is the finding, and overwriting it
+      // would erase the evidence and report `fresh` on the next run.
+      //
+      // **The authorization is the caller's flag, never whether the
+      // fingerprint moved.** Gating this on a fingerprint change was the first
+      // attempt and it was wrong in the one case that matters: editing a
+      // constant changes the body and leaves the fingerprint identical, by
+      // construction, which is the entire reason a body hash exists. The
+      // re-baseline then never fired and drift was permanent. Using the
+      // identity signal to decide a change question is the coupling this field
+      // exists to break — including here, in the writer.
+      const mayRebaseline = options.updateFingerprints !== false;
+      if (grounding && (grounding.bodyHash === undefined || mayRebaseline) && grounding.bodyHash !== bodyHash) {
         grounding.bodyHash = bodyHash;
         dirty = true;
       }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -65,6 +65,17 @@ export function extractGroundings(content: string): Grounding[] {
   return isGroundingArray(value) ? value : [];
 }
 
+/**
+ * Accept a `grounds_to` value.
+ *
+ * The check names the two required keys and deliberately does not enumerate the
+ * optional ones. That is what lets `bodyHash` — and the wiki lane's `file`,
+ * `commit`, `verifiedAt` and `reason` — survive a read/write cycle: the parsed
+ * entries are handed to {@link writeGroundings} unchanged, so every key the
+ * author put in the file is rendered back out. Tightening this into an
+ * exact-shape check would silently strip whichever keys this lane's type had
+ * not yet heard of, which is the failure it exists to avoid.
+ */
 export function isGroundingArray(value: unknown): value is Grounding[] {
   return Array.isArray(value) && value.every((entry) => {
     if (!entry || typeof entry !== "object") return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,13 +210,36 @@ export interface DriftReport {
  * grounds_to:
  *   - node: "function:a3f8...c21"
  *     fingerprint: "mh:64:9f2a..."
+ *     bodyHash: "sha256:7c1d..."
  * ```
  */
 export interface Grounding {
   /** The grounded node's Tier-1 id, `${kind}:sha256(filePath:kind:name)[:32]`. */
   node: string;
-  /** Serialized Tier-2 fingerprint (`mh:<K>:<hex>`) captured when grounded. */
+  /**
+   * Serialized Tier-2 fingerprint (`mh:<K>:<hex>`) captured when grounded.
+   *
+   * An **identity** signal, not a change signal: it is what finds the symbol
+   * again after it moves. It is deliberately insensitive to an edited constant
+   * or a renamed local, so it must never be asked "did this change?".
+   */
   fingerprint: string;
+  /**
+   * The grounded node's body hash when the baseline was captured.
+   *
+   * **The change signal, and canonical because it is committed in Markdown.**
+   * The same value is cached in `_mex_grounded_source` inside `.mex/graph.db`,
+   * but that index is gitignored and disposable by invariant — a rebuild
+   * re-captures it from the current code, so comparing against the cache
+   * compares current against current and drift disappears. Only the copy in
+   * Git survives a rebuild and reaches a teammate who clones.
+   *
+   * Optional, and it has to be: every grounding written before this field
+   * existed lacks it, and requiring it would turn each of those scaffolds into
+   * a parse error. A grounding without it still resolves, through the coarser
+   * structural comparator, and `mex sync` backfills it on the next capture.
+   */
+  bodyHash?: string;
 }
 
 export interface ScaffoldFrontmatter {

--- a/src/wiki/cli/__tests__/commands.test.ts
+++ b/src/wiki/cli/__tests__/commands.test.ts
@@ -417,6 +417,45 @@ describe("bounded output", () => {
   });
 });
 
+describe("the unverified-grounding notice", () => {
+  const GROUNDED = `<!-- mex:entity
+id: mx_01ARZ3NDEKTSV4RRFFQ69G5FAG
+type: decision
+status: promoted
+revision: 1
+grounds_to:
+  - node: "function:deadbeefdeadbeef"
+    fingerprint: "mh:64:aabbccdd"
+-->
+## Grounded
+
+Body.
+`;
+
+  it("does not blame the checkout's code graph for a pass that was never given one", () => {
+    // `runValidate` builds its options from `serviceOptions`, which carries no
+    // graph, so this is the branch every CLI run takes. The old wording
+    // asserted there was no graph in the checkout — a fact this command does
+    // not check, and one that was false on the scaffold that surfaced it.
+    const local = harness(true, { "context/grounded.md": GROUNDED });
+    runValidate(local.io, {});
+    const notice = local.lines.find((line) => line.includes("grounding checks did not run"));
+    expect(notice).toBeDefined();
+    expect(notice).toContain("this pass was given no code graph");
+    expect(notice).not.toContain("no code graph in this checkout");
+  });
+
+  it("carries the discriminator in JSON, so a CI caller can tell the two causes apart", () => {
+    const local = harness(true, { "context/grounded.md": GROUNDED });
+    runValidate(local.io, { json: true });
+    const parsed = JSON.parse(local.lines[0]!) as {
+      data: { groundingsUnverified: boolean; codeGraphAvailable: boolean };
+    };
+    expect(parsed.data.groundingsUnverified).toBe(true);
+    expect(parsed.data.codeGraphAvailable).toBe(false);
+  });
+});
+
 describe("query filters", () => {
   it("mean the same thing wherever they apply", () => {
     expect(filtersFrom({ limit: "25" }).limit).toBe(25);

--- a/src/wiki/cli/commands.ts
+++ b/src/wiki/cli/commands.ts
@@ -270,7 +270,26 @@ export function runValidate(io: CommandIo, flags: CommandFlags): void {
     if (data.groundingsUnverified) {
       // Not a diagnostic: it says how much was checked, not that anything is
       // wrong, and a CI run needs to tell a clean report from an unread one.
-      io.write(chalk.dim("grounding checks did not run — no code graph in this checkout"));
+      //
+      // The flag has two causes and this line used to assert the first of them
+      // unconditionally, so a reader was sent to inspect a code graph nobody
+      // had looked at. Two corrections, and the second is the one that was
+      // costing something:
+      //
+      //  - When a graph *was* supplied and still produced no verdict, the fault
+      //    is in what the groundings committed, and the reader belongs in the
+      //    scaffold rather than in `mex graph`.
+      //  - When none was supplied, "no code graph in this checkout" is a claim
+      //    about the repository that this command never checked. `wiki
+      //    validate` does not load one — `serviceOptions` does not carry it —
+      //    so on the CLI this is always the branch taken, and it read as a
+      //    diagnosis of a fresh 7 MB `graph.db` sitting right there. Say what
+      //    was actually true of the pass, and name the command that does check.
+      io.write(chalk.dim(
+        data.codeGraphAvailable
+          ? "grounding checks did not run — the code graph is present, but no grounding could be compared against it"
+          : "grounding checks did not run — this pass was given no code graph; `mex check` is the grounding check",
+      ));
     }
   });
 }

--- a/src/wiki/service/validate.ts
+++ b/src/wiki/service/validate.ts
@@ -16,14 +16,19 @@ export interface ValidateData {
   /** True when a bound stopped the diagnostic list — data, never a diagnostic. */
   truncated: boolean;
   /**
-   * True when no code graph was available, so grounding checks degraded.
+   * True when there were groundings and not one of them produced a verdict.
    *
    * Reported in `data` rather than as a diagnostic because it is not a problem
    * with the scaffold: it is a statement about how much of the scaffold was
    * actually checked, and a caller in CI needs to be able to tell a clean run
    * from an unread one.
+   *
+   * Two causes, so it is never enough on its own: read it with
+   * {@link ValidateData.codeGraphAvailable}.
    */
   groundingsUnverified: boolean;
+  /** Whether a code graph was supplied — the discriminator for the flag above. */
+  codeGraphAvailable: boolean;
 }
 
 export function wikiValidate(options: ValidateOptions): ServiceResult<ValidateData> {
@@ -35,6 +40,7 @@ export function wikiValidate(options: ValidateOptions): ServiceResult<ValidateDa
       counts: report.counts,
       truncated: report.truncated,
       groundingsUnverified: report.groundingsUnverified,
+      codeGraphAvailable: report.codeGraphAvailable,
     },
     diagnostics: report.diagnostics,
   };

--- a/src/wiki/validation/__tests__/validate.test.ts
+++ b/src/wiki/validation/__tests__/validate.test.ts
@@ -421,6 +421,22 @@ Body with an anchor: [the code](mex://function:0123456789abcdef).
     expect(blind?.severity).toBe("warning");
   });
 
+  it("tells that grounding what is actually missing, not what the shared code's remediation says", () => {
+    // `MALFORMED_GROUNDING` is one code over six problems, and its registry
+    // remediation is written for a missing node id or fingerprint. This
+    // grounding has both. Handing a reader that text sends them to look for a
+    // field already in their file — measured on a real scaffold where all
+    // sixteen warnings carried advice that applied to none of them.
+    const report = validateScaffold({ scaffoldRoot: scaffold({ "context/g.md": grounded }) });
+    const blind = report.diagnostics.find(
+      (entry) => entry.code === "MALFORMED_GROUNDING" && entry.message.includes("body hash"),
+    );
+    expect(blind?.remediation).not.toContain("needs both a code-graph node id and a fingerprint");
+    expect(blind?.remediation).toContain("body hash");
+    // And it names something the reader can actually run.
+    expect(blind?.remediation).toMatch(/mex graph ground|mex sync/);
+  });
+
   it("reports a node the graph no longer has", () => {
     const graph: GroundingGraph = {
       getNode: () => null,

--- a/src/wiki/validation/__tests__/validate.test.ts
+++ b/src/wiki/validation/__tests__/validate.test.ts
@@ -387,9 +387,30 @@ Body with an anchor: [the code](mex://function:0123456789abcdef).
   it("degrades to unverified with no code graph, rather than failing", () => {
     const report = validateScaffold({ scaffoldRoot: scaffold({ "context/g.md": grounded }) });
     expect(report.groundingsUnverified).toBe(true);
+    expect(report.codeGraphAvailable).toBe(false);
     const found = report.diagnostics.map((entry) => entry.code);
     expect(found).not.toContain("GROUNDING_MISSING");
     expect(found).not.toContain("GROUNDING_UNRESOLVED");
+  });
+
+  it("separates the two causes of unverified, because they send a reader to different places", () => {
+    // `groundingsUnverified` means "nothing produced a verdict", and there are
+    // two ways to get there. A graph that is present and fresh, holding the
+    // node but no fingerprint to compare the committed one against, reaches it
+    // just as a missing graph does — and telling that reader to go and look at
+    // their code graph sends them to inspect something with nothing wrong.
+    const presentButUncomparable: GroundingGraph = {
+      getNode: () => ({ id: "function:deadbeefdeadbeef", bodyHash: null, filePath: "src/a.ts", startLine: 1, endLine: 2 }),
+      getFingerprint: () => null,
+      reconcile: () => null,
+      getBaselineSource: () => null,
+    } as unknown as GroundingGraph;
+    const report = validateScaffold({
+      scaffoldRoot: scaffold({ "context/g.md": grounded }),
+      graph: presentButUncomparable,
+    });
+    expect(report.groundingsUnverified).toBe(true);
+    expect(report.codeGraphAvailable).toBe(true);
   });
 
   it("reports a grounding with no body hash, which is otherwise blind to drift", () => {

--- a/src/wiki/validation/validate.ts
+++ b/src/wiki/validation/validate.ts
@@ -110,12 +110,28 @@ export interface ValidationReport {
   /** True when a bound stopped the diagnostic list. Data, never a diagnostic. */
   truncated: boolean;
   /**
-   * True when no code graph was available, so every grounding check degraded.
+   * True when there were groundings and not one of them produced a verdict.
    *
    * Distinct from "every grounding is fine": the caller has to be able to tell
    * a clean bill of health from an unread one.
+   *
+   * **It has two causes, and this flag does not say which.** Either no code
+   * graph was available, or the graph was there and nothing could be compared
+   * against it — an undecodable committed fingerprint, a node the graph holds
+   * no fingerprint for, a rebind onto a node it cannot produce. Pair it with
+   * {@link codeGraphAvailable} to tell them apart before telling a user where
+   * to look.
    */
   groundingsUnverified: boolean;
+  /**
+   * Whether a code graph was supplied for this pass.
+   *
+   * The discriminator for {@link groundingsUnverified}, and it has to be
+   * carried rather than inferred: the grounding diagnostics that would hint at
+   * it are subject to the same bound as every other diagnostic, so a truncated
+   * report could lose the evidence and leave a reader guessing.
+   */
+  codeGraphAvailable: boolean;
 }
 
 /** Commit shape: a hex object name, abbreviated or full. */
@@ -186,6 +202,7 @@ export function validateScaffold(options: ValidateOptions): ValidationReport {
     counts,
     truncated: ordered.length > kept.length,
     groundingsUnverified: groundingResults.unverified,
+    codeGraphAvailable: graph !== null,
   };
 }
 

--- a/src/wiki/validation/validate.ts
+++ b/src/wiki/validation/validate.ts
@@ -456,7 +456,21 @@ function groundingChecks(
           diagnostic(
             "MALFORMED_GROUNDING",
             `The grounding on ${entity.id} for ${grounding.node} carries no body hash, so drift in the grounded code cannot be detected — only a change to its structure.`,
-            { file, entityId: entity.id, path, severity: "warning" },
+            {
+              file,
+              entityId: entity.id,
+              path,
+              severity: "warning",
+              // `MALFORMED_GROUNDING` covers six different problems and its
+              // registry remediation is written for the first two — a missing
+              // node id or fingerprint. This case has both, and telling a
+              // reader to supply them sends them looking for a field that is
+              // already in the file. Say what is actually absent and what
+              // writes it. Reported on a real scaffold where all sixteen
+              // warnings carried advice that did not apply to any of them.
+              remediation:
+                "The node id and fingerprint are present; only the baseline body hash is missing, and nothing you can hand-write supplies it. A grounding capture records it from the graph — `mex graph ground` on an existing scaffold, or `mex sync`. Until then drift is compared structurally.",
+            },
           ),
         );
       }

--- a/test/graph-grounding-body-hash.test.ts
+++ b/test/graph-grounding-body-hash.test.ts
@@ -79,10 +79,20 @@ async function authorGrounding(
   }
 }
 
+/**
+ * Capture in the posture `mex ground` and setup use.
+ *
+ * `captureGroundingBaselines` normalizes a missing `updateFingerprints` to
+ * `false` before it reaches `refreshGroundingBaselines`, so passing it
+ * explicitly is what makes these tests exercise the real command path rather
+ * than the looser default a direct caller gets. It matters: `false` is the
+ * read-only posture that must never overwrite a hash that has drifted, while
+ * `mex sync` passes `true` after an agent pass and re-baselines deliberately.
+ */
 async function captureBaselines(config: MexConfig, scaffold: string): Promise<void> {
   const runtime = await loadGroundingRuntime(config);
   try {
-    refreshGroundingBaselines(config, [scaffold], runtime!);
+    refreshGroundingBaselines(config, [scaffold], runtime!, { updateFingerprints: false });
   } finally {
     runtime!.close();
   }

--- a/test/graph-grounding-body-hash.test.ts
+++ b/test/graph-grounding-body-hash.test.ts
@@ -1,0 +1,190 @@
+/**
+ * The grounding change signal has to survive `mex graph rebuild`.
+ *
+ * `.mex/graph.db` is gitignored and disposable by invariant, and the product
+ * offers a rebuild as a routine repair. A drift baseline held only in that file
+ * is therefore gone whenever a user takes the repair the product recommends,
+ * and it never existed at all for a teammate who cloned. These tests delete the
+ * index and rebuild it — the exact thing that used to destroy the baseline —
+ * and assert that drift is still detected afterwards.
+ */
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MexConfig } from "../src/types.js";
+import { runDriftCheckWithGraphStatus } from "../src/drift/index.js";
+import { createGraphEngine } from "../src/graph/engine-impl.js";
+import { loadGroundingRuntime, refreshGroundingBaselines } from "../src/graph/runtime.js";
+import { extractGroundings, writeGroundings } from "../src/markdown.js";
+import { serializeFingerprint } from "../src/graph/fingerprint.js";
+
+const roots: string[] = [];
+
+/** The body an agent grounds to, and the one-constant edit that drifts it. */
+const ORIGINAL = `export function calculateOrderTotal(items: number[]): number {
+  const subtotal = items.reduce((sum, item) => sum + item, 0);
+  const tax = subtotal * 0.18;
+  const shipping = subtotal > 1000 ? 0 : 75;
+  const discount = items.length > 5 ? subtotal * 0.05 : 0;
+  return subtotal + tax + shipping - discount;
+}
+`;
+const EDITED = ORIGINAL.replace("subtotal * 0.18", "subtotal * 0.21");
+
+function fixture(): { root: string; source: string; scaffold: string; config: MexConfig } {
+  const root = mkdtempSync(join(tmpdir(), "mex-grounding-body-hash-"));
+  roots.push(root);
+  const source = join(root, "src", "service.ts");
+  const scaffold = join(root, ".mex", "context", "architecture.md");
+  mkdirSync(join(root, "src"), { recursive: true });
+  mkdirSync(join(root, ".mex", "context"), { recursive: true });
+  writeFileSync(join(root, ".mex", "ROUTER.md"), "# Router\n");
+  writeFileSync(scaffold, "---\nname: architecture\n---\n\n# Architecture\n");
+  writeFileSync(source, ORIGINAL);
+  return { root, source, scaffold, config: { projectRoot: root, scaffoldRoot: join(root, ".mex"), aiTools: [] } };
+}
+
+async function buildGraph(root: string): Promise<void> {
+  const engine = createGraphEngine({ rootDir: root });
+  await engine.build();
+  engine.close();
+}
+
+/**
+ * Author a grounding the way `mex ground` does: an agent copies the node id and
+ * the fingerprint out of graph output and writes nothing else. There is no body
+ * hash at this point, because the agent was never given one — which is why the
+ * capture pass below is the thing that has to supply it.
+ */
+async function authorGrounding(
+  config: MexConfig,
+  scaffold: string,
+  symbol: string,
+  extra: { bodyHash?: string } = {},
+): Promise<string> {
+  const runtime = await loadGroundingRuntime(config);
+  try {
+    const node = runtime!.graph.searchNodes(symbol).find((entry) => entry.kind === "function")!;
+    const fingerprint = runtime!.reconciler.getFingerprint(node.id)!;
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{
+      node: node.id,
+      fingerprint: serializeFingerprint(fingerprint),
+      ...extra,
+    }]));
+    return node.id;
+  } finally {
+    runtime!.close();
+  }
+}
+
+async function captureBaselines(config: MexConfig, scaffold: string): Promise<void> {
+  const runtime = await loadGroundingRuntime(config);
+  try {
+    refreshGroundingBaselines(config, [scaffold], runtime!);
+  } finally {
+    runtime!.close();
+  }
+}
+
+/** Delete the disposable index and rebuild it, as `mex graph rebuild` does. */
+async function rebuildGraphFromScratch(root: string): Promise<void> {
+  rmSync(join(root, ".mex", "graph.db"), { force: true });
+  rmSync(join(root, ".mex", "graph.db-wal"), { force: true });
+  rmSync(join(root, ".mex", "graph.db-shm"), { force: true });
+  await buildGraph(root);
+}
+
+async function groundingIssueCodes(config: MexConfig): Promise<string[]> {
+  const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
+  expect(report.graphStatus?.status).toBe("fresh");
+  return report.issues.filter((issue) => issue.code.startsWith("GROUNDING_")).map((issue) => issue.code);
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("the grounding body hash is committed to Markdown", () => {
+  it("captures it into the scaffold, so drift survives deleting and rebuilding graph.db", async () => {
+    const { root, source, scaffold, config } = fixture();
+    await buildGraph(root);
+    await authorGrounding(config, scaffold, "calculateOrderTotal");
+
+    // What the agent wrote: identity only, no change signal anywhere in Git.
+    expect(extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash).toBeUndefined();
+
+    await captureBaselines(config, scaffold);
+    const committed = extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash;
+    expect(committed).toBeTypeOf("string");
+    expect(committed!.length).toBeGreaterThan(0);
+
+    // The value is the graph's, not an invention of the writer.
+    const runtime = await loadGroundingRuntime(config);
+    const node = runtime!.graph.getNode(extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.node)!;
+    expect(committed).toBe(node.bodyHash);
+    runtime!.close();
+
+    // The move that used to destroy the baseline, and is offered as a repair.
+    writeFileSync(source, EDITED);
+    await rebuildGraphFromScratch(root);
+
+    expect(await groundingIssueCodes(config)).toEqual(["GROUNDING_DRIFT"]);
+  }, 60_000);
+
+  it("reports nothing after the same rebuild when the scaffold carries no hash", async () => {
+    // The pre-fix world, reproduced deliberately: this is the defect, and it is
+    // also the backward-compatibility case. A grounding with no committed hash
+    // parses, resolves and stays silent — no crash, no false drift, and no
+    // detection either, which is precisely why the field had to be added.
+    const { root, source, scaffold, config } = fixture();
+    await buildGraph(root);
+    await authorGrounding(config, scaffold, "calculateOrderTotal");
+    expect(extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash).toBeUndefined();
+
+    writeFileSync(source, EDITED);
+    await rebuildGraphFromScratch(root);
+
+    expect(await groundingIssueCodes(config)).toEqual([]);
+  }, 60_000);
+
+  it("still detects drift from the graph.db cache for an old grounding with a live index", async () => {
+    // The other half of backward compatibility: a scaffold authored before this
+    // field existed, whose index was never deleted, must behave exactly as it
+    // did. The cache is still consulted when Markdown has nothing to say.
+    const { root, source, scaffold, config } = fixture();
+    await buildGraph(root);
+    await authorGrounding(config, scaffold, "calculateOrderTotal");
+    await captureBaselines(config, scaffold);
+
+    // Strip the field back out, leaving the graph.db row in place.
+    const stripped = extractGroundings(readFileSync(scaffold, "utf-8"))
+      .map(({ node, fingerprint }) => ({ node, fingerprint }));
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), stripped));
+    expect(extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash).toBeUndefined();
+
+    writeFileSync(source, EDITED);
+    await buildGraph(root);
+
+    expect(await groundingIssueCodes(config)).toEqual(["GROUNDING_DRIFT"]);
+  }, 60_000);
+
+  it("does not overwrite a committed hash that has drifted, which would erase the finding", async () => {
+    const { root, source, scaffold, config } = fixture();
+    await buildGraph(root);
+    await authorGrounding(config, scaffold, "calculateOrderTotal");
+    await captureBaselines(config, scaffold);
+    const baseline = extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash!;
+
+    // Edit the body without touching its structure enough to move the
+    // fingerprint, then run the capture pass again. A pass that re-baselined
+    // unconditionally would silently adopt the new body as the truth.
+    writeFileSync(source, EDITED);
+    await buildGraph(root);
+    await captureBaselines(config, scaffold);
+
+    expect(extractGroundings(readFileSync(scaffold, "utf-8"))[0]!.bodyHash).toBe(baseline);
+    expect(await groundingIssueCodes(config)).toEqual(["GROUNDING_DRIFT"]);
+  }, 60_000);
+});

--- a/test/graph-grounding-body-hash.test.ts
+++ b/test/graph-grounding-body-hash.test.ts
@@ -170,6 +170,32 @@ describe("the grounding body hash is committed to Markdown", () => {
     expect(await groundingIssueCodes(config)).toEqual(["GROUNDING_DRIFT"]);
   }, 60_000);
 
+  it("backfills a migrated file-level entity, whose grounding lives under the mex map", async () => {
+    // The population that surfaced this: a scaffold `wiki migrate` has adopted
+    // keeps its groundings under `mex.grounds_to` rather than at the root, and
+    // migration's own `backfill` only adds a body hash when it is handed a
+    // graph — which the wiki CLI does not do. So the capture pass has to reach
+    // this shape too, and it has to splice the one key without disturbing the
+    // rest of the map.
+    const { root, source, scaffold, config } = fixture();
+    writeFileSync(
+      scaffold,
+      "---\nname: architecture\nmex:\n  id: mx_01ARZ3NDEKTSV4RRFFQ69G5FAA\n  type: pattern\n---\n\n# Architecture\n",
+    );
+    await buildGraph(root);
+    await authorGrounding(config, scaffold, "calculateOrderTotal");
+    await captureBaselines(config, scaffold);
+
+    const after = readFileSync(scaffold, "utf-8");
+    expect(after).toContain("mex:");
+    expect(after).toContain("id: mx_01ARZ3NDEKTSV4RRFFQ69G5FAA");
+    expect(extractGroundings(after)[0]!.bodyHash).toBeTypeOf("string");
+
+    writeFileSync(source, EDITED);
+    await rebuildGraphFromScratch(root);
+    expect(await groundingIssueCodes(config)).toEqual(["GROUNDING_DRIFT"]);
+  }, 60_000);
+
   it("does not overwrite a committed hash that has drifted, which would erase the finding", async () => {
     const { root, source, scaffold, config } = fixture();
     await buildGraph(root);


### PR DESCRIPTION
## What this fixes

The value that answers *"has this grounded code changed?"* was captured at
`saveCurrentBaseline` and written only into `_mex_grounded_source` inside
`.mex/graph.db` — a file that is gitignored, disposable by invariant, and whose
deletion the product recommends as a routine repair. So the drift baseline did
not survive `mex graph rebuild` and never reached a teammate who cloned. The
groundings still resolved, so nothing looked broken; they simply stopped being
able to detect a body change.

`bodyHash` is now committed to Markdown alongside `node` and `fingerprint`.

**The field alone would have been inert.** Two reads had to change with it, and
the second was found only by running against a real migrated scaffold:

1. The drift checker took the baseline **exclusively** from `graph.db`. After a
   rebuild that row is gone and the branch reported nothing at all — not a
   coarse verdict, nothing.
2. The same checker read `frontmatter.grounds_to`, the **root** key. A scaffold
   `wiki migrate` has adopted keeps the key under the `mex` map, so the loop ran
   zero times — as did the `hasGroundings` gate, which then never opened the
   grounding runtime. On the scaffold this was found on, `mex check` had never
   checked a single grounding, on any run, and reported clean.

Two diagnostics that named a cause nobody checked are also corrected.

## Measured, on a real migrated scaffold

25 files, 27 entities, 16 groundings, `graph.db` fresh. Identical throwaway
copies, before and after:

| | before | after |
|---|---|---|
| capture reports | 16 captured, 0 skipped | 16 captured, 0 skipped |
| groundings carrying a `bodyHash` | **0** | **16** |
| `wiki validate` warnings | 16 | **0** |
| delete `graph.db`, rebuild, edit a grounded body | **0 `GROUNDING_DRIFT`** | **2 `GROUNDING_DRIFT`** |

Before this branch the capture printed *"16 captured, 0 skipped"* and wrote
nothing durable.

## Backward compatibility

Optional and additive — a required field would turn every existing scaffold into
a parse error. A grounding with no `bodyHash` still parses, still validates,
still warns, and against a live index still detects drift from the `graph.db`
cache, which remains as a documented fallback and still carries the body text
drift review needs for a diff.

A hash that merely **differs** is never overwritten. That difference is the
drift; re-baselining it silently would erase the finding.

## Tests

Five new cases in `test/graph-grounding-body-hash.test.ts`, each deleting
`graph.db` and rebuilding it — the thing that used to destroy the baseline.
**Two fail on the pre-fix tree and three pass**, verified by restoring the base
files and re-running; the three that pass are backward-compatibility pins and
are meant to be insensitive to the fix. Run five times, 5/5 green each time.

## Known-red, and not from this branch

`release-performance` is failing on `integration/human-team-memory-v1` already —
the two most recent runs on the branch, including at `a9e20df`, with 8
`runtime.maintenanceMs.*` violations and `assetViolations: []`. Those are graph
and wiki index maintenance timings; this branch touches drift reading and
grounding capture, not indexing. Not addressed here, and deliberately not
worked around: widening a budget is the same move as raising a timeout.

## Scope left out

There is no shipped command that only captures baselines — the backfill is
reachable only through `mex graph ground`, `mex sync` or `mex setup`, each of
which launches an agent or is scoped to a new scaffold. For an existing scaffold
whose groundings are correct and merely lack a hash, there is no way to ask for
the one thing needed. Recorded rather than fixed; a new command surface was out
of scope.
