### PR TITLE
ci: confirm release performance on fresh runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,11 +123,15 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  release-performance:
-    # Runtime budgets are characterized and enforced only on this exact image.
-    # Node 24 remains compatibility coverage in the check matrix above.
+  release_performance_attempt_1:
+    name: release-performance-attempt-1
+    # Runtime budgets are characterized only on this exact image and Node patch.
+    # A potentially material crossing is confirmed by a separately allocated job.
     runs-on: ubuntu-24.04
     timeout-minutes: 60
+    outputs:
+      requires_confirmation: ${{ steps.decision.outputs.requires_confirmation }}
+      artifact_name: ${{ steps.decision.outputs.artifact_name }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -136,11 +140,109 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
-      - name: Enforce release performance budgets
+      - run: npm run build
+      - name: Measure the first release-performance attempt
         env:
           MEX_ENFORCE_RELEASE_BUDGETS: "1"
-        run: npm run benchmark:release
-      - name: Upload release benchmark report
+        run: >-
+          node scripts/release-benchmark/ci-orchestrator.mjs attempt
+          --report test-results/release-benchmark/attempt-1/report.attempt-1.json
+          --manifest test-results/release-benchmark/attempt-1/manifest.json
+      - name: Publish the bounded confirmation decision
+        id: decision
+        shell: bash
+        run: |
+          REQUIRED="$(node scripts/release-benchmark/ci-orchestrator.mjs retry-required --manifest test-results/release-benchmark/attempt-1/manifest.json)"
+          echo "requires_confirmation=$REQUIRED" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=release-performance-attempt-1-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+      - name: Upload first release benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.decision.outputs.artifact_name }}
+          path: test-results/release-benchmark/attempt-1/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  release_performance_attempt_2:
+    name: release-performance-attempt-2
+    needs: release_performance_attempt_1
+    if: needs.release_performance_attempt_1.outputs.requires_confirmation == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    outputs:
+      artifact_name: ${{ steps.evidence.outputs.artifact_name }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.22.0
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run build
+      - name: Measure the fresh-runner confirmation attempt
+        env:
+          MEX_ENFORCE_RELEASE_BUDGETS: "1"
+        run: >-
+          node scripts/release-benchmark/ci-orchestrator.mjs attempt
+          --report test-results/release-benchmark/attempt-2/report.attempt-2.json
+          --manifest test-results/release-benchmark/attempt-2/manifest.json
+      - name: Publish the bounded evidence identity
+        id: evidence
+        shell: bash
+        run: echo "artifact_name=release-performance-attempt-2-$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
+      - name: Upload second release benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.evidence.outputs.artifact_name }}
+          path: test-results/release-benchmark/attempt-2/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  release-performance:
+    # Preserve this final job name as the stable release gate. It always runs so
+    # a skipped, cancelled, or malformed producer cannot silently bypass CI.
+    needs: [release_performance_attempt_1, release_performance_attempt_2]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22.22.0
+      - name: Download first release benchmark evidence
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.release_performance_attempt_1.outputs.artifact_name }}
+          path: test-results/release-benchmark/attempt-1/
+      - name: Download fresh-runner confirmation evidence
+        if: needs.release_performance_attempt_1.outputs.requires_confirmation == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.release_performance_attempt_2.outputs.artifact_name }}
+          path: test-results/release-benchmark/attempt-2/
+      - name: Finalize release performance without a confirmation
+        if: needs.release_performance_attempt_1.outputs.requires_confirmation != 'true'
+        run: >-
+          node scripts/release-benchmark/ci-orchestrator.mjs finalize
+          --first-report test-results/release-benchmark/attempt-1/report.attempt-1.json
+          --first-manifest test-results/release-benchmark/attempt-1/manifest.json
+          --output test-results/release-benchmark/report.json
+      - name: Finalize release performance with fresh-runner confirmation
+        if: needs.release_performance_attempt_1.outputs.requires_confirmation == 'true'
+        run: >-
+          node scripts/release-benchmark/ci-orchestrator.mjs finalize
+          --first-report test-results/release-benchmark/attempt-1/report.attempt-1.json
+          --first-manifest test-results/release-benchmark/attempt-1/manifest.json
+          --second-report test-results/release-benchmark/attempt-2/report.attempt-2.json
+          --second-manifest test-results/release-benchmark/attempt-2/manifest.json
+          --output test-results/release-benchmark/report.json
+      - name: Upload final release benchmark report
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.mex/patterns/release-performance-gate.md
+++ b/.mex/patterns/release-performance-gate.md
@@ -12,7 +12,7 @@ edges:
   - target: "patterns/safe-graph-snapshot-evolution.md"
     condition: "when changing Graph maintenance or corpus inspection"
 grounds_to: []
-last_updated: 2026-08-29
+last_updated: 2026-09-02
 ---
 
 # Release Performance Gate
@@ -43,7 +43,9 @@ calibration environment.
    before and after ordinary reads.
 5. Use the first healthy pinned report as characterization. Freeze runtime,
    time, RSS, and heap limits at `ceil(p95 * 1.15)` and built asset limits at
-   `ceil(bytes * 1.05)`, then rerun the same pinned job in enforcement mode.
+   `ceil(bytes * 1.05)`. During CI enforcement, collect a potentially material
+   confirmation in a separately allocated pinned hosted job at the exact same
+   repository HEAD; two child processes on one VM are not independent evidence.
 6. Commit the budget file, its versioned schema/golden, and the retained runner
    identity together. Never copy wall-clock numbers from a local machine.
 7. When a new deterministic team fixture adds canonical and checkout-local
@@ -69,6 +71,10 @@ calibration environment.
 - Corpus byte caps prevent runaway allocation, but maintenance should also
   release source bodies and parser state as each file or bounded compiler batch
   completes.
+- Back-to-back confirmation processes on one hosted VM share CPU steal,
+  throttling, and I/O contention. Keep the raw reports as artifacts, pass only
+  a bounded retry decision between jobs, and make missing or same-allocation
+  confirmation evidence fail operationally.
 - An unavailable-route placeholder can already have a frozen asset or heap
   budget. Replacing it with a real lazy workbench should initially fail only
   that route's owned leaves; do not reinterpret the placeholder budget as a
@@ -89,8 +95,9 @@ calibration environment.
 
 If asset hashes change unexpectedly, inspect the built chunks for React
 development sentinels before recalibrating. If runtime enforcement is noisy,
-confirm the exact OS/architecture/Node patch and fixture digest; do not widen a
-budget until the retained raw samples show a real regression or stable shift.
+confirm the exact OS/architecture/Node patch, fixture digest, repository HEAD,
+and distinct hosted-job allocations; do not widen a budget until the retained
+raw samples show a real regression or stable shift.
 
 ## Update Scaffold
 

--- a/docs/design/release-performance-baseline.md
+++ b/docs/design/release-performance-baseline.md
@@ -97,6 +97,19 @@ bytes respectively. Initial CSS/fonts and every unrelated route/runtime budget
 remain unchanged. A clean pinned enforcing run on the final exact head remains
 required before release.
 
+The fresh-runner confirmation topology was added after PR run
+[`33616707003`](https://github.com/mex-memory/mex/actions/runs/33616707003)
+and integration push run
+[`33619416840`](https://github.com/mex-memory/mex/actions/runs/33619416840)
+produced materially different Graph, Wiki, and Search failure sets for Git
+commits with the same tree SHA
+`950182277ee98719ec6971618cb83b597323e468`. The earlier confirmation logic
+started two child processes back-to-back on one hosted VM, so sustained host
+contention could satisfy both sides of the exact-metric rule. This hardening
+changes only confirmation allocation and provenance: `budgets.json`, sample
+counts, material thresholds, category floors, and calibration formulas remain
+byte-for-byte unchanged.
+
 ## Runner contract
 
 `npm run benchmark:release` builds the package and writes the bounded JSON
@@ -178,18 +191,31 @@ Deterministic failures remain immediate: built-asset bytes, outbound requests,
 database-to-input ratios, and any unknown runtime metric never receive a retry.
 The read and maintenance nonmutation contracts likewise remain ordinary hard
 tests. A first pass containing only wall-clock, RSS, CPU, or browser-heap
-breaches triggers one independent full benchmark pass on the same pinned
-runner and exact repository HEAD only when at least one crossing could still
-become material. A crossing is potentially material when its p95 is strictly
-above the material threshold and at least two of its raw samples are also
-strictly above that threshold. If every first-pass crossing is below the
-threshold or has fewer than two supporting samples, enforcement records the
-advisories and passes without spending another full benchmark run. CI fails a
-noisy metric only when that exact metric breaches again, both p95 measurements
-exceed its material threshold, and both attempts have at least two supporting
-raw samples. This avoids treating the single maximum selected by nearest-rank
-p95 over either ten timing samples or five memory samples as
-distribution-level evidence. The committed p95 budgets remain the raw
+breaches requests one independent full benchmark pass only when at least one
+crossing could still become material. In CI that conditional confirmation runs
+in a separately allocated Ubuntu 24.04 hosted job, not as another process on
+the first job's VM. Both jobs measure the exact same repository HEAD and pinned
+Node version; a final fail-closed aggregation job validates their bounded raw
+reports and runner-allocation records before applying the existing exact-metric
+rule. A missing, malformed, same-runner, or different-HEAD confirmation is an
+operational failure rather than a pass. The local `npm run benchmark:release`
+command remains self-contained and uses its existing in-process orchestration.
+Producer-specific artifact identities allow GitHub's failed-only rerun to reuse
+valid evidence from an earlier attempt of the same workflow run. Aggregation
+accepts only the same run and SHA, nondecreasing producer attempts, and evidence
+no newer than the finalizer attempt.
+
+A crossing is potentially material when its p95 is strictly above the material
+threshold and at least two of its raw samples are also strictly above that
+threshold. If every first-pass crossing is below the threshold or has fewer
+than two supporting samples, enforcement records the advisories and passes
+without allocating a confirmation runner. CI fails a noisy metric only when
+that exact metric breaches on the fresh confirmation runner, both p95
+measurements exceed its material threshold, and both attempts have at least two
+supporting raw samples. This avoids treating the single maximum selected by
+nearest-rank p95 over either ten timing samples or five memory samples as
+distribution-level evidence, while preventing one contended VM from supplying
+both sides of the confirmation. The committed p95 budgets remain the raw
 alert/crossing line and are not recalibrated. For each exact metric key, the
 blocking threshold is
 `budget + max(15% of budget, minimum excess)`:
@@ -217,16 +243,20 @@ inconsistent raw sample evidence, are never retried as budget noise.
 Enforcement exits 0 for a pass, 1 for a budget failure, and 2 when a pass cannot
 produce a valid bounded report.
 
-The dedicated `release-performance` CI job installs Chromium on the pinned
-runner, enforces the budgets, and retains the final report plus both attempt
-reports when confirmation was required. It also retains the first raw attempt
-when advisory sample support makes a second pass unnecessary. Runtime
-candidates in that report are `ceil(p95 * 1.15)` independently for each fixture profile,
-route, read, and maintenance operation. The committed values are copied exactly
-from the first healthy retained pinned report; its enforcing rerun must pass
-before Checkpoint A is considered green. Future recalibration uses the same
-retained-report workflow. Do not derive runtime limits from an unpinned local
-run or collapse fixture profiles into one worst-case envelope.
+The dedicated CI topology uses `release-performance-attempt-1`, a conditional
+`release-performance-attempt-2`, and the final required
+`release-performance` aggregation job. Each measuring job installs Chromium on
+the pinned image and retains its raw report and bounded decision manifest for
+14 days. The final job retains the combined report; it runs even if a producer
+was cancelled or failed so missing evidence cannot silently skip the gate. The
+first raw attempt is still retained when advisory sample support makes a second
+runner unnecessary. Runtime candidates in that report are `ceil(p95 * 1.15)`
+independently for each fixture profile, route, read, and maintenance operation.
+The committed values are copied exactly from the first healthy retained pinned
+report; its enforcing rerun must pass before Checkpoint A is considered green.
+Future recalibration uses the same retained-report workflow. Do not derive
+runtime limits from an unpinned local run or collapse fixture profiles into one
+worst-case envelope.
 
 The report is capped at 2 MiB. Response bodies, child-process diagnostics,
 recorded request paths, asset lists, and violation lists also have explicit

--- a/scripts/release-benchmark/ci-orchestrator.mjs
+++ b/scripts/release-benchmark/ci-orchestrator.mjs
@@ -1,0 +1,671 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  classifyRuntimeViolations,
+  evaluateRuntimeConfirmation,
+  runtimeSampleSupport,
+} from "./runtime-confirmation.mjs";
+
+const scriptRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(scriptRoot, "../..");
+const runnerPath = resolve(scriptRoot, "run.mjs");
+const MAX_REPORT_BYTES = 2 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 16 * 1024;
+const MAX_VIOLATIONS = 200;
+const SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const DIGEST_PATTERN = /^[0-9a-f]{64}$/u;
+const GITHUB_NUMBER_PATTERN = /^[1-9][0-9]{0,19}$/u;
+const JOB_PATTERN = /^[A-Za-z0-9_.-]{1,128}$/u;
+const DISPOSITIONS = new Set([
+  "clean",
+  "advisory",
+  "confirmation_required",
+  "hard_failure",
+]);
+
+if (process.argv[1] !== undefined
+  && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exitCode = main(process.argv.slice(2));
+}
+
+function main(args) {
+  try {
+    const parsed = parseArguments(args);
+    if (parsed.command === "help") {
+      process.stdout.write(helpText());
+      return 0;
+    }
+    if (parsed.command === "attempt") return runCiAttempt(parsed.options);
+    if (parsed.command === "retry-required") {
+      process.stdout.write(`${readCiRetryRequired(parsed.options.manifestPath)}\n`);
+      return 0;
+    }
+    return finalizeCiAttempts(parsed.options);
+  } catch (error) {
+    process.stderr.write(`Release benchmark CI orchestration failed operationally: ${errorMessage(error)}\n`);
+    return 2;
+  }
+}
+
+export function runCiAttempt(options, dependencies = {}) {
+  try {
+    const enforceReleaseBudgets = dependencies.enforceReleaseBudgets
+      ?? process.env.MEX_ENFORCE_RELEASE_BUDGETS;
+    if (enforceReleaseBudgets !== "1") {
+      throw new Error("MEX_ENFORCE_RELEASE_BUDGETS=1 is required for a CI benchmark attempt");
+    }
+    const reportPath = requiredResolvedPath(options?.reportPath, "reportPath");
+    const manifestPath = requiredResolvedPath(options?.manifestPath, "manifestPath");
+    assertDistinctPaths([reportPath, manifestPath]);
+    rmSync(reportPath, { force: true });
+    rmSync(manifestPath, { force: true });
+
+    const resolveRepositoryHead = dependencies.resolveRepositoryHead ?? readRepositoryHead;
+    const resolveGithubIdentity = dependencies.resolveGithubIdentity ?? readGithubIdentity;
+    const executePass = dependencies.executePass ?? runRawPass;
+    const repositoryHead = requireRepositoryHead(resolveRepositoryHead());
+    const identity = validateGithubIdentity(resolveGithubIdentity());
+    if (identity.sha !== repositoryHead) {
+      throw new Error("GITHUB_SHA does not match the checked-out repository HEAD");
+    }
+
+    const result = executePass(reportPath);
+    const artifact = readRawReport(reportPath, result);
+    const analysis = analyzeInitialAttempt(artifact.report);
+    const manifest = createManifest({
+      repositoryHead,
+      identity,
+      rawReportSha256: artifact.sha256,
+      analysis,
+    });
+    writeBoundedJsonAtomic(manifestPath, manifest, MAX_MANIFEST_BYTES);
+    return 0;
+  } catch (error) {
+    (dependencies.emitError ?? defaultEmitError)(error);
+    return 2;
+  }
+}
+
+export function readCiRetryRequired(manifestPath) {
+  return readManifest(requiredResolvedPath(manifestPath, "manifestPath")).retryRequired;
+}
+
+export function finalizeCiAttempts(options, dependencies = {}) {
+  try {
+    const firstReportPath = requiredResolvedPath(options?.firstReportPath, "firstReportPath");
+    const firstManifestPath = requiredResolvedPath(options?.firstManifestPath, "firstManifestPath");
+    const outputPath = requiredResolvedPath(options?.outputPath, "outputPath");
+    const hasSecondReport = options?.secondReportPath !== undefined;
+    const hasSecondManifest = options?.secondManifestPath !== undefined;
+    if (hasSecondReport !== hasSecondManifest) {
+      throw new Error("secondReportPath and secondManifestPath must be supplied together");
+    }
+    const secondReportPath = hasSecondReport
+      ? requiredResolvedPath(options.secondReportPath, "secondReportPath")
+      : undefined;
+    const secondManifestPath = hasSecondManifest
+      ? requiredResolvedPath(options.secondManifestPath, "secondManifestPath")
+      : undefined;
+    assertDistinctPaths([
+      firstReportPath,
+      firstManifestPath,
+      outputPath,
+      ...(secondReportPath === undefined ? [] : [secondReportPath, secondManifestPath]),
+    ]);
+    rmSync(outputPath, { force: true });
+
+    const resolveRepositoryHead = dependencies.resolveRepositoryHead ?? readRepositoryHead;
+    const resolveGithubIdentity = dependencies.resolveGithubIdentity ?? readGithubIdentity;
+    const currentHead = requireRepositoryHead(resolveRepositoryHead());
+    const finalizerIdentity = validateGithubIdentity(resolveGithubIdentity());
+    if (finalizerIdentity.sha !== currentHead) {
+      throw new Error("The finalizer GITHUB_SHA does not match repository HEAD");
+    }
+
+    const first = readAndValidateArtifact(firstReportPath, firstManifestPath, {
+      currentHead,
+      finalizerIdentity,
+    });
+    if (first.analysis.retryRequired !== hasSecondReport) {
+      throw new Error(first.analysis.retryRequired
+        ? "The required fresh-runner confirmation report is missing"
+        : "A second report was supplied even though confirmation was not required");
+    }
+
+    let finalReport;
+    let exitCode;
+    if (!first.analysis.retryRequired) {
+      ({ finalReport, exitCode } = finalizeSingleAttempt(first));
+    } else {
+      const second = readAndValidateArtifact(secondReportPath, secondManifestPath, {
+        currentHead,
+        finalizerIdentity,
+      });
+      assertCompatibleAttempts(first.manifest, second.manifest);
+      ({ finalReport, exitCode } = finalizeConfirmedAttempts(first, second));
+    }
+
+    const serialized = writeBoundedJsonAtomic(outputPath, finalReport, MAX_REPORT_BYTES);
+    (dependencies.emitReport ?? defaultEmitReport)(serialized);
+    return exitCode;
+  } catch (error) {
+    (dependencies.emitError ?? defaultEmitError)(error);
+    return 2;
+  }
+}
+
+function analyzeInitialAttempt(report) {
+  const assetViolations = report.budgetEvaluation.assetViolations;
+  const runtimeViolations = report.budgetEvaluation.runtimeViolations;
+  if (assetViolations.length > 0) {
+    return {
+      retryRequired: false,
+      disposition: "hard_failure",
+      decision: undefined,
+      sampleSupport: undefined,
+    };
+  }
+
+  const classification = classifyRuntimeViolations(runtimeViolations);
+  let sampleSupport;
+  if (classification.confirmable.length > 0 && classification.immediate.length === 0) {
+    sampleSupport = runtimeSampleSupport(report, classification.confirmable);
+  }
+  const decision = evaluateRuntimeConfirmation(
+    runtimeViolations,
+    undefined,
+    { first: sampleSupport },
+  );
+  const disposition = decision.retryRequired
+    ? "confirmation_required"
+    : decision.finalViolations.length > 0
+      ? "hard_failure"
+      : decision.status === "not_required"
+        ? "clean"
+        : "advisory";
+  return { retryRequired: decision.retryRequired, disposition, decision, sampleSupport };
+}
+
+function analyzeConfirmationAttempt(report) {
+  const sampleSupport = runtimeSampleSupport(
+    report,
+    report.budgetEvaluation.runtimeViolations,
+  );
+  return { sampleSupport };
+}
+
+function createManifest({ repositoryHead, identity, rawReportSha256, analysis }) {
+  return {
+    schemaVersion: 1,
+    kind: "mex-release-benchmark-attempt",
+    repositoryHead,
+    github: {
+      runId: identity.runId,
+      runAttempt: identity.runAttempt,
+      sha: identity.sha,
+    },
+    runnerAllocation: {
+      job: identity.job,
+      runnerName: identity.runnerName,
+      runnerOs: identity.runnerOs,
+      runnerArch: identity.runnerArch,
+    },
+    rawReportSha256,
+    retryRequired: analysis.retryRequired,
+    disposition: analysis.disposition,
+  };
+}
+
+function readAndValidateArtifact(reportPath, manifestPath, expected) {
+  const artifact = readRawReport(reportPath);
+  const manifest = readManifest(manifestPath);
+  if (manifest.rawReportSha256 !== artifact.sha256) {
+    throw new Error("A raw report does not match its manifest digest");
+  }
+  if (manifest.repositoryHead !== expected.currentHead
+    || manifest.github.sha !== expected.currentHead) {
+    throw new Error("A benchmark attempt SHA does not match repository HEAD");
+  }
+  if (manifest.github.runId !== expected.finalizerIdentity.runId
+    || BigInt(manifest.github.runAttempt) > BigInt(expected.finalizerIdentity.runAttempt)) {
+    throw new Error("Benchmark evidence belongs to a different GitHub run allocation");
+  }
+  const analysis = analyzeInitialAttempt(artifact.report);
+  if (manifest.retryRequired !== analysis.retryRequired
+    || manifest.disposition !== analysis.disposition) {
+    throw new Error("A manifest does not match the recomputed retry decision");
+  }
+  return { ...artifact, manifest, analysis };
+}
+
+function assertCompatibleAttempts(first, second) {
+  if (first.repositoryHead !== second.repositoryHead
+    || first.github.sha !== second.github.sha
+    || first.github.runId !== second.github.runId) {
+    throw new Error("Benchmark attempts do not describe the same GitHub run and repository SHA");
+  }
+  if (BigInt(first.github.runAttempt) > BigInt(second.github.runAttempt)) {
+    throw new Error("Benchmark confirmation predates the first benchmark attempt");
+  }
+  if (first.runnerAllocation.job === second.runnerAllocation.job) {
+    throw new Error("Benchmark confirmation reused the first job allocation");
+  }
+}
+
+function finalizeSingleAttempt(first) {
+  const runtimeViolations = first.report.budgetEvaluation.runtimeViolations;
+  if (first.report.budgetEvaluation.assetViolations.length > 0) {
+    return {
+      finalReport: finalReportFrom(first.report, {
+        confirmation: confirmationRecord({
+          status: "skipped_immediate_failure",
+          repositoryHead: first.manifest.repositoryHead,
+          firstPassViolations: runtimeViolations,
+          firstManifest: first.manifest,
+        }),
+        runtimeViolations,
+        passed: false,
+      }),
+      exitCode: 1,
+    };
+  }
+
+  const decision = first.analysis.decision;
+  const passed = decision.finalViolations.length === 0;
+  return {
+    finalReport: finalReportFrom(first.report, {
+      confirmation: confirmationRecord({
+        status: decision.status,
+        repositoryHead: first.manifest.repositoryHead,
+        firstPassViolations: runtimeViolations,
+        confirmedViolations: decision.confirmed,
+        advisoryAssessments: decision.advisoryAssessments,
+        materialAssessments: decision.materialAssessments,
+        firstManifest: first.manifest,
+      }),
+      runtimeViolations: decision.finalViolations,
+      passed,
+    }),
+    exitCode: passed ? 0 : 1,
+  };
+}
+
+function finalizeConfirmedAttempts(first, second) {
+  const secondEvidence = analyzeConfirmationAttempt(second.report);
+  const decision = evaluateRuntimeConfirmation(
+    first.report.budgetEvaluation.runtimeViolations,
+    second.report.budgetEvaluation.runtimeViolations,
+    {
+      first: first.analysis.sampleSupport,
+      second: secondEvidence.sampleSupport,
+    },
+  );
+  const passed = second.report.budgetEvaluation.assetViolations.length === 0
+    && decision.finalViolations.length === 0;
+  return {
+    finalReport: finalReportFrom(second.report, {
+      confirmation: confirmationRecord({
+        status: passed ? "passed" : "failed",
+        repositoryHead: first.manifest.repositoryHead,
+        firstPassViolations: first.report.budgetEvaluation.runtimeViolations,
+        secondPassViolations: second.report.budgetEvaluation.runtimeViolations,
+        confirmedViolations: decision.confirmed,
+        advisoryAssessments: decision.advisoryAssessments,
+        materialAssessments: decision.materialAssessments,
+        firstManifest: first.manifest,
+        secondManifest: second.manifest,
+      }),
+      runtimeViolations: decision.finalViolations,
+      passed,
+    }),
+    exitCode: passed ? 0 : 1,
+  };
+}
+
+function confirmationRecord({
+  status,
+  repositoryHead,
+  firstPassViolations,
+  secondPassViolations = [],
+  confirmedViolations = [],
+  advisoryAssessments = [],
+  materialAssessments = [],
+  firstManifest,
+  secondManifest,
+}) {
+  return {
+    status,
+    repositoryHead,
+    firstPassViolations: firstPassViolations.slice(0, MAX_VIOLATIONS),
+    secondPassViolations: secondPassViolations.slice(0, MAX_VIOLATIONS),
+    confirmedViolations: confirmedViolations.slice(0, MAX_VIOLATIONS),
+    advisoryAssessments: advisoryAssessments.slice(0, MAX_VIOLATIONS * 2),
+    materialAssessments: materialAssessments.slice(0, MAX_VIOLATIONS),
+    runnerAllocations: {
+      first: runnerProvenance(firstManifest),
+      ...(secondManifest === undefined ? {} : { second: runnerProvenance(secondManifest) }),
+    },
+  };
+}
+
+function runnerProvenance(manifest) {
+  return {
+    runId: manifest.github.runId,
+    runAttempt: manifest.github.runAttempt,
+    job: manifest.runnerAllocation.job,
+    runnerName: manifest.runnerAllocation.runnerName,
+    runnerOs: manifest.runnerAllocation.runnerOs,
+    runnerArch: manifest.runnerAllocation.runnerArch,
+  };
+}
+
+function finalReportFrom(report, { confirmation, runtimeViolations, passed }) {
+  const finalReport = structuredClone(report);
+  finalReport.budgetEvaluation.runtimeConfirmation = confirmation;
+  finalReport.budgetEvaluation.runtimeViolations = runtimeViolations;
+  finalReport.budgetEvaluation.passed = passed;
+  return finalReport;
+}
+
+function readRawReport(path, result) {
+  if (result !== undefined
+    && ((result.status !== 0 && result.status !== 1) || result.signal !== null)) {
+    throw new Error("The raw benchmark did not complete with a report-producing exit status");
+  }
+  const { value: report, serialized, sha256 } = readBoundedJson(path, MAX_REPORT_BYTES, "raw report");
+  if (!isPlainObject(report)
+    || report.schemaVersion !== 1
+    || report.benchmark !== "mex-release-performance"
+    || !isPlainObject(report.environment)
+    || report.environment.pinnedBudgetEnvironment !== true
+    || !isPlainObject(report.configuration)
+    || report.configuration.runtimeBudgetsEnforced !== true
+    || report.configuration.assetBudgetsEnforced !== true
+    || !isPlainObject(report.budgetEvaluation)
+    || !hasExactKeys(report.budgetEvaluation, ["assetViolations", "runtimeViolations", "passed"])
+    || !validViolations(report.budgetEvaluation.assetViolations)
+    || !validViolations(report.budgetEvaluation.runtimeViolations)
+    || typeof report.budgetEvaluation.passed !== "boolean") {
+    throw new Error("The raw benchmark report has an invalid bounded shape");
+  }
+  const expectedPassed = report.budgetEvaluation.assetViolations.length === 0
+    && report.budgetEvaluation.runtimeViolations.length === 0;
+  if (report.budgetEvaluation.passed !== expectedPassed
+    || (result !== undefined && report.budgetEvaluation.passed !== (result.status === 0))) {
+    throw new Error("The raw benchmark report disagrees with its budget exit status");
+  }
+  return { report, serialized, sha256 };
+}
+
+function validViolations(value) {
+  return Array.isArray(value)
+    && value.length <= MAX_VIOLATIONS
+    && value.every((violation) => isPlainObject(violation)
+      && hasExactKeys(violation, ["metric", "measured", "budget", "reason"])
+      && validBoundedString(violation.metric, 256)
+      && validOptionalFiniteNumber(violation.measured)
+      && validOptionalFiniteNumber(violation.budget)
+      && validBoundedString(violation.reason, 100));
+}
+
+function validOptionalFiniteNumber(value) {
+  return value === null || (typeof value === "number" && Number.isFinite(value));
+}
+
+function readManifest(path) {
+  const { value } = readBoundedJson(path, MAX_MANIFEST_BYTES, "attempt manifest");
+  if (!isPlainObject(value)
+    || !hasExactKeys(value, [
+      "schemaVersion",
+      "kind",
+      "repositoryHead",
+      "github",
+      "runnerAllocation",
+      "rawReportSha256",
+      "retryRequired",
+      "disposition",
+    ])
+    || value.schemaVersion !== 1
+    || value.kind !== "mex-release-benchmark-attempt"
+    || !SHA_PATTERN.test(value.repositoryHead)
+    || !DIGEST_PATTERN.test(value.rawReportSha256)
+    || typeof value.retryRequired !== "boolean"
+    || !DISPOSITIONS.has(value.disposition)
+    || !validManifestGithub(value.github)
+    || !validRunnerAllocation(value.runnerAllocation)
+    || value.repositoryHead !== value.github.sha
+    || value.retryRequired !== (value.disposition === "confirmation_required")) {
+    throw new Error("The release benchmark attempt manifest is invalid");
+  }
+  return value;
+}
+
+function validManifestGithub(value) {
+  return isPlainObject(value)
+    && hasExactKeys(value, ["runId", "runAttempt", "sha"])
+    && GITHUB_NUMBER_PATTERN.test(value.runId)
+    && GITHUB_NUMBER_PATTERN.test(value.runAttempt)
+    && SHA_PATTERN.test(value.sha);
+}
+
+function validRunnerAllocation(value) {
+  return isPlainObject(value)
+    && hasExactKeys(value, ["job", "runnerName", "runnerOs", "runnerArch"])
+    && JOB_PATTERN.test(value.job)
+    && validBoundedString(value.runnerName, 256)
+    && validBoundedString(value.runnerOs, 32)
+    && validBoundedString(value.runnerArch, 32);
+}
+
+function validateGithubIdentity(identity) {
+  if (!isPlainObject(identity)
+    || !hasExactKeys(identity, [
+      "runId",
+      "runAttempt",
+      "sha",
+      "job",
+      "runnerName",
+      "runnerOs",
+      "runnerArch",
+    ])
+    || !validManifestGithub({
+      runId: identity.runId,
+      runAttempt: identity.runAttempt,
+      sha: identity.sha,
+    })
+    || !validRunnerAllocation({
+      job: identity.job,
+      runnerName: identity.runnerName,
+      runnerOs: identity.runnerOs,
+      runnerArch: identity.runnerArch,
+    })) {
+    throw new Error("The GitHub Actions run identity is missing or invalid");
+  }
+  return identity;
+}
+
+function readGithubIdentity(environment = process.env) {
+  return {
+    runId: environment.GITHUB_RUN_ID,
+    runAttempt: environment.GITHUB_RUN_ATTEMPT,
+    sha: environment.GITHUB_SHA,
+    job: environment.GITHUB_JOB,
+    runnerName: environment.RUNNER_NAME,
+    runnerOs: environment.RUNNER_OS,
+    runnerArch: environment.RUNNER_ARCH,
+  };
+}
+
+function readRepositoryHead() {
+  const result = spawnSync("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function requireRepositoryHead(value) {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value)) {
+    throw new Error("The checked-out repository HEAD could not be resolved");
+  }
+  return value;
+}
+
+function runRawPass(reportPath) {
+  const result = spawnSync(process.execPath, [runnerPath, "--output", reportPath], {
+    cwd: repositoryRoot,
+    env: { ...process.env, MEX_ENFORCE_RELEASE_BUDGETS: "1" },
+    stdio: ["inherit", "ignore", "inherit"],
+  });
+  return { status: result.status, signal: result.signal };
+}
+
+function readBoundedJson(path, maximumBytes, label) {
+  if (!existsSync(path)) throw new Error(`The ${label} is missing`);
+  const size = statSync(path).size;
+  if (size <= 0 || size > maximumBytes) throw new Error(`The ${label} exceeds its size bound`);
+  const serialized = readFileSync(path, "utf8");
+  let value;
+  try {
+    value = JSON.parse(serialized);
+  } catch {
+    throw new Error(`The ${label} is not valid JSON`);
+  }
+  return {
+    value,
+    serialized,
+    sha256: createHash("sha256").update(serialized).digest("hex"),
+  };
+}
+
+function writeBoundedJsonAtomic(path, value, maximumBytes) {
+  const serialized = `${JSON.stringify(value, null, 2)}\n`;
+  if (Buffer.byteLength(serialized) > maximumBytes) {
+    throw new Error(`A release benchmark output exceeded ${maximumBytes} bytes`);
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  const temporary = resolve(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    writeFileSync(temporary, serialized, { encoding: "utf8", flag: "wx" });
+    renameSync(temporary, path);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+  return serialized;
+}
+
+function requiredResolvedPath(value, name) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} is required`);
+  return resolve(value);
+}
+
+function assertDistinctPaths(paths) {
+  if (new Set(paths).size !== paths.length) {
+    throw new Error("Release benchmark input and output paths must be distinct");
+  }
+}
+
+function isPlainObject(value) {
+  return value !== null
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+function hasExactKeys(value, expected) {
+  const actual = Object.keys(value).sort();
+  return actual.length === expected.length
+    && actual.every((key, index) => key === [...expected].sort()[index]);
+}
+
+function validBoundedString(value, maximumLength) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= maximumLength
+    && !/[\r\n\0]/u.test(value);
+}
+
+function defaultEmitReport(serialized) {
+  process.stdout.write(serialized);
+}
+
+function defaultEmitError(error) {
+  process.stderr.write(`Release benchmark CI orchestration failed operationally: ${errorMessage(error)}\n`);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : "unknown error";
+}
+
+function parseArguments(args) {
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    return { command: "help", options: {} };
+  }
+  const command = args[0];
+  if (!new Set(["attempt", "retry-required", "finalize"]).has(command)) {
+    throw new Error(`Unknown release benchmark CI command: ${command}`);
+  }
+  if (args.slice(1).some((argument) => argument === "--help" || argument === "-h")) {
+    return { command: "help", options: {} };
+  }
+  const definitions = command === "attempt"
+    ? { "--report": "reportPath", "--manifest": "manifestPath" }
+    : command === "retry-required"
+      ? { "--manifest": "manifestPath" }
+      : {
+          "--first-report": "firstReportPath",
+          "--first-manifest": "firstManifestPath",
+          "--second-report": "secondReportPath",
+          "--second-manifest": "secondManifestPath",
+          "--output": "outputPath",
+        };
+  const required = command === "attempt"
+    ? ["reportPath", "manifestPath"]
+    : command === "retry-required"
+      ? ["manifestPath"]
+      : ["firstReportPath", "firstManifestPath", "outputPath"];
+  const options = {};
+  for (let index = 1; index < args.length; index += 2) {
+    const flag = args[index];
+    const name = definitions[flag];
+    const value = args[index + 1];
+    if (name === undefined) throw new Error(`Unknown ${command} option: ${flag}`);
+    if (!value || value.startsWith("-")) throw new Error(`${flag} requires a path`);
+    if (options[name] !== undefined) throw new Error(`${flag} may only be supplied once`);
+    options[name] = value;
+  }
+  for (const name of required) {
+    if (options[name] === undefined) throw new Error(`${name} is required`);
+  }
+  if ((options.secondReportPath === undefined) !== (options.secondManifestPath === undefined)) {
+    throw new Error("--second-report and --second-manifest must be supplied together");
+  }
+  return { command, options };
+}
+
+function helpText() {
+  return [
+    "Usage:",
+    "  node scripts/release-benchmark/ci-orchestrator.mjs attempt --report <raw.json> --manifest <manifest.json>",
+    "  node scripts/release-benchmark/ci-orchestrator.mjs retry-required --manifest <manifest.json>",
+    "  node scripts/release-benchmark/ci-orchestrator.mjs finalize --first-report <raw.json> --first-manifest <manifest.json> [--second-report <raw.json> --second-manifest <manifest.json>] --output <report.json>",
+    "",
+    "The attempt command executes exactly one raw pinned benchmark pass.",
+    "Finalization requires a distinct GitHub job allocation for a requested confirmation.",
+    "",
+  ].join("\n");
+}

--- a/scripts/release-benchmark/ci-orchestrator.test.js
+++ b/scripts/release-benchmark/ci-orchestrator.test.js
@@ -1,0 +1,431 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  finalizeCiAttempts,
+  readCiRetryRequired,
+  runCiAttempt,
+} from "./ci-orchestrator.mjs";
+import { runtimeMaterialityPolicy } from "./runtime-confirmation.mjs";
+
+const HEAD = "a".repeat(40);
+const SCRIPT = new URL("./ci-orchestrator.mjs", import.meta.url);
+
+describe("release benchmark fresh-runner CI orchestration", () => {
+  it("runs exactly one enforcing raw attempt and prints its bounded retry decision", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-ci-attempt-"));
+    const metric = "runtime.apiLatencyMs.small.code";
+    const pass = runtimePass(metric);
+    try {
+      const blocked = attempt(root, "first", pass, { enforceReleaseBudgets: "0" });
+      expect(blocked.exitCode).toBe(2);
+      expect(blocked.calls).toBe(0);
+      expect(blocked.errors).toEqual([
+        "MEX_ENFORCE_RELEASE_BUDGETS=1 is required for a CI benchmark attempt",
+      ]);
+
+      const result = attempt(root, "first", pass);
+      expect(result.exitCode).toBe(0);
+      expect(result.calls).toBe(1);
+      expect(result.manifest).toEqual({
+        schemaVersion: 1,
+        kind: "mex-release-benchmark-attempt",
+        repositoryHead: HEAD,
+        github: { runId: "12345", runAttempt: "2", sha: HEAD },
+        runnerAllocation: {
+          job: "first",
+          runnerName: "runner-first",
+          runnerOs: "Linux",
+          runnerArch: "X64",
+        },
+        rawReportSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+        retryRequired: true,
+        disposition: "confirmation_required",
+      });
+      expect(readCiRetryRequired(result.manifestPath)).toBe(true);
+      expect(Buffer.byteLength(readFileSync(result.manifestPath))).toBeLessThan(16 * 1024);
+
+      const cli = spawnSync(process.execPath, [
+        fileURLToPath(SCRIPT),
+        "retry-required",
+        "--manifest",
+        result.manifestPath,
+      ], { encoding: "utf8" });
+      expect(cli.status).toBe(0);
+      expect(cli.stdout).toBe("true\n");
+      expect(cli.stderr).toBe("");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires raw reports to prove pinned runtime and asset enforcement", () => {
+    for (const mutate of [
+      (pass) => { pass.environment.pinnedBudgetEnvironment = false; },
+      (pass) => { pass.configuration.runtimeBudgetsEnforced = false; },
+      (pass) => { pass.configuration.assetBudgetsEnforced = false; },
+      (pass) => { delete pass.configuration.runtimeBudgetsEnforced; },
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), "mex-release-ci-pinned-"));
+      try {
+        const pass = benchmarkPass();
+        mutate(pass);
+        const result = attempt(root, "first", pass);
+        expect(result.exitCode).toBe(2);
+        expect(result.calls).toBe(1);
+        expect(result.manifest).toBeUndefined();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("skips a fresh runner for clean and advisory first attempts", () => {
+    for (const [name, pass, expectedStatus] of [
+      ["clean", benchmarkPass(), "not_required"],
+      ["advisory", runtimePass("runtime.apiLatencyMs.small.code", { measured: 52, support: 0 }), "passed"],
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), `mex-release-ci-${name}-`));
+      try {
+        const first = attempt(root, "first", pass);
+        expect(first.exitCode).toBe(0);
+        expect(first.manifest.retryRequired).toBe(false);
+        const finalized = finalize(root, first);
+        expect(finalized.exitCode).toBe(0);
+        expect(finalized.report.budgetEvaluation).toMatchObject({
+          runtimeViolations: [],
+          passed: true,
+          runtimeConfirmation: {
+            status: expectedStatus,
+            repositoryHead: HEAD,
+            runnerAllocations: {
+              first: {
+                runId: "12345",
+                runAttempt: "2",
+                job: "first",
+              },
+            },
+          },
+        });
+        expect(finalized.report.budgetEvaluation.runtimeConfirmation.runnerAllocations)
+          .not.toHaveProperty("second");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("passes different material metrics measured by distinct job allocations", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-ci-different-"));
+    try {
+      const first = attempt(root, "first", runtimePass("runtime.apiLatencyMs.small.code"));
+      const second = attempt(root, "second", runtimePass("runtime.apiLatencyMs.small.search"));
+      expect(first.manifest.retryRequired).toBe(true);
+      expect(second.manifest.retryRequired).toBe(true);
+
+      const finalized = finalize(root, first, second);
+      expect(finalized.exitCode).toBe(0);
+      expect(finalized.report.budgetEvaluation).toMatchObject({
+        assetViolations: [],
+        runtimeViolations: [],
+        passed: true,
+        runtimeConfirmation: {
+          status: "passed",
+          confirmedViolations: [],
+          materialAssessments: [],
+          runnerAllocations: {
+            first: { job: "first" },
+            second: { job: "second" },
+          },
+        },
+      });
+      expect(finalized.report.budgetEvaluation.runtimeConfirmation.advisoryAssessments)
+        .toEqual(expect.arrayContaining([
+          expect.objectContaining({ metric: "runtime.apiLatencyMs.small.code", reason: "not_repeated" }),
+          expect.objectContaining({ metric: "runtime.apiLatencyMs.small.search", reason: "not_repeated" }),
+        ]));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails the same supported material metric across distinct jobs", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-ci-same-"));
+    const metric = "runtime.apiLatencyMs.small.code";
+    try {
+      const first = attempt(root, "first", runtimePass(metric, { excess: 1 }));
+      const second = attempt(root, "second", runtimePass(metric, { excess: 4 }));
+      const finalized = finalize(root, first, second);
+      expect(finalized.exitCode).toBe(1);
+      expect(finalized.report.budgetEvaluation).toMatchObject({
+        runtimeViolations: [expect.objectContaining({ metric })],
+        passed: false,
+        runtimeConfirmation: {
+          status: "failed",
+          confirmedViolations: [expect.objectContaining({ metric })],
+          materialAssessments: [{
+            metric,
+            classification: "material",
+            reason: "repeated_material_threshold",
+            firstSupportingSamples: 2,
+            secondSupportingSamples: 2,
+          }],
+        },
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts mixed selective-rerun attempts and still applies the exact metric policy", () => {
+    const metric = "runtime.apiLatencyMs.small.code";
+    for (const [name, secondMetric, expectedExit] of [
+      ["different", "runtime.apiLatencyMs.small.search", 0],
+      ["same", metric, 1],
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), `mex-release-ci-mixed-${name}-`));
+      try {
+        const first = attempt(root, "first", runtimePass(metric), { runAttempt: "1" });
+        const second = attempt(root, "second", runtimePass(secondMetric), { runAttempt: "2" });
+        const finalized = finalize(root, first, second, { runAttempt: "2" });
+        expect(finalized.exitCode, name).toBe(expectedExit);
+        expect(finalized.errors, name).toEqual([]);
+        expect(finalized.report.budgetEvaluation.runtimeConfirmation.runnerAllocations)
+          .toMatchObject({
+            first: { runAttempt: "1", job: "first" },
+            second: { runAttempt: "2", job: "second" },
+          });
+        expect(finalized.report.budgetEvaluation.runtimeConfirmation.status)
+          .toBe(expectedExit === 0 ? "passed" : "failed");
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("rejects producer evidence from a future workflow attempt", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-ci-future-attempt-"));
+    try {
+      const first = attempt(
+        root,
+        "first",
+        runtimePass("runtime.apiLatencyMs.small.code"),
+        { runAttempt: "9007199254740993" },
+      );
+      const result = finalize(root, first, undefined, { runAttempt: "9007199254740992" });
+      expect(result.exitCode).toBe(2);
+      expect(result.errors).toEqual([
+        "Benchmark evidence belongs to a different GitHub run allocation",
+      ]);
+      expect(result.report).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps deterministic, immediate, and second-attempt asset failures hard", () => {
+    const immediate = violation("runtime.databaseToInputRatio.small.graph", 101, 100);
+    const asset = violation("assets.routes.home.jsBytes", 101, 100);
+    for (const [name, firstPass, secondPass] of [
+      ["first-immediate", benchmarkPass({ runtimeViolations: [immediate] }), undefined],
+      ["first-asset", benchmarkPass({ assetViolations: [asset] }), undefined],
+      ["second-immediate", runtimePass("runtime.apiLatencyMs.small.code"), benchmarkPass({ runtimeViolations: [immediate] })],
+      ["second-asset", runtimePass("runtime.apiLatencyMs.small.code"), benchmarkPass({ assetViolations: [asset] })],
+    ]) {
+      const root = mkdtempSync(join(tmpdir(), `mex-release-ci-${name}-`));
+      try {
+        const first = attempt(root, "first", firstPass);
+        const second = secondPass === undefined ? undefined : attempt(root, "second", secondPass);
+        const finalized = finalize(root, first, second);
+        expect(finalized.exitCode, name).toBe(1);
+        expect(finalized.report.budgetEvaluation.passed, name).toBe(false);
+        if (name === "second-asset") {
+          expect(finalized.report.budgetEvaluation.assetViolations).toEqual([asset]);
+          expect(finalized.report.budgetEvaluation.runtimeConfirmation.status).toBe("failed");
+        }
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("fails operationally for missing, invalid, mismatched, or reused evidence", () => {
+    const metric = "runtime.apiLatencyMs.small.code";
+    const scenarios = [
+      ["missing-first-report", ({ root, first }) => {
+        rmSync(first.reportPath, { force: true });
+        return finalize(root, first);
+      }],
+      ["malformed-first-report", ({ root, first }) => {
+        writeFileSync(first.reportPath, "not-json\n");
+        return finalize(root, first);
+      }],
+      ["missing-second", ({ root, first }) => finalize(root, first)],
+      ["same-job", ({ root, first }) => {
+        const second = attempt(root, "first", runtimePass(metric), { suffix: "second" });
+        return finalize(root, first, second);
+      }],
+      ["different-run", ({ root, first }) => {
+        const second = attempt(root, "second", runtimePass(metric), { runId: "99999" });
+        return finalize(root, first, second);
+      }],
+      ["older-confirmation-attempt", ({ root, first }) => {
+        const second = attempt(root, "second", runtimePass(metric), { runAttempt: "1" });
+        return finalize(root, first, second);
+      }],
+      ["second-sha", ({ root, first }) => {
+        const second = attempt(root, "second", runtimePass(metric), { sha: "b".repeat(40) });
+        return finalize(root, first, second);
+      }],
+      ["report-digest", ({ root, first }) => {
+        const second = attempt(root, "second", runtimePass(metric));
+        writeFileSync(second.reportPath, `${readFileSync(second.reportPath, "utf8")}\n`);
+        return finalize(root, first, second);
+      }],
+      ["malformed-manifest", ({ root, first }) => {
+        const second = attempt(root, "second", runtimePass(metric));
+        writeFileSync(second.manifestPath, "not-json\n");
+        return finalize(root, first, second);
+      }],
+    ];
+    for (const [name, run] of scenarios) {
+      const root = mkdtempSync(join(tmpdir(), `mex-release-ci-operational-${name}-`));
+      try {
+        const first = attempt(root, "first", runtimePass(metric));
+        const outputPath = join(root, "report.json");
+        writeFileSync(outputPath, "stale\n");
+        const result = run({ root, first });
+        expect(result.exitCode, name).toBe(2);
+        expect(result.errors, name).toHaveLength(1);
+        expect(existsSync(outputPath), name).toBe(false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("rejects malformed sample evidence before publishing a retry manifest", () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-release-ci-evidence-"));
+    const pass = runtimePass("runtime.apiLatencyMs.small.code");
+    pass.profiles.small.apiLatencyMs.code.samples.pop();
+    try {
+      const result = attempt(root, "first", pass);
+      expect(result.exitCode).toBe(2);
+      expect(result.calls).toBe(1);
+      expect(result.manifest).toBeUndefined();
+      expect(result.errors[0]).toMatch(/Invalid raw samples/u);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function attempt(root, job, pass, overrides = {}) {
+  const suffix = overrides.suffix ?? job;
+  const reportPath = join(root, `report-${suffix}.json`);
+  const manifestPath = join(root, `manifest-${suffix}.json`);
+  let calls = 0;
+  const errors = [];
+  const dependencies = {
+    enforceReleaseBudgets: Object.hasOwn(overrides, "enforceReleaseBudgets")
+      ? overrides.enforceReleaseBudgets
+      : "1",
+    resolveRepositoryHead: () => overrides.sha ?? HEAD,
+    resolveGithubIdentity: () => githubIdentity(job, overrides),
+    executePass(path) {
+      calls += 1;
+      writeFileSync(path, `${JSON.stringify(pass, null, 2)}\n`);
+      return { status: pass.budgetEvaluation.passed ? 0 : 1, signal: null };
+    },
+    emitError: (error) => errors.push(error.message),
+  };
+  const exitCode = runCiAttempt({ reportPath, manifestPath }, dependencies);
+  return {
+    calls,
+    errors,
+    exitCode,
+    reportPath,
+    manifestPath,
+    manifest: existsSync(manifestPath)
+      ? JSON.parse(readFileSync(manifestPath, "utf8"))
+      : undefined,
+  };
+}
+
+function finalize(root, first, second, identityOverrides = {}) {
+  const outputPath = join(root, "report.json");
+  const errors = [];
+  const exitCode = finalizeCiAttempts({
+    firstReportPath: first.reportPath,
+    firstManifestPath: first.manifestPath,
+    ...(second === undefined ? {} : {
+      secondReportPath: second.reportPath,
+      secondManifestPath: second.manifestPath,
+    }),
+    outputPath,
+  }, {
+    resolveRepositoryHead: () => HEAD,
+    resolveGithubIdentity: () => githubIdentity("finalizer", identityOverrides),
+    emitReport: () => undefined,
+    emitError: (error) => errors.push(error.message),
+  });
+  return {
+    errors,
+    exitCode,
+    report: existsSync(outputPath) ? JSON.parse(readFileSync(outputPath, "utf8")) : undefined,
+  };
+}
+
+function githubIdentity(job, overrides = {}) {
+  return {
+    runId: overrides.runId ?? "12345",
+    runAttempt: overrides.runAttempt ?? "2",
+    sha: overrides.sha ?? HEAD,
+    job,
+    runnerName: `runner-${job}`,
+    runnerOs: "Linux",
+    runnerArch: "X64",
+  };
+}
+
+function benchmarkPass({ assetViolations = [], runtimeViolations = [], profiles = {} } = {}) {
+  return {
+    schemaVersion: 1,
+    benchmark: "mex-release-performance",
+    environment: { pinnedBudgetEnvironment: true },
+    configuration: { runtimeBudgetsEnforced: true, assetBudgetsEnforced: true },
+    profiles,
+    budgetEvaluation: {
+      assetViolations,
+      runtimeViolations,
+      passed: assetViolations.length === 0 && runtimeViolations.length === 0,
+    },
+  };
+}
+
+function runtimePass(metric, { measured, excess = 1, support = 2 } = {}) {
+  const policy = runtimeMaterialityPolicy(metric);
+  const value = measured ?? policy.materialThreshold + excess;
+  const runtimeViolation = violation(metric, value, policy.budget);
+  const samples = Array(policy.sampleCount).fill(0);
+  if (support > 0) {
+    for (let index = policy.sampleCount - support; index < policy.sampleCount - 1; index += 1) {
+      samples[index] = policy.materialThreshold + ((value - policy.materialThreshold) / 2);
+    }
+  }
+  samples[policy.sampleCount - 1] = value;
+  const summary = { samples, p95: value };
+  const [, category, profile, name] = metric.split(".");
+  if (category !== "apiLatencyMs") throw new Error(`Unsupported test metric: ${metric}`);
+  return benchmarkPass({
+    runtimeViolations: [runtimeViolation],
+    profiles: { [profile]: { apiLatencyMs: { [name]: summary } } },
+  });
+}
+
+function violation(metric, measured, budget) {
+  return { metric, measured, budget, reason: "budget_exceeded" };
+}

--- a/scripts/release-benchmark/ci-workflow.test.js
+++ b/scripts/release-benchmark/ci-workflow.test.js
@@ -1,0 +1,100 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/ci.yml", import.meta.url),
+  "utf8",
+);
+
+function jobBlock(name, nextName) {
+  const startMarker = `  ${name}:\n`;
+  const start = workflow.indexOf(startMarker);
+  if (start === -1) throw new Error(`Missing CI job: ${name}`);
+  if (nextName === undefined) return workflow.slice(start);
+  const end = workflow.indexOf(`  ${nextName}:\n`, start + startMarker.length);
+  if (end === -1) throw new Error(`Missing following CI job: ${nextName}`);
+  return workflow.slice(start, end);
+}
+
+describe("release-performance CI topology", () => {
+  it("allocates a fresh hosted job only for a requested confirmation", () => {
+    const first = jobBlock(
+      "release_performance_attempt_1",
+      "release_performance_attempt_2",
+    );
+    const second = jobBlock("release_performance_attempt_2", "release-performance");
+
+    expect(first).toContain("name: release-performance-attempt-1");
+    expect(first).toContain("runs-on: ubuntu-24.04");
+    expect(first).toContain("requires_confirmation:");
+    expect(first).toContain("ci-orchestrator.mjs attempt");
+    expect(first).toContain("ci-orchestrator.mjs retry-required");
+    expect(first).not.toContain("npm run benchmark:release");
+
+    expect(second).toContain("name: release-performance-attempt-2");
+    expect(second).toContain("needs: release_performance_attempt_1");
+    expect(second).toContain(
+      "if: needs.release_performance_attempt_1.outputs.requires_confirmation == 'true'",
+    );
+    expect(second).toContain("runs-on: ubuntu-24.04");
+    expect(second).toContain("ci-orchestrator.mjs attempt");
+    expect(second).not.toContain("ci-orchestrator.mjs finalize");
+    expect(second).not.toContain("npm run benchmark:release");
+  });
+
+  it("keeps one always-running final release-performance gate", () => {
+    const final = jobBlock("release-performance");
+    expect(workflow.match(/^  release-performance:$/gmu)).toHaveLength(1);
+    expect(final).toContain(
+      "needs: [release_performance_attempt_1, release_performance_attempt_2]",
+    );
+    expect(final).toContain("if: always()");
+    expect(final).toContain("ci-orchestrator.mjs finalize");
+    expect(final).toContain("--second-report");
+    expect(final).toContain("--second-manifest");
+    expect(final).toContain("name: release-performance-${{ github.run_attempt }}");
+  });
+
+  it("retains producer artifact identities across failed-only reruns", () => {
+    const first = jobBlock(
+      "release_performance_attempt_1",
+      "release_performance_attempt_2",
+    );
+    const second = jobBlock("release_performance_attempt_2", "release-performance");
+    const final = jobBlock("release-performance");
+
+    expect(first).toContain(
+      "artifact_name: ${{ steps.decision.outputs.artifact_name }}",
+    );
+    expect(first).toContain(
+      "artifact_name=release-performance-attempt-1-$GITHUB_RUN_ATTEMPT",
+    );
+    expect(first).toContain("name: ${{ steps.decision.outputs.artifact_name }}");
+
+    expect(second).toContain(
+      "artifact_name: ${{ steps.evidence.outputs.artifact_name }}",
+    );
+    expect(second).toContain(
+      "artifact_name=release-performance-attempt-2-$GITHUB_RUN_ATTEMPT",
+    );
+    expect(second).toContain("name: ${{ steps.evidence.outputs.artifact_name }}");
+
+    expect(final).toContain(
+      "name: ${{ needs.release_performance_attempt_1.outputs.artifact_name }}",
+    );
+    expect(final).toContain(
+      "name: ${{ needs.release_performance_attempt_2.outputs.artifact_name }}",
+    );
+    expect(workflow).toContain("retention-days: 14");
+  });
+
+  it("retains the local benchmark command", () => {
+    const packageJson = JSON.parse(readFileSync(
+      new URL("../../package.json", import.meta.url),
+      "utf8",
+    ));
+    expect(packageJson.scripts["benchmark:release"]).toContain(
+      "scripts/release-benchmark/enforce.mjs",
+    );
+  });
+});

--- a/scripts/release-benchmark/release-benchmark.test.js
+++ b/scripts/release-benchmark/release-benchmark.test.js
@@ -193,8 +193,10 @@ describe("release benchmark contract", () => {
     ]);
     expect(reportSchema.$defs.runtimeConfirmation.required).not.toContain("advisoryAssessments");
     expect(reportSchema.$defs.runtimeConfirmation.required).not.toContain("materialAssessments");
+    expect(reportSchema.$defs.runtimeConfirmation.required).not.toContain("runnerAllocations");
     expect(reportSchema.$defs.runtimeConfirmation.properties).toHaveProperty("advisoryAssessments");
     expect(reportSchema.$defs.runtimeConfirmation.properties).toHaveProperty("materialAssessments");
+    expect(reportSchema.$defs.runtimeConfirmation.properties).toHaveProperty("runnerAllocations");
     expect(reportSchema.$defs.profile.properties.fixture.required).toContain("workstreams");
     expect(reportSchema.$defs.profile.properties.fixture.required).not.toContain("inboxDrafts");
     expect(reportSchema.$defs.profile.properties.fixture.required).not.toContain("inboxProposals");
@@ -343,6 +345,24 @@ describe("release benchmark contract", () => {
         confirmedViolations: [secondAdvisory],
         advisoryAssessments: [advisoryAssessment],
         materialAssessments: [],
+        runnerAllocations: {
+          first: {
+            runId: "12345",
+            runAttempt: "2",
+            job: "release_performance_attempt_1",
+            runnerName: "Hosted Agent 1",
+            runnerOs: "Linux",
+            runnerArch: "X64",
+          },
+          second: {
+            runId: "12345",
+            runAttempt: "2",
+            job: "release_performance_attempt_2",
+            runnerName: "Hosted Agent 2",
+            runnerOs: "Linux",
+            runnerArch: "X64",
+          },
+        },
       },
     });
     expect(validate(advisoryReport), JSON.stringify(validate.errors)).toBe(true);

--- a/scripts/release-benchmark/report.schema.json
+++ b/scripts/release-benchmark/report.schema.json
@@ -307,7 +307,30 @@
         "secondPassViolations": { "$ref": "#/$defs/violations" },
         "confirmedViolations": { "$ref": "#/$defs/violations" },
         "advisoryAssessments": { "$ref": "#/$defs/advisoryAssessments" },
-        "materialAssessments": { "$ref": "#/$defs/materialAssessments" }
+        "materialAssessments": { "$ref": "#/$defs/materialAssessments" },
+        "runnerAllocations": { "$ref": "#/$defs/runnerAllocations" }
+      }
+    },
+    "runnerAllocations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["first"],
+      "properties": {
+        "first": { "$ref": "#/$defs/runnerAllocation" },
+        "second": { "$ref": "#/$defs/runnerAllocation" }
+      }
+    },
+    "runnerAllocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runId", "runAttempt", "job", "runnerName", "runnerOs", "runnerArch"],
+      "properties": {
+        "runId": { "type": "string", "pattern": "^[1-9][0-9]{0,19}$" },
+        "runAttempt": { "type": "string", "pattern": "^[1-9][0-9]{0,19}$" },
+        "job": { "type": "string", "pattern": "^[A-Za-z0-9_.-]{1,128}$" },
+        "runnerName": { "type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[^\\r\\n\\u0000]+$" },
+        "runnerOs": { "type": "string", "minLength": 1, "maxLength": 32, "pattern": "^[^\\r\\n\\u0000]+$" },
+        "runnerArch": { "type": "string", "minLength": 1, "maxLength": 32, "pattern": "^[^\\r\\n\\u0000]+$" }
       }
     },
     "advisoryAssessments": {


### PR DESCRIPTION
## Summary

- run the first release-performance measurement in its own pinned Ubuntu 24.04 / Node 22.22 job
- allocate a second GitHub-hosted job only when the existing materiality policy requests confirmation
- aggregate bounded, digest-bound reports in the stable release-performance gate
- preserve deterministic failures, exact-metric confirmation, existing budgets, and the local benchmark command
- retain producer artifact identities across GitHub failed-only reruns while rejecting cross-run, cross-SHA, future, malformed, or reused-job evidence

## Why

The previous confirmation passes ran back-to-back on one hosted VM. Retained CI evidence showed identical repository content oscillating across materially different Graph, Wiki, and Search failure sets, so sustained runner contention could satisfy both sides of the confirmation rule.

GitHub-hosted jobs provide the independent runner allocation the policy intended. This PR changes only CI orchestration and evidence validation; release-performance budgets, sample counts, thresholds, and formulas are unchanged.

## Validation

- Node 22 focused release-performance tests: 49/49 passed
- npm run typecheck: passed
- npm run build: passed
- asset-only release benchmark: passed
- workflow YAML parse, Node syntax check, and git diff --check: passed
- full local Vitest run: 2,967 passed, 1 skipped, and 7 fixed 15-second timeouts under parallel load
- both timeout-affected contract files passed independently: 82/82
- independent review found no P0-P2 issues

No Graph, Wiki, Hub, skill, or budget implementation files are changed.
