### PR TITLE
Hub: Discord invite and a feedback card

### DIFF
--- a/packages/hub-web/src/app/App.test.tsx
+++ b/packages/hub-web/src/app/App.test.tsx
@@ -315,6 +315,14 @@ describe("Project Hub routes", () => {
     expect(within(repositoryBar).getByText(initialHome.repository.name)).toBeVisible();
     expect(screen.getByLabelText("3 proposals awaiting team review.")).toBeVisible();
 
+    // The Hub's only outbound link. `target="_blank"` without
+    // `rel="noopener noreferrer"` would hand the opened tab a handle on this
+    // one, so the rel is asserted rather than assumed.
+    const discord = within(repositoryBar).getByRole("link", { name: "Join MEX Discord" });
+    expect(discord).toHaveAttribute("href", "https://discord.gg/FEdNsQ4Qt4");
+    expect(discord).toHaveAttribute("target", "_blank");
+    expect(discord).toHaveAttribute("rel", "noopener noreferrer");
+
     await act(async () => {
       await queryClient.invalidateQueries({ queryKey: ["home"] });
     });

--- a/packages/hub-web/src/app/HubLayout.tsx
+++ b/packages/hub-web/src/app/HubLayout.tsx
@@ -4,6 +4,7 @@ import { FolderGit2, GitBranch, GitCommitHorizontal, Menu, X } from "lucide-reac
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import type { CapabilitiesResponse, HomeResponse, OverviewResponse, SessionResponse } from "../api/types";
 import { useHubApi } from "../api/context";
+import { Button } from "../components/primitives/button";
 import { formatTime, StatePanel, StatusPill } from "../components/ui";
 import styles from "../styles/shell.module.css";
 import { JobLifecycleObserver } from "./JobLifecycleObserver";
@@ -84,17 +85,32 @@ function RepositoryBar({ repository, session }: { repository?: HomeResponse["rep
           * itself is `aria-hidden` — without it the link would go nameless at
           * exactly the width where it is hardest to guess.
           */}
-        <a
+        {/*
+          * `role="link"` is set back deliberately. The Hub's `Button` announces
+          * as a button even when it renders an anchor, which is fine for the
+          * in-app navigations that use it — but this one leaves the Hub for
+          * another site, and that is precisely the case where a reader needs to
+          * hear "link" before deciding to follow it.
+          */}
+        <Button
           aria-label="Join MEX Discord"
           className={styles.discordLink}
-          href={DISCORD_INVITE}
-          rel="noopener noreferrer"
-          target="_blank"
-          title="Join MEX Discord"
+          nativeButton={false}
+          render={(
+            <a
+              href={DISCORD_INVITE}
+              rel="noopener noreferrer"
+              target="_blank"
+              title="Join MEX Discord"
+            />
+          )}
+          role="link"
+          size="sm"
+          variant="outline"
         >
           <DiscordMark />
           <span>Join MEX Discord</span>
-        </a>
+        </Button>
         {context?.branch ? (
           <span><GitBranch aria-hidden="true" /> <span>{context.branch}</span></span>
         ) : null}

--- a/packages/hub-web/src/app/HubLayout.tsx
+++ b/packages/hub-web/src/app/HubLayout.tsx
@@ -9,6 +9,15 @@ import styles from "../styles/shell.module.css";
 import { JobLifecycleObserver } from "./JobLifecycleObserver";
 import { HubSidebar } from "./HubSidebar";
 
+/**
+ * The project's community invite.
+ *
+ * A permanent vanity invite, deliberately: a default Discord invite expires,
+ * and this URL is compiled into published builds that people keep running for
+ * months after they install them.
+ */
+const DISCORD_INVITE = "https://discord.gg/FEdNsQ4Qt4";
+
 export interface HubOutletContext {
   capabilities?: CapabilitiesResponse;
   clearSearchFocusRequest: () => void;
@@ -44,6 +53,22 @@ export function shouldHandleSearchShortcut(event: KeyboardEvent): boolean {
   return !target.closest("input, textarea, select") && !contentEditable(target);
 }
 
+/**
+ * The Discord mark, inlined.
+ *
+ * `lucide-react` carries no brand icons, and a brand mark is not something to
+ * add a dependency for. Unlike every other icon in this bar it is filled rather
+ * than stroked, so it sets `fill` and clears `stroke` explicitly instead of
+ * inheriting the stroke-based defaults.
+ */
+function DiscordMark() {
+  return (
+    <svg aria-hidden="true" fill="currentColor" stroke="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M20.317 4.3698a19.7913 19.7913 0 0 0-4.8851-1.5152.0741.0741 0 0 0-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 0 0-.0785-.037 19.7363 19.7363 0 0 0-4.8852 1.515.0699.0699 0 0 0-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 0 0 .0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 0 0 .0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 0 0-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 0 1-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 0 1 .0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 0 1 .0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 0 1-.0066.1276 12.2986 12.2986 0 0 1-1.873.8914.0766.0766 0 0 0-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 0 0 .0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 0 0 .0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 0 0-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+    </svg>
+  );
+}
+
 function RepositoryBar({ repository, session }: { repository?: HomeResponse["repository"]; session: SessionResponse }) {
   const context = repository;
   return (
@@ -53,6 +78,23 @@ function RepositoryBar({ repository, session }: { repository?: HomeResponse["rep
         <span><strong>{context?.name ?? "Current project"}</strong></span>
       </div>
       <div className={styles.repoFacts}>
+        {/*
+          * The accessible name is set explicitly and matches the visible label
+          * word for word, because the label is hidden below 1190px and the mark
+          * itself is `aria-hidden` — without it the link would go nameless at
+          * exactly the width where it is hardest to guess.
+          */}
+        <a
+          aria-label="Join MEX Discord"
+          className={styles.discordLink}
+          href={DISCORD_INVITE}
+          rel="noopener noreferrer"
+          target="_blank"
+          title="Join MEX Discord"
+        >
+          <DiscordMark />
+          <span>Join MEX Discord</span>
+        </a>
         {context?.branch ? (
           <span><GitBranch aria-hidden="true" /> <span>{context.branch}</span></span>
         ) : null}

--- a/packages/hub-web/src/pages/HomeOverview.tsx
+++ b/packages/hub-web/src/pages/HomeOverview.tsx
@@ -12,7 +12,6 @@ import {
   GitBranch,
   Inbox,
   LoaderCircle,
-  Mail,
   RadioTower,
   RefreshCw,
   ScrollText,
@@ -585,29 +584,28 @@ function UpdatesSignupCard() {
     <Card className={homeStyles.updatesCard} role="region" aria-labelledby="overview-updates-heading">
       <CardHeader className={homeStyles.panelHeader}>
         <div>
-          <CardTitle><h2 id="overview-updates-heading">Heads-up before something breaks</h2></CardTitle>
+          <CardTitle><h2 id="overview-updates-heading">Help make MEX better</h2></CardTitle>
         </div>
       </CardHeader>
       <CardContent className={homeStyles.updatesContent}>
         <p className={homeStyles.updatesBody}>
-          MEX is pre-1.0 and the scaffold format is still moving. Leave an email and we
-          will tell you before a change needs action from you.
+          A short form about how you&rsquo;re using it. Your answers help shape mex :)
         </p>
         <div className={homeStyles.updatesActions}>
+          {/*
+            * The trailing arrow is the only remaining cue that this leaves the
+            * Hub for a new tab, so it stays where the mail glyph did not.
+            */}
           <Button
             nativeButton={false}
             render={<a href={UPDATES_FORM} rel="noopener noreferrer" target="_blank" />}
             size="sm"
             variant="outline"
           >
-            <Mail aria-hidden="true" data-icon="inline-start" />
-            Leave your email
+            Open the form
             <ExternalLink aria-hidden="true" data-icon="inline-end" />
           </Button>
         </div>
-        <p className={homeStyles.updatesFootnote}>
-          Opens in your browser. Nothing is sent from this machine.
-        </p>
       </CardContent>
     </Card>
   );

--- a/packages/hub-web/src/pages/HomeOverview.tsx
+++ b/packages/hub-web/src/pages/HomeOverview.tsx
@@ -8,9 +8,11 @@ import {
   CheckCircle2,
   ChevronDown,
   CircleDashed,
+  ExternalLink,
   GitBranch,
   Inbox,
   LoaderCircle,
+  Mail,
   RadioTower,
   RefreshCw,
   ScrollText,
@@ -558,6 +560,82 @@ function ActivityRow({ item }: { item: ActivityItem }) {
   );
 }
 
+/**
+ * Where the signup lives, and why the Hub never sees the address.
+ *
+ * The form is hosted; this card only opens it. That is not a shortcut — the Hub
+ * serves itself under a policy that permits neither an outbound `fetch` nor a
+ * cross-origin form post (`src/hub/app.ts`, `connect-src 'self'`,
+ * `form-action 'self'`), so an input here could not submit anywhere without
+ * loosening the rule that makes "Runs locally" in the sidebar true. Opening a
+ * link is a navigation rather than a connection, so it stays inside the policy.
+ *
+ * The consequence worth stating: **no email address ever passes through mex.**
+ */
+const UPDATES_FORM = "https://tally.so/r/KYjv4k";
+
+/** Dismissal is a preference of this browser, so it is stored in this browser. */
+const UPDATES_DISMISSED_KEY = "mex.hub.updatesSignupDismissed";
+
+function readDismissed(): boolean {
+  // Storage throws outright in some contexts rather than returning null — a
+  // private window, or a browser set to block site data. A card that cannot
+  // remember a dismissal is a much smaller problem than an Overview that will
+  // not render, so the failure resolves to "not dismissed" and moves on.
+  try {
+    return window.localStorage.getItem(UPDATES_DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function UpdatesSignupCard() {
+  const [dismissed, setDismissed] = useState(readDismissed);
+
+  if (dismissed) return null;
+
+  function dismiss() {
+    setDismissed(true);
+    try {
+      window.localStorage.setItem(UPDATES_DISMISSED_KEY, "true");
+    } catch {
+      // Dismissed for this session even where the preference cannot outlive it.
+    }
+  }
+
+  return (
+    <Card className={homeStyles.updatesCard} role="region" aria-labelledby="overview-updates-heading">
+      <CardHeader className={homeStyles.panelHeader}>
+        <div>
+          <CardTitle><h2 id="overview-updates-heading">Heads-up before something breaks</h2></CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className={homeStyles.updatesContent}>
+        <p className={homeStyles.updatesBody}>
+          MEX is pre-1.0 and the scaffold format is still moving. Leave an email and we
+          will tell you before a change needs action from you.
+        </p>
+        <div className={homeStyles.updatesActions}>
+          <Button
+            nativeButton={false}
+            render={<a href={UPDATES_FORM} rel="noopener noreferrer" target="_blank" />}
+            size="sm"
+            variant="outline"
+          >
+            <Mail aria-hidden="true" data-icon="inline-start" />
+            Leave your email
+            <ExternalLink aria-hidden="true" data-icon="inline-end" />
+          </Button>
+          <Button onClick={dismiss} size="sm" variant="ghost">Not now</Button>
+        </div>
+        <p className={homeStyles.updatesFootnote}>
+          Opens in your browser. Nothing is sent from this machine.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
 function LatestActivityCard({ activity, onRetry }: { activity: OverviewResponse["activity"]; onRetry: () => void }) {
   return (
     <Card className={homeStyles.activityCard} role="region" aria-labelledby="overview-activity-heading">
@@ -1003,7 +1081,10 @@ export function HomeOverview() {
           <FocusCard data={data} onRetry={() => void refresh()} />
           <ContextReadinessCard context={data.context} onRetry={() => void refresh()} repository={data.shell.repository} />
         </div>
-        <LatestActivityCard activity={data.activity} onRetry={() => void refresh()} />
+        <div className={homeStyles.asideColumn}>
+          <LatestActivityCard activity={data.activity} onRetry={() => void refresh()} />
+          <UpdatesSignupCard />
+        </div>
         <OperationCard operation={data.operation} />
       </div>
     </div>

--- a/packages/hub-web/src/pages/HomeOverview.tsx
+++ b/packages/hub-web/src/pages/HomeOverview.tsx
@@ -574,35 +574,13 @@ function ActivityRow({ item }: { item: ActivityItem }) {
  */
 const UPDATES_FORM = "https://tally.so/r/KYjv4k";
 
-/** Dismissal is a preference of this browser, so it is stored in this browser. */
-const UPDATES_DISMISSED_KEY = "mex.hub.updatesSignupDismissed";
-
-function readDismissed(): boolean {
-  // Storage throws outright in some contexts rather than returning null — a
-  // private window, or a browser set to block site data. A card that cannot
-  // remember a dismissal is a much smaller problem than an Overview that will
-  // not render, so the failure resolves to "not dismissed" and moves on.
-  try {
-    return window.localStorage.getItem(UPDATES_DISMISSED_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
+/**
+ * The card is permanent and carries no dismissal, which is why it has to stay
+ * quiet. Anything that cannot be put away has to be worth living with on every
+ * visit, so this one states its offer once and never asks twice — no badge, no
+ * count, nothing that reads as unresolved work.
+ */
 function UpdatesSignupCard() {
-  const [dismissed, setDismissed] = useState(readDismissed);
-
-  if (dismissed) return null;
-
-  function dismiss() {
-    setDismissed(true);
-    try {
-      window.localStorage.setItem(UPDATES_DISMISSED_KEY, "true");
-    } catch {
-      // Dismissed for this session even where the preference cannot outlive it.
-    }
-  }
-
   return (
     <Card className={homeStyles.updatesCard} role="region" aria-labelledby="overview-updates-heading">
       <CardHeader className={homeStyles.panelHeader}>
@@ -626,7 +604,6 @@ function UpdatesSignupCard() {
             Leave your email
             <ExternalLink aria-hidden="true" data-icon="inline-end" />
           </Button>
-          <Button onClick={dismiss} size="sm" variant="ghost">Not now</Button>
         </div>
         <p className={homeStyles.updatesFootnote}>
           Opens in your browser. Nothing is sent from this machine.

--- a/packages/hub-web/src/styles/global.css
+++ b/packages/hub-web/src/styles/global.css
@@ -110,6 +110,13 @@
   --danger-soft: color-mix(in oklch, var(--danger) 9%, transparent);
   --danger-border: color-mix(in oklch, var(--danger) 24%, transparent);
   --info: oklch(0.74 0 0);
+  /*
+   * Discord's own blurple, #5865F2, converted rather than approximated. It is a
+   * brand colour and not a semantic one — it means "Discord", never "good" or
+   * "attention" — so it belongs to the one mark that carries it and must not be
+   * reached for as a general accent.
+   */
+  --discord: oklch(0.577 0.209 274);
   --info-soft: color-mix(in oklch, var(--foreground) 6%, transparent);
   --info-border: color-mix(in oklch, var(--foreground) 16%, transparent);
   --focus: var(--ring);

--- a/packages/hub-web/src/styles/home.module.css
+++ b/packages/hub-web/src/styles/home.module.css
@@ -44,18 +44,69 @@
   min-width: 0;
 }
 
-.activityCard {
+/*
+ * The right-hand column. Activity used to be the only card here and placed
+ * itself; now that something sits beneath it, the column is explicit — stacking
+ * a second `span 4` card by auto-placement would drop it to the next row's
+ * first column rather than under the one above it.
+ */
+.asideColumn {
+  display: grid;
   grid-column: span 4;
+  gap: 14px;
+  min-width: 0;
+  align-content: start;
+}
+
+.activityCard {
   min-width: 0;
 }
 
 .focusCard,
 .readinessCard,
 .activityCard,
+.updatesCard,
 .operationCard {
   --card-spacing: 18px;
   min-width: 0;
   border-radius: 14px;
+}
+
+/*
+ * The only card here that asks for something rather than reporting something,
+ * so it is drawn quieter than the panels above it: no fill of its own, a
+ * dimmer border, and body copy at secondary weight. It should read as a note at
+ * the foot of the column, never as a status the reader has to resolve.
+ */
+.updatesCard {
+  background: transparent;
+  border-color: color-mix(in oklch, var(--border) 70%, transparent);
+}
+
+.updatesContent {
+  display: grid;
+  gap: 12px;
+}
+
+.updatesBody {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.updatesActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.updatesFootnote {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 10.5px;
+  line-height: 1.4;
 }
 
 .focusCard {

--- a/packages/hub-web/src/styles/home.module.css
+++ b/packages/hub-web/src/styles/home.module.css
@@ -102,13 +102,6 @@
   align-items: center;
 }
 
-.updatesFootnote {
-  margin: 0;
-  color: var(--muted-foreground);
-  font-size: 10.5px;
-  line-height: 1.4;
-}
-
 .focusCard {
   background: var(--card);
 }

--- a/packages/hub-web/src/styles/shell.module.css
+++ b/packages/hub-web/src/styles/shell.module.css
@@ -425,25 +425,42 @@
 }
 
 /*
- * The one outbound link in the Hub. It sits with the repository facts because
- * that strip is already the bar's secondary information, but it is styled a
- * step quieter than they are and only reaches full contrast on hover — it is an
- * invitation, not a fact about this repository.
+ * The one outbound link in the Hub, and the only control in this bar — the
+ * repository facts beside it are readouts. It is drawn as a button so that
+ * difference is visible before it is read, borrowing the pill's metrics so it
+ * sits on the same optical line, with a squarer radius so it does not read as
+ * one more status.
+ *
+ * The mark keeps Discord's own colour and the label does not: the glyph is what
+ * identifies the destination, while a fully branded button would outrank the
+ * repository state, which is what the bar is actually for.
  */
 .discordLink {
-  display: flex;
-  gap: 5px;
+  display: inline-flex;
+  min-height: 21px;
+  gap: 6px;
   align-items: center;
+  padding: 2px 9px;
   color: var(--muted-foreground);
+  background: var(--muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
   font-size: 10.5px;
+  font-weight: 520;
   text-decoration: none;
   white-space: nowrap;
-  transition: color 120ms ease;
+  transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+}
+
+.discordLink svg {
+  color: var(--discord);
 }
 
 .discordLink:hover,
 .discordLink:focus-visible {
   color: var(--foreground);
+  background: color-mix(in oklch, var(--discord) 12%, var(--muted));
+  border-color: color-mix(in oklch, var(--discord) 42%, transparent);
 }
 
 .mono {
@@ -581,8 +598,14 @@
   /*
    * The mark alone below this width. The repository facts are what the bar is
    * for, so the invitation gives up its label first rather than crowding them —
-   * the `title` still names it, and so does the accessible name.
+   * the `title` still names it, and so does the accessible name. The button
+   * keeps its box and squares up around the glyph rather than collapsing to a
+   * bare icon, so it still reads as something to press.
    */
+  .discordLink {
+    padding: 2px 6px;
+  }
+
   .discordLink > span {
     display: none;
   }

--- a/packages/hub-web/src/styles/shell.module.css
+++ b/packages/hub-web/src/styles/shell.module.css
@@ -424,6 +424,28 @@
   height: 13px;
 }
 
+/*
+ * The one outbound link in the Hub. It sits with the repository facts because
+ * that strip is already the bar's secondary information, but it is styled a
+ * step quieter than they are and only reaches full contrast on hover — it is an
+ * invitation, not a fact about this repository.
+ */
+.discordLink {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  color: var(--muted-foreground);
+  font-size: 10.5px;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: color 120ms ease;
+}
+
+.discordLink:hover,
+.discordLink:focus-visible {
+  color: var(--foreground);
+}
+
 .mono {
   font-family: var(--font-mono);
 }
@@ -554,6 +576,15 @@
 
   .repoFacts > span > span {
     max-width: 170px;
+  }
+
+  /*
+   * The mark alone below this width. The repository facts are what the bar is
+   * for, so the invitation gives up its label first rather than crowding them —
+   * the `title` still names it, and so does the accessible name.
+   */
+  .discordLink > span {
+    display: none;
   }
 
   .sessionMeta {

--- a/packages/hub-web/src/styles/shell.module.css
+++ b/packages/hub-web/src/styles/shell.module.css
@@ -426,41 +426,17 @@
 
 /*
  * The one outbound link in the Hub, and the only control in this bar — the
- * repository facts beside it are readouts. It is drawn as a button so that
- * difference is visible before it is read, borrowing the pill's metrics so it
- * sits on the same optical line, with a squarer radius so it does not read as
- * one more status.
+ * repository facts beside it are readouts. It is the Hub's own outline button
+ * rather than a hand-drawn one, which is both cheaper and more consistent: an
+ * earlier version restyled it from scratch and put 705 bytes into the entry
+ * stylesheet, enough on its own to breach the initial-CSS budget.
  *
- * The mark keeps Discord's own colour and the label does not: the glyph is what
- * identifies the destination, while a fully branded button would outrank the
- * repository state, which is what the bar is actually for.
+ * Only the mark's colour is ours. The label stays neutral, because a fully
+ * branded button would outrank the repository state, which is what the bar is
+ * actually for.
  */
-.discordLink {
-  display: inline-flex;
-  min-height: 21px;
-  gap: 6px;
-  align-items: center;
-  padding: 2px 9px;
-  color: var(--muted-foreground);
-  background: var(--muted);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 10.5px;
-  font-weight: 520;
-  text-decoration: none;
-  white-space: nowrap;
-  transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
-}
-
 .discordLink svg {
   color: var(--discord);
-}
-
-.discordLink:hover,
-.discordLink:focus-visible {
-  color: var(--foreground);
-  background: color-mix(in oklch, var(--discord) 12%, var(--muted));
-  border-color: color-mix(in oklch, var(--discord) 42%, transparent);
 }
 
 .mono {
@@ -599,13 +575,8 @@
    * The mark alone below this width. The repository facts are what the bar is
    * for, so the invitation gives up its label first rather than crowding them —
    * the `title` still names it, and so does the accessible name. The button
-   * keeps its box and squares up around the glyph rather than collapsing to a
-   * bare icon, so it still reads as something to press.
+   * keeps its own padding and box, so it still reads as something to press.
    */
-  .discordLink {
-    padding: 2px 6px;
-  }
-
   .discordLink > span {
     display: none;
   }


### PR DESCRIPTION
Two additions to the Hub. Both are outbound links, and neither sends anything from the machine.

## Discord invite

A button in the repository bar, immediately left of the branch name.

- A **permanent vanity invite**, deliberately: a default Discord invite expires, and this URL is compiled into published builds people keep running for months.
- The mark is **inlined rather than imported** — `lucide-react` carries no brand icons, and a brand glyph is not worth a dependency. Unlike every other icon in that bar it is filled rather than stroked, so it sets `fill` and clears `stroke` explicitly.
- The glyph keeps Discord's blurple, converted from `#5865F2` rather than approximated, as its own token. The **label stays neutral** — a fully branded button would visually outrank the repository state, which is what the bar is for.
- Below 1190px the label is hidden and the mark stands alone, so the accessible name is set explicitly and matches the visible label word for word.

## Feedback card

Under *Latest team memory*, opening a hosted Tally form.

**The Hub cannot collect this itself, and that is structural rather than a shortcut.** It serves under `connect-src 'self'` and `form-action 'self'` (`src/hub/app.ts`), so an input here could submit neither by `fetch` nor by cross-origin form post without loosening the rule that makes *"Runs locally"* in the sidebar true. Opening a link is a navigation, not a connection, so it stays inside the policy.

The consequence worth stating plainly: **no address ever passes through mex.**

The card carries no dismissal and is permanent, so it is drawn quieter than the panels above it — no fill, dimmer border, secondary body copy. Anything that cannot be put away has to be worth living with, so it states its offer once and never reads as unresolved work.

## One structural change

The Overview aside is now an explicit grid column. Activity used to be the only card on that side and placed itself; stacking a second `span 4` card by auto-placement would have dropped it to the next row's *first* column rather than under the one above it.

## Verified

| | |
|---|---|
| `npx tsc --noEmit` | clean |
| `npm run build:hub` | clean |
| `App.test.tsx` + `page-states.test.tsx` | **86 / 86** |
| Control bytes across changed files | **0** |
| New dependencies | none |

The Discord link's `rel="noopener noreferrer"` is asserted rather than assumed — `target="_blank"` without it hands the opened tab a handle on this one. Verified by removing the attribute and watching the assertion fail.

## Note for reviewers on CI

`hub-web`'s full suite is **flaky under parallel load**, and this predates the branch: measured at **14 failures on `integration/human-team-memory-v1`** with no changes applied, all passing in isolation. If checks come back red, take a base run before attributing it to this PR.
