### PR TITLE
Complete fresh setup onboarding through Hub readiness

### DIFF
--- a/.mex/.tool-configs/CLAUDE.md
+++ b/.mex/.tool-configs/CLAUDE.md
@@ -59,6 +59,7 @@ For full project context, patterns, and task guidance — everything is there.
 
 <!-- mex-agent:skills:start -->
 ## MEX agent skills
+- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.
 - Use `/mex-inbox` for durable governed Spec proposals and `/mex-relay` for durable team handoffs. Invoke them automatically when intent clearly matches; explicit invocation remains available.
 - When MEX context materially influences an answer or implementation, include one concise acknowledgement: `MEX context used: <specific records/files/entities consulted>.`
 - Do not claim an author, date, or historical event unless the retrieved data actually provides it.

--- a/.mex/ROUTER.md
+++ b/.mex/ROUTER.md
@@ -14,7 +14,7 @@ edges:
     condition: when setting up the dev environment or running the project for the first time
   - target: patterns/INDEX.md
     condition: when starting a task — check the pattern index for a matching pattern file
-last_updated: 2026-09-01
+last_updated: 2026-09-02
 ---
 
 # Session Bootstrap
@@ -26,6 +26,11 @@ Then read this file fully before doing anything else in this session.
 ## Current Project State
 
 **Working:**
+- Fresh-user setup is now a release-complete path: it preserves authored
+  scaffold files, protects disposable Graph/Wiki/local state from Git, launches
+  the first selected available Claude Code or Codex CLI from the repository
+  root, captures grounding, migrates and indexes Wiki content, validates the
+  result, and prints the required canonical commit checkpoint before Hub.
 - MEX v0.7.3 graph extraction and protocol-v3 JSONL behavior, including
   sequential TypeScript programs, compiler crash isolation, explicit WASM tree
   disposal, compact fingerprints/LSH, and bounded repair.

--- a/.mex/SETUP.md
+++ b/.mex/SETUP.md
@@ -10,11 +10,14 @@ This scaffold is currently empty. Follow the steps below to populate it for your
 mex setup
 ```
 
-The command handles everything automatically:
-1. Detects your project state (existing codebase, fresh project, or partial)
-2. Asks which AI tool you use and installs the right project instructions
-3. Pre-scans your codebase with `mex init` to build a structured brief (~5-8k tokens vs ~50k from AI exploration)
-4. Builds and runs the population prompt — or prints it for manual paste
+The command handles the setup workflow:
+1. Detects your project state without overwriting existing scaffold files
+2. Protects `.mex/graph.db*`, `.mex/wiki.db*`, and `.mex/local/` from Git
+3. Asks which AI tool you use and installs the right project instructions
+4. Scans the codebase and builds the local code graph
+5. Launches the first selected available Claude Code or Codex CLI, or prints the prompt for manual paste
+6. Captures grounding, migrates the populated Markdown, builds the Wiki index, and validates it
+7. Prints the canonical files to review and commit before running `mex hub`
 
 For Claude Code and Codex, setup also copies the packaged `mex-inbox` and
 `mex-relay` skills into the project. No plugin or separate skill installer is
@@ -222,6 +225,11 @@ Codex uses `$mex-inbox` and `$mex-relay`. Clear natural-language requests work
 too. Commit the project skill copies so teammates receive them; MEX never
 stages, commits, or pushes them automatically.
 
+Setup prints the scoped Git commands for the selected tools. Review those files
+and commit them before running `mex hub`; Hub requires `.mex/config.json` to
+match the version committed at the current Git `HEAD`. The local Graph/Wiki
+databases and `.mex/local/` remain ignored.
+
 **Verify** by starting a fresh session and asking your agent:
 "Read `.mex/ROUTER.md` and tell me what you now know about this project."
 
@@ -236,6 +244,6 @@ A well-populated scaffold should give the agent enough to:
 Once the scaffold is populated, use these to keep it aligned with your codebase:
 
 - **`mex check`** — detect drift (zero tokens, zero AI)
-- **`.mex/sync.sh`** — interactive drift check + targeted or full resync
+- **`mex sync`** — interactive drift check + targeted resync
 - **`mex skills sync`** — safely receive updated official agent skills after a package upgrade
 - **`mex watch`** — auto drift score after every commit

--- a/.mex/SYNC.md
+++ b/.mex/SYNC.md
@@ -1,12 +1,12 @@
 # Sync — Realign This Scaffold
 
-## Recommended: Use sync.sh
+## Recommended: Use `mex sync`
 
 ```bash
-.mex/sync.sh
+mex sync
 ```
 
-The script runs drift detection first, shows you exactly what's wrong, then offers:
+The command runs drift detection first, shows you exactly what's wrong, then offers:
 1. **Targeted sync** — AI fixes only the flagged files (fastest, cheapest)
 2. **Full resync** — AI re-reads everything and updates all scaffold files
 3. **Prompt export** — shows the prompts for manual paste

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 <!-- mex-agent:skills:start -->
 ## MEX agent skills
+- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.
 - Use `$mex-inbox` for durable governed Spec proposals and `$mex-relay` for durable team handoffs. Invoke them automatically when intent clearly matches; explicit invocation remains available.
 - When MEX context materially influences an answer or implementation, include one concise acknowledgement: `MEX context used: <specific records/files/entities consulted>.`
 - Do not claim an author, date, or historical event unless the retrieved data actually provides it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ All notable changes to this project will be documented in this file.
   overwriting user instructions, modified managed copies, or unrelated skills.
 
 ### Changed
+- `mex setup` now preserves existing scaffold files, launches the first selected
+  available Claude Code or Codex CLI from the project root, completes Wiki
+  migration/indexing after population, and stops at an explicit Git commit
+  checkpoint before Hub.
 - The integration graph uses schema v4: v0.7.3's compact BLOB fingerprints and
   integer-reference LSH storage combined with subject-generalized Wiki
   grounding. The v0.7.3 sequential compiler, crash isolation, fallback, and
@@ -37,6 +41,19 @@ All notable changes to this project will be documented in this file.
   same-directory candidate instead of mutating the published database in place.
 - Inbox and Relay contracts now support bounded action-scoped discovery while
   preserving the existing complete contract catalogs for compatibility.
+
+### Fixed
+- Fresh setup now installs and verifies ignore protection for Graph/Wiki
+  databases and `.mex/local/`, refuses broad rules that hide canonical config,
+  and no longer overwrites authored files merely because they contain template
+  examples or date placeholders.
+- Setup now refuses malformed or redirected canonical config, publishes config
+  updates atomically, honors Wiki exclude/read-only scope, and blocks readiness
+  when authored grounding cannot be verified.
+- Claude Code and Codex population now uses an ignored prompt file with a short
+  launcher argument, avoiding Windows command-line length limits.
+- New Claude Code and Codex root instructions bootstrap `.mex/AGENTS.md` and
+  `.mex/ROUTER.md` on later sessions instead of installing only skill policy.
 
 ### Compatibility
 - Explicit graph maintenance recognizes v1, v2, released-main v3,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 <!-- mex-agent:skills:start -->
 ## MEX agent skills
+- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.
 - Use `/mex-inbox` for durable governed Spec proposals and `/mex-relay` for durable team handoffs. Invoke them automatically when intent clearly matches; explicit invocation remains available.
 - When MEX context materially influences an answer or implementation, include one concise acknowledgement: `MEX context used: <specific records/files/entities consulted>.`
 - Do not claim an author, date, or historical event unless the retrieved data actually provides it.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ mex requires Node.js 22.5 or newer. The npm package is named `mex-agent` because
 npx mex-agent setup
 ```
 
-Setup inspects the repository, builds the local code graph, creates the Markdown wiki, asks your coding agent to populate it from graph evidence, installs the right project anchor and official MEX skills, and validates the result.
+Setup protects checkout-local databases from Git, builds the code graph, asks your selected Claude Code or Codex CLI to populate the Markdown scaffold, migrates and indexes the Wiki, installs the project anchor and official MEX skills, and validates the result. It then prints the commit checkpoint required before Hub can start.
 
 ### Official Claude Code and Codex skills
 
@@ -231,7 +231,7 @@ The `mex-agent` npm package ships two official project skills from one canonical
 - `mex-inbox` prepares governed Spec, requirement, constraint, and acceptance-criterion proposals.
 - `mex-relay` prepares durable team handoffs.
 
-The normal `mex setup` flow installs copies for every selected supported agent; no separate plugin or skill installer is required. Claude Code receives `.claude/skills/mex-inbox` and `.claude/skills/mex-relay`, while Codex receives `.agents/skills/mex-inbox` and `.agents/skills/mex-relay`. Selecting both agents installs both sets and updates only the marker-delimited MEX block in `CLAUDE.md` and `AGENTS.md`.
+The normal `mex setup` flow installs copies for every selected supported agent; no separate plugin or skill installer is required. Claude Code receives `.claude/skills/mex-inbox` and `.claude/skills/mex-relay`, while Codex receives `.agents/skills/mex-inbox` and `.agents/skills/mex-relay`. Selecting both agents installs both sets and updates only the marker-delimited MEX block in `CLAUDE.md` and `AGENTS.md`. That managed block also directs every new agent session to read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work.
 
 Invoke the skills explicitly as `/mex-inbox` and `/mex-relay` in Claude Code, or `$mex-inbox` and `$mex-relay` in Codex. Clear natural-language requests for governed Spec proposals or durable handoffs invoke them automatically as well.
 
@@ -249,10 +249,13 @@ A standalone Codex plugin or marketplace package may be added later, but it is n
 After setup:
 
 ```bash
+git status --short            # Review the canonical MEX files
+git add .mex                  # Local Graph/Wiki databases stay ignored
+git commit -m "chore: initialize MEX"
 mex check                    # Check wiki health and code grounding
 mex sync                     # Repair drift with targeted agent prompts
 mex graph scope "<task>"     # Retrieve compact task context
-mex hub                      # Open the local Project Hub
+mex hub                      # Opens after .mex/config.json is committed at HEAD
 ```
 
 If you skipped global installation, use `npx mex-agent` in place of `mex`. Install globally at any time with:

--- a/scripts/hub-pack-smoke.mjs
+++ b/scripts/hub-pack-smoke.mjs
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -9,10 +10,11 @@ import {
   readdirSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -38,6 +40,7 @@ try {
   const packResult = parsePackResult(packOutput);
   const tarball = join(work, basename(packResult.filename));
   verifyPackedSkillTrees(packResult);
+  await verifyFreshCodeRepoSetup(tarball, work, npmCache, packResult.version);
   const project = join(work, "project");
   mkdirSync(join(project, ".mex"), { recursive: true });
   writeFileSync(join(project, "package.json"), "{\n  \"private\": true\n}\n");
@@ -167,6 +170,7 @@ try {
   const setupOutput = await runInteractiveAgentSetup(cli, project, work);
   verifyPackedSetupOutput(setupOutput);
   verifySetupConfig(project);
+  verifySetupIgnoreProtection(project);
   verifyInstalledAgentAssets(project, installed, installedPackageVersion);
   if (
     run("git", ["rev-parse", "HEAD"], project).trim() !== beforeSetupHead
@@ -860,13 +864,200 @@ function parsePackResult(output) {
   return result;
 }
 
+async function verifyFreshCodeRepoSetup(tarball, workRoot, cache, version) {
+  const project = join(workRoot, "fresh-setup-project");
+  mkdirSync(join(project, "src"), { recursive: true });
+  writeFileSync(join(project, "package.json"), "{\n  \"private\": true\n}\n");
+  writeFileSync(join(project, ".gitignore"), "node_modules/\n");
+  writeFileSync(join(project, "src", "index.ts"), [
+    "export function freshSetupValue(): number {",
+    "  return 42;",
+    "}",
+    "",
+  ].join("\n"));
+  run("git", ["init", "--quiet"], project);
+  run("git", ["config", "user.name", "Fresh Setup"], project);
+  run("git", ["config", "user.email", "fresh-setup@example.test"], project);
+  run("git", ["add", ".gitignore", "package.json", "src"], project);
+  run("git", ["commit", "--quiet", "-m", "initial fixture"], project);
+
+  runNpm([
+    "install",
+    tarball,
+    "--no-audit",
+    "--no-fund",
+    "--omit=dev",
+    "--cache",
+    cache,
+  ], project);
+  if (existsSync(join(project, ".mex")) || existsSync(join(project, "AGENTS.md"))) {
+    throw new Error("Plain packed install mutated the fresh setup project.");
+  }
+
+  const installed = join(project, "node_modules", "mex-agent");
+  const installedVersion = JSON.parse(readFileSync(join(installed, "package.json"), "utf8")).version;
+  if (installedVersion !== version) throw new Error("Fresh setup installed the wrong packed version.");
+  const cli = join(installed, "dist", "cli.js");
+  const agentBin = join(workRoot, "fresh-setup-agent-bin");
+  mkdirSync(agentBin, { recursive: true });
+  installFakeCodex(agentBin, workRoot);
+
+  const beforeHead = run("git", ["rev-parse", "HEAD"], project).trim();
+  const output = await runFreshCodeRepoSetup(cli, project, agentBin);
+  const normalized = output.replace(/\u001b\[[0-?]*[ -/]*[@-~]/gu, "");
+  for (const expected of [
+    "Codex finished the population session",
+    "Wiki migration and index are ready.",
+    "Graph and Wiki are ready. Setup is ready to commit.",
+  ]) {
+    if (!normalized.includes(expected)) {
+      throw new Error(`Packed fresh setup omitted: ${expected}\n${normalized}`);
+    }
+  }
+  if (
+    run("git", ["rev-parse", "HEAD"], project).trim() !== beforeHead
+    || run("git", ["diff", "--cached", "--name-only"], project).trim().length !== 0
+  ) {
+    throw new Error("Fresh packed setup staged or committed changes automatically.");
+  }
+
+  const config = JSON.parse(readFileSync(join(project, ".mex", "config.json"), "utf8"));
+  if (JSON.stringify(config.aiTools) !== JSON.stringify(["codex"])) {
+    throw new Error("Fresh packed setup did not persist the selected Codex client.");
+  }
+  for (const file of [
+    "AGENTS.md",
+    "ROUTER.md",
+    "context/architecture.md",
+    "context/stack.md",
+    "context/conventions.md",
+    "context/decisions.md",
+    "context/setup.md",
+  ]) {
+    const content = readFileSync(join(project, ".mex", file), "utf8");
+    if (content.includes("[Project Name]") || content.includes("[YYYY-MM-DD]")) {
+      throw new Error(`Fake Codex population left a required placeholder in ${file}.`);
+    }
+  }
+  for (const database of ["graph.db", "wiki.db"]) {
+    if (!existsSync(join(project, ".mex", database))) {
+      throw new Error(`Fresh packed setup omitted .mex/${database}.`);
+    }
+  }
+  verifySetupIgnoreProtection(project);
+  const wiki = JSON.parse(run(process.execPath, [cli, "wiki", "list", "--json"], project));
+  if (wiki?.ok !== true || !Array.isArray(wiki?.data?.entities) || wiki.data.entities.length === 0) {
+    throw new Error("Fresh packed setup did not publish a readable Wiki index.");
+  }
+
+  run("git", ["add", ".mex", "AGENTS.md", ".agents"], project);
+  const staged = run("git", ["diff", "--cached", "--name-only"], project);
+  if (/\.mex\/(?:graph|wiki)\.db|\.mex\/local\//u.test(staged)) {
+    throw new Error(`Fresh packed setup staged checkout-local state:\n${staged}`);
+  }
+  run("git", ["commit", "--quiet", "-m", "initialize MEX"], project);
+  const committedConfig = run("git", ["show", "HEAD:.mex/config.json"], project);
+  if (committedConfig !== readFileSync(join(project, ".mex", "config.json"), "utf8")) {
+    throw new Error("Fresh packed setup config does not match current HEAD.");
+  }
+  const capabilities = JSON.parse(run(process.execPath, [cli, "capabilities", "--json"], project));
+  for (const id of ["project_hub", "code_graph", "wiki"]) {
+    const capability = capabilities?.data?.capabilities?.find((entry) => entry?.id === id);
+    if (capability?.availability !== "available") {
+      throw new Error(`Fresh packed setup left ${id} unavailable after the canonical commit.`);
+    }
+  }
+}
+
+function installFakeCodex(directory, workRoot) {
+  const script = join(workRoot, "fake-codex-populate.mjs");
+  writeFileSync(script, [
+    'import { readFileSync, readdirSync, writeFileSync } from "node:fs";',
+    'import { join } from "node:path";',
+    'const root = join(process.cwd(), ".mex");',
+    'const visit = (directory) => {',
+    '  for (const entry of readdirSync(directory, { withFileTypes: true })) {',
+    '    const path = join(directory, entry.name);',
+    '    if (entry.isDirectory()) visit(path);',
+    '    else if (entry.isFile() && entry.name.endsWith(".md")) {',
+    '      const content = readFileSync(path, "utf8")',
+    '        .replaceAll("[Project Name]", "Packed First Run")',
+    '        .replaceAll("[YYYY-MM-DD]", "2026-09-02");',
+    '      writeFileSync(path, content, "utf8");',
+    '    }',
+    '  }',
+    '};',
+    'visit(root);',
+    'process.stdout.write("fake Codex populated the scaffold\\n");',
+    '',
+  ].join("\n"), "utf8");
+  if (process.platform === "win32") {
+    writeFileSync(join(directory, "codex.cmd"), `@"${process.execPath}" "${script}" %*\r\n`, "utf8");
+  } else {
+    const command = join(directory, "codex");
+    writeFileSync(command, `#!/bin/sh\nexec "${process.execPath}" "${script}" "$@"\n`, "utf8");
+    chmodSync(command, 0o755);
+  }
+}
+
+function runFreshCodeRepoSetup(cli, project, agentBin) {
+  const env = {
+    ...process.env,
+    MEX_TELEMETRY: "0",
+    NO_COLOR: "1",
+    PATH: `${agentBin}${delimiter}${process.env.PATH ?? ""}`,
+  };
+  return new Promise((resolveOutput, reject) => {
+    const setup = spawn(process.execPath, [cli, "setup"], {
+      cwd: project,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let selected = false;
+    let settled = false;
+    const finish = (error, output) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (error) reject(error);
+      else resolveOutput(output);
+    };
+    const timer = setTimeout(() => {
+      if (setup.exitCode === null) setup.kill("SIGKILL");
+      finish(new Error(`Timed out running packed fresh setup.\n${stdout}\n${stderr}`));
+    }, 120_000);
+    setup.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+      if (!selected && stdout.includes("Choice [1-8] (default: 1):")) {
+        selected = true;
+        setup.stdin.end("6\n");
+      }
+    });
+    setup.stderr.on("data", (chunk) => { stderr += chunk.toString("utf8"); });
+    setup.on("error", (error) => finish(error));
+    setup.on("close", (code, signal) => {
+      if (code !== 0 || signal !== null || !selected) {
+        finish(new Error(
+          `Packed fresh setup failed (exit ${String(code)}, signal ${String(signal)}).\n${stdout}\n${stderr}`,
+        ));
+        return;
+      }
+      finish(null, stdout);
+    });
+  });
+}
+
 function runInteractiveAgentSetup(cli, project, workRoot) {
   const emptyPath = join(workRoot, "empty-agent-path");
   mkdirSync(emptyPath, { recursive: true });
+  installGitOnlyPath(emptyPath);
 
   // Keep the packed smoke independent from developer-machine agent installs.
-  // The CLI itself is launched through an absolute Node path, while an empty
-  // PATH makes the setup flow reliably choose its manual-population branch.
+  // The CLI itself is launched through an absolute Node path. PATH contains
+  // only Git, which setup needs for ignore verification, so agent discovery
+  // reliably chooses the manual-population branch.
   const env = { ...process.env, MEX_TELEMETRY: "0", NO_COLOR: "1" };
   for (const key of Object.keys(env)) {
     if (key.toLowerCase() === "path") delete env[key];
@@ -883,7 +1074,6 @@ function runInteractiveAgentSetup(cli, project, workRoot) {
     let stderr = "";
     let choseMultiple = false;
     let choseClients = false;
-    let declinedGlobalInstall = false;
     let settled = false;
 
     const fail = (error) => {
@@ -908,10 +1098,6 @@ function runInteractiveAgentSetup(cli, project, workRoot) {
       if (!choseClients && stdout.includes("Enter tool numbers separated by spaces")) {
         choseClients = true;
         answer("1 6");
-      }
-      if (!declinedGlobalInstall && stdout.includes("Install mex globally? [Y/n]")) {
-        declinedGlobalInstall = true;
-        answer("n");
         setup.stdin.end();
       }
     };
@@ -938,7 +1124,6 @@ function runInteractiveAgentSetup(cli, project, workRoot) {
         || signal !== null
         || !choseMultiple
         || !choseClients
-        || !declinedGlobalInstall
       ) {
         reject(new Error(
           `The packed interactive setup did not complete all expected prompts `
@@ -949,6 +1134,20 @@ function runInteractiveAgentSetup(cli, project, workRoot) {
       resolveOutput(stdout);
     });
   });
+}
+
+function installGitOnlyPath(directory) {
+  const locator = process.platform === "win32" ? "where.exe" : "which";
+  const located = spawnSync(locator, ["git"], { encoding: "utf8" });
+  const executable = located.status === 0
+    ? located.stdout.split(/\r?\n/u).find((line) => line.trim().length > 0)?.trim()
+    : undefined;
+  if (!executable) throw new Error("The packed setup smoke could not locate Git.");
+  if (process.platform === "win32") {
+    writeFileSync(join(directory, "git.cmd"), `@"${executable}" %*\r\n`, "utf8");
+  } else {
+    symlinkSync(executable, join(directory, "git"));
+  }
 }
 
 function verifyPackedSetupOutput(output) {
@@ -984,6 +1183,21 @@ function verifySetupConfig(project) {
     })
   ) {
     throw new Error("The packed interactive setup did not persist both clients without changing existing config.");
+  }
+}
+
+function verifySetupIgnoreProtection(project) {
+  const content = readFileSync(join(project, ".mex", ".gitignore"), "utf8");
+  for (const rule of ["graph.db*", "wiki.db*", "local/"]) {
+    if (!content.split(/\r?\n/u).includes(rule)) {
+      throw new Error(`Packed setup omitted ${rule} from .mex/.gitignore.`);
+    }
+  }
+  for (const path of [".mex/graph.db-wal", ".mex/wiki.db-shm", ".mex/local/team.db"]) {
+    const ignored = spawnSync("git", ["check-ignore", "--no-index", "--quiet", "--", path], {
+      cwd: project,
+    });
+    if (ignored.status !== 0) throw new Error(`Packed setup left ${path} trackable.`);
   }
 }
 

--- a/src/agent-skills/__tests__/instructions.test.ts
+++ b/src/agent-skills/__tests__/instructions.test.ts
@@ -15,6 +15,9 @@ describe("managed MEX instruction blocks", () => {
     const codex = renderManagedInstructionBlock("codex");
 
     for (const block of [claude, codex]) {
+      expect(block).toContain(
+        "At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md`",
+      );
       expect(block).toContain("durable governed Spec proposals");
       expect(block).toContain("durable team handoffs");
       expect(block).toContain("Invoke them automatically when intent clearly matches");

--- a/src/agent-skills/instructions.ts
+++ b/src/agent-skills/instructions.ts
@@ -53,6 +53,7 @@ export function renderManagedInstructionBlock(
   return [
     MEX_INSTRUCTIONS_START,
     "## MEX agent skills",
+    "- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.",
     `- Use \`${inbox}\` for durable governed Spec proposals and \`${relay}\` for durable team handoffs. Invoke them automatically when intent clearly matches; explicit invocation remains available.`,
     "- When MEX context materially influences an answer or implementation, include one concise acknowledgement: `MEX context used: <specific records/files/entities consulted>.`",
     "- Do not claim an author, date, or historical event unless the retrieved data actually provides it.",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, rmSync } from "node:fs";
 import { resolve, dirname, isAbsolute, basename } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { MexConfig, AiTool, StalenessThresholds, WatchConfig, HeartbeatConfig, ScaffoldIdentity, WikiConfig, WikiSynthesisConfig } from "./types.js";
@@ -346,8 +346,15 @@ function mergeIntoConfig(scaffoldRoot: string, patch: Record<string, unknown>): 
     } catch { /* start fresh */ }
   }
   Object.assign(existing, patch);
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, JSON.stringify(existing, null, 2) + "\n");
+  const configDirectory = dirname(configPath);
+  mkdirSync(configDirectory, { recursive: true });
+  const stagedPath = resolve(configDirectory, `.config.json.mex-stage-${randomUUID()}`);
+  try {
+    writeFileSync(stagedPath, JSON.stringify(existing, null, 2) + "\n", { flag: "wx" });
+    renameSync(stagedPath, configPath);
+  } finally {
+    rmSync(stagedPath, { force: true });
+  }
 }
 
 export function saveAiTools(scaffoldRoot: string, tools: AiTool[]): void {

--- a/src/setup/__tests__/ignore.test.ts
+++ b/src/setup/__tests__/ignore.test.ts
@@ -1,0 +1,186 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ensureSetupIgnoreProtection,
+  renderSetupIgnoreProtection,
+  SetupIgnoreProtectionError,
+  verifySetupIgnoreProtection,
+} from "../ignore.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("setup local-data ignore protection", () => {
+  it("creates .mex/.gitignore with all required rules", () => {
+    const root = fixture();
+
+    const result = ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(result).toEqual({
+      path: ".mex/.gitignore",
+      action: "create",
+      dryRun: false,
+      applied: true,
+      changed: true,
+      addedRules: ["graph.db*", "wiki.db*", "local/"],
+    });
+    expect(readIgnore(root)).toBe("graph.db*\nwiki.db*\nlocal/\n");
+    expect(renderSetupIgnoreProtection(result)).toBe(
+      "Created .mex/.gitignore with graph.db*, wiki.db*, local/",
+    );
+  });
+
+  it("preserves existing content and appends only missing rules", () => {
+    const root = fixtureWithMex();
+    writeIgnore(root, "# User rule\ngraph.db*\n*.scratch\n");
+
+    const result = ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(result).toMatchObject({
+      action: "update",
+      addedRules: ["wiki.db*", "local/"],
+    });
+    expect(readIgnore(root)).toBe(
+      "# User rule\ngraph.db*\n*.scratch\nwiki.db*\nlocal/\n",
+    );
+  });
+
+  it("uses the existing CRLF style for appended rules", () => {
+    const root = fixtureWithMex();
+    const before = "# User rule\r\ngraph.db*\r\n";
+    writeIgnore(root, before);
+
+    ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(readIgnore(root)).toBe(`${before}wiki.db*\r\nlocal/\r\n`);
+  });
+
+  it("adds one separator when an existing file has no final newline", () => {
+    const root = fixtureWithMex();
+    writeIgnore(root, "# User rule");
+
+    ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(readIgnore(root)).toBe(
+      "# User rule\ngraph.db*\nwiki.db*\nlocal/\n",
+    );
+  });
+
+  it("retains existing duplicate lines without adding another required rule", () => {
+    const root = fixtureWithMex();
+    const before = "graph.db*\ngraph.db*\nwiki.db*\n";
+    writeIgnore(root, before);
+
+    const result = ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(result.addedRules).toEqual(["local/"]);
+    expect(readIgnore(root)).toBe(`${before}local/\n`);
+  });
+
+  it("is a byte-preserving no-op on rerun", () => {
+    const root = fixture();
+    ensureSetupIgnoreProtection({ projectRoot: root });
+    const afterFirstRun = readFileSync(join(root, ".mex/.gitignore"));
+
+    const result = ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(result).toMatchObject({
+      action: "unchanged",
+      applied: false,
+      changed: false,
+      addedRules: [],
+    });
+    expect(readFileSync(join(root, ".mex/.gitignore"))).toEqual(afterFirstRun);
+  });
+
+  it("reports a dry run without creating files", () => {
+    const root = fixture();
+
+    const result = ensureSetupIgnoreProtection({ projectRoot: root, dryRun: true });
+
+    expect(result).toMatchObject({
+      action: "create",
+      dryRun: true,
+      applied: false,
+      changed: true,
+    });
+    expect(existsSync(join(root, ".mex"))).toBe(false);
+    expect(renderSetupIgnoreProtection(result)).toContain("Would create");
+  });
+
+  it("fails closed when .mex/.gitignore is a symlink", () => {
+    const root = fixtureWithMex();
+    const outside = join(fixture(), "outside.gitignore");
+    writeFileSync(outside, "outside\n");
+    symlinkSync(outside, join(root, ".mex/.gitignore"), "file");
+
+    expect(() => ensureSetupIgnoreProtection({ projectRoot: root })).toThrow(
+      SetupIgnoreProtectionError,
+    );
+    expect(readFileSync(outside, "utf8")).toBe("outside\n");
+  });
+
+  it("fails closed when .mex/.gitignore is not a regular file", () => {
+    const root = fixtureWithMex();
+    mkdirSync(join(root, ".mex/.gitignore"));
+
+    expect(() => ensureSetupIgnoreProtection({ projectRoot: root })).toThrow(
+      SetupIgnoreProtectionError,
+    );
+  });
+
+  it("verifies derived files are ignored and canonical config remains trackable", () => {
+    const root = fixture();
+    initGit(root);
+    ensureSetupIgnoreProtection({ projectRoot: root });
+
+    expect(() => verifySetupIgnoreProtection(root)).not.toThrow();
+  });
+
+  it("rejects a broad root rule that hides canonical MEX files", () => {
+    const root = fixture();
+    initGit(root);
+    ensureSetupIgnoreProtection({ projectRoot: root });
+    writeFileSync(join(root, ".gitignore"), ".mex/\n", "utf8");
+
+    expect(() => verifySetupIgnoreProtection(root)).toThrow(/hides \.mex\/config\.json/u);
+  });
+});
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-setup-ignore-"));
+  roots.push(root);
+  return root;
+}
+
+function fixtureWithMex(): string {
+  const root = fixture();
+  mkdirSync(join(root, ".mex"));
+  return root;
+}
+
+function writeIgnore(root: string, content: string): void {
+  writeFileSync(join(root, ".mex/.gitignore"), content, "utf8");
+}
+
+function readIgnore(root: string): string {
+  return readFileSync(join(root, ".mex/.gitignore"), "utf8");
+}
+
+function initGit(root: string): void {
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+}

--- a/src/setup/__tests__/population.test.ts
+++ b/src/setup/__tests__/population.test.ts
@@ -1,0 +1,110 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  launchSetupPopulation,
+  selectSetupAgent,
+  SetupPopulationError,
+} from "../population.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("setup population launcher", () => {
+  it("launches the first selected available supported agent", () => {
+    const available = vi.fn((command: string) => command === "codex");
+    expect(selectSetupAgent(["claude", "codex"], available)).toBe("codex");
+    expect(available).toHaveBeenCalledWith("claude");
+    expect(available).toHaveBeenCalledWith("codex");
+  });
+
+  it("never falls back to an unselected agent", () => {
+    expect(selectSetupAgent(["cursor"], () => true)).toBeNull();
+  });
+
+  it("keeps a large prompt off argv while the agent can read every byte", () => {
+    const project = fixture();
+    const prompt = `# Population\n\n${"x".repeat(12 * 1024)}\n`;
+    const run = vi.fn((_tool: string, instruction: string, cwd: string) => {
+      expect(Buffer.byteLength(instruction, "utf8")).toBeLessThan(256);
+      const pointer = /`([^`]+)`/u.exec(instruction)?.[1];
+      expect(pointer).toBeDefined();
+      expect(readFileSync(join(cwd, pointer!), "utf8")).toBe(prompt);
+      return true;
+    });
+
+    expect(launchSetupPopulation(["codex"], prompt, project, {
+      isAvailable: () => true,
+      run,
+    })).toEqual({ tool: "codex", completed: true });
+    expect(run).toHaveBeenCalledWith(
+      "codex",
+      expect.stringMatching(/^Read the full setup population prompt from `\.mex\/local\/setup-population-[^/]+\/prompt\.md`/u),
+      project,
+      { timeoutMs: null },
+    );
+    expect(readdirSync(join(project, ".mex", "local"))).toEqual([]);
+  });
+
+  it("reports unavailable and failed launches without pretending population completed", () => {
+    const unavailableProject = fixture();
+    expect(launchSetupPopulation(["codex"], "prompt", unavailableProject, {
+      isAvailable: () => false,
+    })).toEqual({ tool: null, completed: false });
+
+    const failedProject = fixture();
+    expect(launchSetupPopulation(["claude"], "prompt", failedProject, {
+      isAvailable: () => true,
+      run: () => false,
+    })).toEqual({ tool: "claude", completed: false });
+    expect(readdirSync(join(failedProject, ".mex", "local"))).toEqual([]);
+    expect(() => readdirSync(join(unavailableProject, ".mex", "local"))).toThrow();
+  });
+
+  it("removes its private prompt when the runner throws", () => {
+    const project = fixture();
+    expect(() => launchSetupPopulation(["codex"], "secret prompt", project, {
+      isAvailable: () => true,
+      run: () => { throw new Error("runner failed"); },
+    })).toThrow("runner failed");
+    expect(readdirSync(join(project, ".mex", "local"))).toEqual([]);
+  });
+
+  it.each(["symlink", "file"] as const)("fails closed when .mex/local is a %s", (kind) => {
+    const project = fixture();
+    const local = join(project, ".mex", "local");
+    if (kind === "symlink") {
+      const outside = mkdtempSync(join(tmpdir(), "mex-population-outside-"));
+      roots.push(outside);
+      symlinkSync(outside, local, "dir");
+    } else {
+      writeFileSync(local, "not a directory\n", "utf8");
+    }
+    const run = vi.fn(() => true);
+
+    expect(() => launchSetupPopulation(["codex"], "prompt", project, {
+      isAvailable: () => true,
+      run,
+    })).toThrow(SetupPopulationError);
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-setup-population-"));
+  roots.push(root);
+  mkdirSync(join(root, ".mex"));
+  return root;
+}

--- a/src/setup/__tests__/state.test.ts
+++ b/src/setup/__tests__/state.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  detectProjectState,
+  assertGroundingCaptureReady,
+  ensureScaffoldFile,
+  isScaffoldPopulated,
+  verifyExistingSetupConfig,
+} from "../index.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("setup state and scaffold ownership", () => {
+  it("treats even a small codebase as existing", () => {
+    const root = fixture();
+    mkdirSync(join(root, "src"));
+    writeFileSync(join(root, "src", "index.ts"), "export const ready = true;\n");
+    expect(detectProjectState(root, join(root, ".mex"))).toBe("existing");
+  });
+
+  it("recognizes a fully populated scaffold and rejects remaining placeholders", () => {
+    const root = fixture();
+    const mex = join(root, ".mex");
+    writePopulatedScaffold(mex);
+    expect(isScaffoldPopulated(mex)).toBe(true);
+    writeFileSync(join(mex, "context", "setup.md"), "last_updated: [YYYY-MM-DD]\n");
+    expect(isScaffoldPopulated(mex)).toBe(false);
+  });
+
+  it("never overwrites an existing scaffold file on rerun", () => {
+    const root = fixture();
+    const source = join(root, "template.md");
+    const destination = join(root, ".mex", "context", "setup.md");
+    writeFileSync(source, "template\n");
+    mkdirSync(join(root, ".mex", "context"), { recursive: true });
+    writeFileSync(destination, "authored [YYYY-MM-DD] content\n");
+
+    expect(ensureScaffoldFile(source, destination)).toBe("skip");
+    expect(readFileSync(destination, "utf-8")).toBe("authored [YYYY-MM-DD] content\n");
+  });
+
+  it("refuses malformed canonical config without replacing its bytes", () => {
+    const root = fixture();
+    const mex = join(root, ".mex");
+    mkdirSync(mex);
+    const config = join(mex, "config.json");
+    writeFileSync(config, "{broken\n", "utf8");
+
+    expect(() => verifyExistingSetupConfig(mex)).toThrow(/valid JSON object/u);
+    expect(readFileSync(config, "utf8")).toBe("{broken\n");
+  });
+
+  it("refuses a redirected canonical config", () => {
+    const root = fixture();
+    const mex = join(root, ".mex");
+    mkdirSync(mex);
+    const outside = join(fixture(), "outside.json");
+    writeFileSync(outside, "{}\n", "utf8");
+    symlinkSync(outside, join(mex, "config.json"), "file");
+
+    expect(() => verifyExistingSetupConfig(mex)).toThrow(/regular file/u);
+    expect(readFileSync(outside, "utf8")).toBe("{}\n");
+  });
+
+  it("does not report setup ready when authored grounding was skipped", () => {
+    expect(() => assertGroundingCaptureReady({ captured: 2, skipped: 1 }))
+      .toThrow(/could not be verified against the code graph/u);
+    expect(() => assertGroundingCaptureReady({ captured: 2, skipped: 0 })).not.toThrow();
+  });
+});
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-setup-state-"));
+  roots.push(root);
+  return root;
+}
+
+function writePopulatedScaffold(mex: string): void {
+  for (const file of [
+    "AGENTS.md",
+    "ROUTER.md",
+    "context/architecture.md",
+    "context/stack.md",
+    "context/conventions.md",
+    "context/decisions.md",
+    "context/setup.md",
+  ]) {
+    const path = join(mex, file);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, "last_updated: 2026-09-02\n# Ready\n");
+  }
+}

--- a/src/setup/__tests__/wiki-finalize.test.ts
+++ b/src/setup/__tests__/wiki-finalize.test.ts
@@ -1,0 +1,196 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { finalizeSetupWiki } from "../wiki-finalize.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      // Windows can briefly retain a just-closed SQLite handle.
+    }
+  }
+});
+
+describe("setup Wiki finalization", () => {
+  it("plans, migrates, rebuilds, validates, and reports abstentions", async () => {
+    const { projectRoot, scaffoldRoot } = legacyScaffold();
+    const progress: string[] = [];
+    const warnings: string[] = [];
+
+    const result = await finalizeSetupWiki({
+      projectRoot,
+      scaffoldRoot,
+      onProgress: (message) => progress.push(message),
+      onWarning: (message) => warnings.push(message),
+    });
+
+    expect(result).toMatchObject({
+      ready: true,
+      stage: "complete",
+      reason: null,
+      migrated: true,
+      plannedEntities: 1,
+      indexedEntities: 1,
+      entitiesChecked: 1,
+      abstentions: 1,
+      warningCount: 1,
+    });
+    expect(result.diagnostics.filter((entry) => entry.severity === "error")).toEqual([]);
+    expect(readFileSync(join(scaffoldRoot, "context", "setup.md"), "utf8")).toContain("mex:");
+    expect(existsSync(join(scaffoldRoot, "wiki.db"))).toBe(true);
+    expect(warnings[0]).toContain("notes.md");
+    expect(progress).toEqual([
+      "Planning Wiki migration...",
+      "Applying Wiki migration...",
+      "Rebuilding Wiki index...",
+      "Validating Wiki scaffold...",
+      "Wiki migration and index are ready.",
+    ]);
+  });
+
+  it("is safe to rerun without changing canonical files or the operation log", async () => {
+    const { projectRoot, scaffoldRoot } = legacyScaffold(false);
+    const first = await finalizeSetupWiki({ projectRoot, scaffoldRoot });
+    expect(first.ready).toBe(true);
+
+    const canonicalPath = join(scaffoldRoot, "context", "setup.md");
+    const logPath = join(scaffoldRoot, "events", "operations.jsonl");
+    const canonicalBefore = readFileSync(canonicalPath, "utf8");
+    const logBefore = readFileSync(logPath, "utf8");
+
+    const second = await finalizeSetupWiki({ projectRoot, scaffoldRoot });
+
+    expect(second).toMatchObject({
+      ready: true,
+      stage: "complete",
+      migrated: false,
+      plannedEntities: 0,
+      indexedEntities: 1,
+      entitiesChecked: 1,
+    });
+    expect(readFileSync(canonicalPath, "utf8")).toBe(canonicalBefore);
+    expect(readFileSync(logPath, "utf8")).toBe(logBefore);
+  });
+
+  it("refuses a blocked dry run before migration or index writes", async () => {
+    const projectRoot = fixture();
+    const scaffoldRoot = join(projectRoot, ".mex");
+    const brokenPath = join(scaffoldRoot, "context", "setup.md");
+    mkdirSync(join(scaffoldRoot, "context"), { recursive: true });
+    writeFileSync(
+      brokenPath,
+      [
+        "<!-- mex:entity",
+        "id: not-an-entity-id",
+        "type: guide",
+        "status: promoted",
+        "revision: 1",
+        "-->",
+        "# Broken setup",
+        "",
+        "This entity cannot be indexed safely.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const before = readFileSync(brokenPath, "utf8");
+    const progress: string[] = [];
+
+    const result = await finalizeSetupWiki({
+      projectRoot,
+      scaffoldRoot,
+      onProgress: (message) => progress.push(message),
+    });
+
+    expect(result).toMatchObject({
+      ready: false,
+      stage: "plan",
+      migrated: false,
+      indexedEntities: 0,
+    });
+    expect(result.reason).toContain("blocked");
+    expect(result.diagnostics.some((entry) => entry.severity === "error")).toBe(true);
+    expect(readFileSync(brokenPath, "utf8")).toBe(before);
+    expect(existsSync(join(scaffoldRoot, "events", "operations.jsonl"))).toBe(false);
+    expect(existsSync(join(scaffoldRoot, "wiki.db"))).toBe(false);
+    expect(progress).toEqual(["Planning Wiki migration..."]);
+  });
+
+  it("honors configured read-only paths during migration", async () => {
+    const { projectRoot, scaffoldRoot } = legacyScaffold(false);
+    const canonicalPath = join(scaffoldRoot, "context", "setup.md");
+    const before = readFileSync(canonicalPath, "utf8");
+
+    const result = await finalizeSetupWiki({
+      projectRoot,
+      scaffoldRoot,
+      readOnly: ["context/**"],
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.stage).toBe("migration");
+    expect(readFileSync(canonicalPath, "utf8")).toBe(before);
+    expect(existsSync(join(scaffoldRoot, "wiki.db"))).toBe(false);
+  });
+
+  it("uses configured exclusions for both migration and indexing", async () => {
+    const { projectRoot, scaffoldRoot } = legacyScaffold(false);
+    const canonicalPath = join(scaffoldRoot, "context", "setup.md");
+    const before = readFileSync(canonicalPath, "utf8");
+
+    const result = await finalizeSetupWiki({
+      projectRoot,
+      scaffoldRoot,
+      exclude: ["context/**"],
+    });
+
+    expect(result).toMatchObject({ ready: true, plannedEntities: 0, indexedEntities: 0 });
+    expect(readFileSync(canonicalPath, "utf8")).toBe(before);
+  });
+});
+
+function legacyScaffold(withAbstention = true): { projectRoot: string; scaffoldRoot: string } {
+  const projectRoot = fixture();
+  const scaffoldRoot = join(projectRoot, ".mex");
+  mkdirSync(join(scaffoldRoot, "context"), { recursive: true });
+  writeFileSync(
+    join(scaffoldRoot, "context", "setup.md"),
+    [
+      "---",
+      "name: setup",
+      "description: Preparing a machine to work on this project.",
+      "---",
+      "# Setup",
+      "",
+      "Install dependencies before running the project locally.",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  if (withAbstention) {
+    writeFileSync(
+      join(scaffoldRoot, "notes.md"),
+      "# Scratch notes\n\nThis file has no migration classification rule.\n",
+      "utf8",
+    );
+  }
+  return { projectRoot, scaffoldRoot };
+}
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "mex-setup-wiki-finalize-"));
+  roots.push(root);
+  return root;
+}

--- a/src/setup/ignore.ts
+++ b/src/setup/ignore.ts
@@ -1,0 +1,209 @@
+import {
+  appendFileSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+export const SETUP_IGNORE_PATH = ".mex/.gitignore" as const;
+export const SETUP_IGNORE_RULES = ["graph.db*", "wiki.db*", "local/"] as const;
+
+export type SetupIgnoreAction = "create" | "update" | "unchanged";
+
+export interface SetupIgnoreProtectionOptions {
+  readonly projectRoot: string;
+  readonly dryRun?: boolean;
+}
+
+export interface SetupIgnoreProtectionResult {
+  readonly path: typeof SETUP_IGNORE_PATH;
+  readonly action: SetupIgnoreAction;
+  readonly dryRun: boolean;
+  /** True only when this invocation wrote the missing rules. */
+  readonly applied: boolean;
+  /** True when rules need to be written, including during a dry run. */
+  readonly changed: boolean;
+  readonly addedRules: readonly string[];
+}
+
+export class SetupIgnoreProtectionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SetupIgnoreProtectionError";
+  }
+}
+
+/**
+ * Ensure checkout-local MEX databases and state cannot be staged accidentally.
+ * Existing bytes are left untouched; only missing rules are appended.
+ */
+export function ensureSetupIgnoreProtection(
+  options: SetupIgnoreProtectionOptions,
+): SetupIgnoreProtectionResult {
+  const dryRun = options.dryRun === true;
+  const projectRoot = resolve(options.projectRoot);
+  const mexDirectory = resolve(projectRoot, ".mex");
+  const ignorePath = resolve(projectRoot, SETUP_IGNORE_PATH);
+
+  requireSafeDirectory(projectRoot, "project root");
+
+  const mexStats = lstatIfExists(mexDirectory);
+  if (mexStats && (mexStats.isSymbolicLink() || !mexStats.isDirectory())) {
+    throw new SetupIgnoreProtectionError(
+      `Cannot protect local MEX data: ${mexDirectory} is not a safe directory.`,
+    );
+  }
+
+  const ignoreStats = lstatIfExists(ignorePath);
+  if (ignoreStats && (ignoreStats.isSymbolicLink() || !ignoreStats.isFile())) {
+    throw new SetupIgnoreProtectionError(
+      `Cannot protect local MEX data: ${ignorePath} is not a regular file.`,
+    );
+  }
+
+  const existing = ignoreStats ? readFileSync(ignorePath) : Buffer.alloc(0);
+  const content = existing.toString("utf8");
+  const presentRules = new Set(splitLines(content));
+  const addedRules = SETUP_IGNORE_RULES.filter((rule) => !presentRules.has(rule));
+  const changed = addedRules.length > 0;
+  const action: SetupIgnoreAction = changed
+    ? ignoreStats ? "update" : "create"
+    : "unchanged";
+
+  const result: SetupIgnoreProtectionResult = {
+    path: SETUP_IGNORE_PATH,
+    action,
+    dryRun,
+    applied: changed && !dryRun,
+    changed,
+    addedRules,
+  };
+
+  if (!changed || dryRun) return result;
+
+  if (!mexStats) {
+    try {
+      mkdirSync(mexDirectory);
+    } catch (error) {
+      throw new SetupIgnoreProtectionError(
+        `Could not create the MEX directory at ${mexDirectory}.`,
+        { cause: error },
+      );
+    }
+    requireSafeDirectory(mexDirectory, ".mex directory");
+  }
+
+  const eol = detectEol(content);
+  const needsLeadingEol = existing.length > 0 && !endsWithEol(content);
+  const suffix = `${needsLeadingEol ? eol : ""}${addedRules.join(eol)}${eol}`;
+
+  try {
+    if (ignoreStats) {
+      appendFileSync(ignorePath, suffix, { encoding: "utf8" });
+    } else {
+      writeFileSync(ignorePath, suffix, { encoding: "utf8", flag: "wx" });
+    }
+  } catch (error) {
+    throw new SetupIgnoreProtectionError(
+      `Could not write local MEX data protection to ${ignorePath}.`,
+      { cause: error },
+    );
+  }
+
+  return result;
+}
+
+/** Render one concise setup status line without coupling the helper to the CLI. */
+export function renderSetupIgnoreProtection(result: SetupIgnoreProtectionResult): string {
+  if (!result.changed) {
+    return `Local MEX data is already ignored by ${result.path}`;
+  }
+
+  const verb = result.dryRun
+    ? result.action === "create" ? "Would create" : "Would update"
+    : result.action === "create" ? "Created" : "Updated";
+  return `${verb} ${result.path} with ${result.addedRules.join(", ")}`;
+}
+
+/** Verify Git sees derived state as ignored while canonical config stays trackable. */
+export function verifySetupIgnoreProtection(projectRoot: string): void {
+  const root = resolve(projectRoot);
+  if (isIgnored(root, ".mex/config.json")) {
+    throw new SetupIgnoreProtectionError(
+      "A Git ignore rule hides .mex/config.json. Remove the broad .mex ignore so canonical MEX files can be committed.",
+    );
+  }
+  for (const path of [
+    ".mex/graph.db",
+    ".mex/graph.db-wal",
+    ".mex/wiki.db",
+    ".mex/wiki.db-shm",
+    ".mex/local/setup-state.json",
+  ]) {
+    if (!isIgnored(root, path)) {
+      throw new SetupIgnoreProtectionError(`Local MEX path is not ignored by Git: ${path}`);
+    }
+  }
+}
+
+function splitLines(content: string): string[] {
+  const lines = content.split(/\r\n|\n|\r/u);
+  if (lines[0]?.startsWith("\uFEFF")) lines[0] = lines[0].slice(1);
+  return lines;
+}
+
+function detectEol(content: string): "\r\n" | "\n" | "\r" {
+  return /\r\n|\n|\r/u.exec(content)?.[0] as "\r\n" | "\n" | "\r" | undefined ?? "\n";
+}
+
+function endsWithEol(content: string): boolean {
+  return content.endsWith("\n") || content.endsWith("\r");
+}
+
+function requireSafeDirectory(path: string, label: string): void {
+  const stats = lstatIfExists(path);
+  if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new SetupIgnoreProtectionError(
+      `Cannot protect local MEX data: ${label} at ${path} is not a safe directory.`,
+    );
+  }
+}
+
+function lstatIfExists(path: string): ReturnType<typeof lstatSync> | null {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw new SetupIgnoreProtectionError(
+      `Could not inspect setup path ${path}.`,
+      { cause: error },
+    );
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isIgnored(projectRoot: string, path: string): boolean {
+  const checked = spawnSync(
+    "git",
+    ["check-ignore", "--no-index", "--quiet", "--", path],
+    { cwd: projectRoot, encoding: "utf8" },
+  );
+  if (checked.error) {
+    throw new SetupIgnoreProtectionError("Could not run Git to verify local MEX data protection.", {
+      cause: checked.error,
+    });
+  }
+  if (checked.status === 0) return true;
+  if (checked.status === 1) return false;
+  throw new SetupIgnoreProtectionError(
+    `Git could not verify local MEX data protection: ${checked.stderr.trim() || `exit ${checked.status}`}`,
+  );
+}

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -1,9 +1,8 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
-import { resolve, dirname, relative, join } from "node:path";
+import { existsSync, readFileSync, mkdirSync, copyFileSync, lstatSync } from "node:fs";
+import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createInterface } from "node:readline/promises";
 import { execSync } from "node:child_process";
-import crossSpawn from "cross-spawn";
 import { stdin, stdout } from "node:process";
 import { globSync } from "glob";
 import chalk from "chalk";
@@ -12,9 +11,11 @@ import {
   buildExistingWithBriefPrompt,
   buildExistingNoBriefPrompt,
 } from "./prompts.js";
-import { saveAiTools, ensureScaffoldIdentity } from "../config.js";
-import { isCliAvailable } from "../cli-tools.js";
-import { captureGroundingBaselines } from "../graph/runtime.js";
+import { saveAiTools, ensureScaffoldIdentity, findConfig, readScaffoldId } from "../config.js";
+import {
+  captureGroundingBaselines,
+  type GroundingBaselineCaptureResult,
+} from "../graph/runtime.js";
 import { VERSION } from "../version.js";
 import {
   renderInstructionChangePreview,
@@ -22,7 +23,14 @@ import {
   type AgentAssetsReport,
   type AgentSkillClient,
 } from "../agent-skills/index.js";
-import type { AiTool } from "../types.js";
+import { AI_TOOLS, type AiTool } from "../types.js";
+import { launchSetupPopulation } from "./population.js";
+import {
+  ensureSetupIgnoreProtection,
+  renderSetupIgnoreProtection,
+  verifySetupIgnoreProtection,
+} from "./ignore.js";
+import { finalizeSetupWiki } from "./wiki-finalize.js";
 
 // ── Constants ──
 
@@ -56,6 +64,42 @@ const AGENT_MEMORY_FILES = [
   "HEARTBEAT.md",
 ];
 
+export type ScaffoldFileAction = "copy" | "skip";
+
+export function ensureScaffoldFile(src: string, dest: string, dryRun = false): ScaffoldFileAction {
+  if (existsSync(dest)) return "skip";
+  if (!dryRun) {
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(src, dest);
+  }
+  return "copy";
+}
+
+/** Refuse to replace malformed or redirected canonical config during setup. */
+export function verifyExistingSetupConfig(mexDir: string): void {
+  const path = resolve(mexDir, "config.json");
+  let stats: ReturnType<typeof lstatSync>;
+  try {
+    stats = lstatSync(path);
+  } catch (error) {
+    if (error instanceof Error
+      && "code" in error
+      && (error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error("Could not inspect existing .mex/config.json. Fix its permissions before rerunning setup.", {
+      cause: error,
+    });
+  }
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error("Existing .mex/config.json must be a regular file. Fix it before rerunning setup.");
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) throw new Error();
+  } catch {
+    throw new Error("Existing .mex/config.json is not a valid JSON object. Fix it before rerunning setup.");
+  }
+}
+
 const TOOL_CONFIGS: Record<string, { src: string; dest: string }> = {
   "2": { src: ".tool-configs/.cursorrules", dest: ".cursorrules" },
   "3": { src: ".tool-configs/.windsurfrules", dest: ".windsurfrules" },
@@ -80,10 +124,6 @@ function findProjectRoot(): string {
   }
 }
 
-function isTemplateContent(content: string): boolean {
-  return content.includes("[Project Name]") || content.includes("[YYYY-MM-DD]");
-}
-
 function banner() {
   const GRN = "\x1b[38;2;91;140;90m";
   const DGR = "\x1b[38;2;74;122;73m";
@@ -106,7 +146,7 @@ function banner() {
 
 // ── Main ──
 
-type ProjectState = "existing" | "fresh" | "partial";
+export type ProjectState = "existing" | "fresh" | "partial";
 
 type SetupMode = "code-repo" | "agent-memory";
 
@@ -132,6 +172,10 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   const projectRoot = findProjectRoot();
   const mexDir = resolve(projectRoot, ".mex");
 
+  if (mode === "code-repo" && !existsSync(resolve(projectRoot, ".git"))) {
+    throw new Error("No Git repository found. Run `git init` first, then rerun mex setup.");
+  }
+
   // Guard: don't run inside the mex repo itself
   if (existsSync(resolve(projectRoot, "src", "setup", "index.ts"))) {
     const pkg = resolve(projectRoot, "package.json");
@@ -147,6 +191,7 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
 
   // ── Step 1: Detect project state ──
 
+  const scaffoldPopulatedAtStart = isScaffoldPopulated(mexDir);
   const state = detectProjectState(projectRoot, mexDir);
 
   if (mode === "agent-memory") {
@@ -163,8 +208,8 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
         info("Mode: populate scaffold from intent");
         break;
       case "partial":
-        info("Detected: existing codebase with partially populated scaffold");
-        info("Mode: will populate empty slots, skip what's already filled");
+        info("Detected: existing codebase with a populated scaffold");
+        info("Mode: preserve authored files and finish setup readiness");
         break;
     }
   }
@@ -175,6 +220,14 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   header("Creating .mex/ scaffold...");
   console.log();
 
+  const ignoreProtection = ensureSetupIgnoreProtection({ projectRoot, dryRun });
+  const ignoreMessage = renderSetupIgnoreProtection(ignoreProtection);
+  if (ignoreProtection.changed) ok(ignoreMessage);
+  else info(ignoreMessage);
+  if (mode === "code-repo" && !dryRun) verifySetupIgnoreProtection(projectRoot);
+  verifyExistingSetupConfig(mexDir);
+  console.log();
+
   const scaffoldFiles = mode === "agent-memory" ? AGENT_MEMORY_FILES : SCAFFOLD_FILES;
   for (const file of scaffoldFiles) {
     const agentMemorySrc = resolve(TEMPLATES_DIR, "agent-memory", file);
@@ -183,22 +236,15 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
       : resolve(TEMPLATES_DIR, file);
     const dest = resolve(mexDir, file);
 
-    if (existsSync(dest)) {
-      const existingContent = readFileSync(dest, "utf-8");
-      const templateContent = readFileSync(src, "utf-8");
-
-      // Skip if file has been populated (no longer matches template markers)
-      if (!isTemplateContent(existingContent) && existingContent !== templateContent) {
-        info(`Skipped .mex/${file} (already populated)`);
-        continue;
-      }
+    const action = ensureScaffoldFile(src, dest, dryRun);
+    if (action === "skip") {
+      info(`Skipped .mex/${file} (already exists)`);
+      continue;
     }
 
     if (dryRun) {
       ok(`(dry run) Would copy .mex/${file}`);
     } else {
-      mkdirSync(dirname(dest), { recursive: true });
-      copyFileSync(src, dest);
       ok(`Copied .mex/${file}`);
     }
   }
@@ -208,11 +254,17 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
 
   let selectedTools: AiTool[] = [];
 
-  const rl = createInterface({ input: stdin, output: stdout });
-  try {
-    selectedTools = await selectToolConfig(rl, projectRoot, dryRun);
-  } finally {
-    rl.close();
+  const configuredTools = scaffoldPopulatedAtStart ? findConfig(projectRoot).aiTools : [];
+  if (configuredTools.length > 0) {
+    selectedTools = configuredTools;
+    info(`Using configured AI tools: ${selectedTools.map((tool) => AI_TOOLS[tool].name).join(", ")}`);
+  } else {
+    const rl = createInterface({ input: stdin, output: stdout });
+    try {
+      selectedTools = await selectToolConfig(rl, projectRoot, dryRun);
+    } finally {
+      rl.close();
+    }
   }
   console.log();
 
@@ -222,13 +274,18 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   if (selectedAgentClients.length > 0) {
     header("Installing official MEX agent skills...");
     console.log();
-    const agentAssets = installSetupAgentAssets({ projectRoot, selectedTools, dryRun })!;
+    const agentAssets = installSetupAgentAssets({
+      projectRoot,
+      selectedTools,
+      dryRun,
+      checkIgnored: mode === "code-repo",
+    })!;
     renderAgentAssetsReport(agentAssets);
     console.log();
     const sessionSummary = `a new ${formatAgentClientList(agentAssets.clients)} session `
       + "to guarantee the new skills and project instructions are loaded.";
     if (agentAssets.conflicted) {
-      warn(`Resolve the reported conflicts and rerun setup or mex skills sync. Then start ${sessionSummary}`);
+      throw new Error("Official MEX agent assets have conflicts. Resolve the warnings above and rerun setup or mex skills sync.");
     } else if (dryRun) {
       info(`After applying this setup, start ${sessionSummary}`);
     } else {
@@ -240,7 +297,10 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   // Mint a stable scaffold identity. Independent of tool selection so a setup
   // that picks no AI tool still gets a scaffold_id written to config.json.
   if (!dryRun) {
-    ensureScaffoldIdentity(mexDir, projectRoot);
+    const identity = ensureScaffoldIdentity(mexDir, projectRoot);
+    if (readScaffoldId(mexDir) !== identity.scaffold_id) {
+      throw new Error("Could not persist .mex/config.json. Fix its permissions or contents and rerun setup.");
+    }
   }
 
   // ── Step 4: Run scanner (if not fresh) ──
@@ -270,7 +330,7 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
       ok("Code graph ready");
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      warn(`Code graph unavailable — setup will continue: ${message}`);
+      throw new Error(`Code graph setup failed: ${message}. Fix the problem and rerun mex setup.`);
     }
   }
 
@@ -297,60 +357,50 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
     return;
   }
 
-  const hasClaude = hasClaudeCli();
-
-  if (selectedTools.includes("claude") && hasClaude) {
-    header("Launching Claude Code to populate the scaffold...");
+  let populationFinished = scaffoldPopulatedAtStart;
+  if (populationFinished) {
+    header("Finishing setup from the existing populated scaffold...");
     console.log();
-    info("An interactive Claude Code session will open with the population prompt.");
-    info("You'll see the agent working in real-time.");
-    console.log();
-
-    try {
-      await launchClaude(prompt);
-      if (mode === "code-repo") {
-        try {
-          const result = await captureGroundingBaselines(
-            { projectRoot, scaffoldRoot: mexDir, aiTools: [] },
-            { warn },
-          );
-          if (result.captured > 0) ok(`Captured ${result.captured} grounding baseline(s)`);
-          else warn("No grounding baselines were captured; verify the agent authored grounding.");
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          warn(`Grounding baselines unavailable — setup will continue: ${message}`);
-        }
-      }
-      console.log();
-      ok("Setup complete.");
-    } catch (err) {
-      // A launch/exit failure must not crash setup with an unhandled
-      // rejection — report it and fall back to the manual-paste prompt.
-      console.log();
-      warn(`Couldn't run Claude Code automatically: ${(err as Error).message}`);
-      info("Paste the prompt below into your AI tool to populate the scaffold instead.");
-      printPromptForManualPaste(prompt);
-      await confirmAndCaptureGrounding(projectRoot, mexDir, mode);
-    }
-    await promptGlobalInstall();
-    return;
   } else {
+    header("Launching an agent to populate the scaffold...");
+    console.log();
+    info("The first selected available Claude Code or Codex CLI will run in the project root.");
+    console.log();
+    const launched = launchSetupPopulation(selectedTools, prompt, projectRoot);
+    if (launched.completed) {
+      ok(`${AI_TOOLS[launched.tool!].name} finished the population session`);
+      populationFinished = isScaffoldPopulated(mexDir);
+      if (!populationFinished) {
+        warn("The agent exited successfully, but required scaffold placeholders remain.");
+      }
+    } else if (launched.tool !== null) {
+      warn(`${AI_TOOLS[launched.tool].name} did not complete population.`);
+    }
+  }
+
+  if (!populationFinished) {
     header("Almost done. One more step — populate the scaffold.");
     console.log();
-
-    if (hasClaude) {
-      info("You can run this directly with Claude Code:");
-      console.log();
-      console.log("  claude -p '<the prompt below>'");
-      console.log();
-      info("Or paste the prompt below into your AI tool.");
-    } else {
-      info("Paste the prompt below into your AI tool.");
-      info("The agent will read your codebase and fill every scaffold file.");
-    }
-
+    info("Paste the prompt below into your AI tool.");
+    info("The agent will read your codebase and fill every scaffold file.");
     printPromptForManualPaste(prompt);
-    await confirmAndCaptureGrounding(projectRoot, mexDir, mode);
+    populationFinished = await confirmPopulationFinished(mexDir);
+  }
+
+  if (!populationFinished || !isScaffoldPopulated(mexDir)) {
+    console.log();
+    info("Setup paused at population. After the agent finishes, rerun `mex setup` to finalize Graph and Wiki readiness.");
+    return;
+  }
+
+  if (mode === "code-repo") {
+    await finalizeCodeRepoSetup(projectRoot, mexDir);
+    console.log();
+    ok("Graph and Wiki are ready. Setup is ready to commit.");
+    printCommitCheckpoint(selectedTools);
+  } else {
+    console.log();
+    ok("Setup complete.");
   }
 
   await promptGlobalInstall();
@@ -364,16 +414,26 @@ function normalizeMode(raw: string | undefined): SetupMode {
 
 // ── Step functions ──
 
-function detectProjectState(projectRoot: string, mexDir: string): ProjectState {
-  // Check if scaffold is already partially populated
-  const agentsMd = resolve(mexDir, "AGENTS.md");
-  let scaffoldPopulated = false;
-  if (existsSync(agentsMd)) {
-    const content = readFileSync(agentsMd, "utf-8");
-    if (!content.includes("[Project Name]")) {
-      scaffoldPopulated = true;
-    }
-  }
+export function isScaffoldPopulated(mexDir: string): boolean {
+  const required = [
+    "AGENTS.md",
+    "ROUTER.md",
+    "context/architecture.md",
+    "context/stack.md",
+    "context/conventions.md",
+    "context/decisions.md",
+    "context/setup.md",
+  ];
+  return required.every((file) => {
+    const path = resolve(mexDir, file);
+    if (!existsSync(path)) return false;
+    const content = readFileSync(path, "utf-8");
+    return !content.includes("[Project Name]") && !content.includes("[YYYY-MM-DD]");
+  });
+}
+
+export function detectProjectState(projectRoot: string, mexDir: string): ProjectState {
+  const scaffoldPopulated = isScaffoldPopulated(mexDir);
 
   // Count source files
   const patterns = SOURCE_EXTENSIONS.map(
@@ -388,7 +448,7 @@ function detectProjectState(projectRoot: string, mexDir: string): ProjectState {
 
   if (scaffoldPopulated && sourceFiles.length > 0) {
     return "partial";
-  } else if (sourceFiles.length > 3) {
+  } else if (sourceFiles.length > 0) {
     return "existing";
   } else {
     return "fresh";
@@ -443,7 +503,7 @@ async function selectToolConfig(
 
     if (dryRun) {
       if (existsSync(dest)) {
-        warn(`(dry run) Would overwrite ${config.dest}`);
+        info(`(dry run) Would keep existing ${config.dest}`);
       } else {
         ok(`(dry run) Would copy ${config.dest}`);
       }
@@ -519,6 +579,8 @@ export interface InstallSetupAgentAssetsOptions {
   packagedSkillsRoot?: string;
   /** Injectable only for package-version upgrade tests. */
   packageVersion?: string;
+  /** Agent-memory workspaces may intentionally live outside Git. */
+  checkIgnored?: boolean;
 }
 
 /** The noninteractive installation seam used by the normal setup flow. */
@@ -533,6 +595,7 @@ export function installSetupAgentAssets(
     projectRoot: options.projectRoot,
     packageVersion: options.packageVersion ?? VERSION,
     clients,
+    ...(options.checkIgnored === undefined ? {} : { checkIgnored: options.checkIgnored }),
     ...(options.dryRun === undefined ? {} : { dryRun: options.dryRun }),
     ...(options.packagedSkillsRoot === undefined
       ? {}
@@ -559,56 +622,90 @@ function printPromptForManualPaste(prompt: string): void {
   ok("Paste the prompt above into your agent to populate the scaffold.");
 }
 
-async function confirmAndCaptureGrounding(
-  projectRoot: string,
-  mexDir: string,
-  mode: SetupMode,
-): Promise<void> {
-  if (mode !== "code-repo" || !stdin.isTTY) return;
+async function confirmPopulationFinished(mexDir: string): Promise<boolean> {
+  if (!stdin.isTTY) return false;
   const rl = createInterface({ input: stdin, output: stdout });
   try {
     console.log();
-    info("After the agent finishes populating, return here to capture grounding baselines.");
+    info("After the agent finishes populating, return here to finish setup.");
     const answer = (await rl.question("  Has population finished? [y/N] ")).trim().toLowerCase();
-    if (answer !== "y" && answer !== "yes") return;
-    const result = await captureGroundingBaselines(
-      { projectRoot, scaffoldRoot: mexDir, aiTools: [] },
-      { warn },
-    );
-    if (result.captured > 0) ok(`Captured ${result.captured} grounding baseline(s)`);
-    else warn("No grounding baselines were captured; verify the agent authored grounding.");
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    warn(`Grounding baselines unavailable — setup will continue: ${message}`);
+    if (answer !== "y" && answer !== "yes") return false;
+    if (!isScaffoldPopulated(mexDir)) {
+      warn("Required placeholders remain in the .mex scaffold files.");
+      return false;
+    }
+    return true;
   } finally {
     rl.close();
   }
 }
 
-function hasClaudeCli(): boolean {
-  return isCliAvailable("claude");
+async function finalizeCodeRepoSetup(projectRoot: string, mexDir: string): Promise<void> {
+  info("Capturing grounding baselines...");
+  try {
+    const result = await captureGroundingBaselines(
+      { projectRoot, scaffoldRoot: mexDir, aiTools: [] },
+      { warn },
+    );
+    assertGroundingCaptureReady(result);
+    if (result.captured > 0) ok(`Captured ${result.captured} grounding baseline(s)`);
+    else info("No authored grounding baselines needed capture");
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Grounding finalization failed: ${message}. Rerun mex setup after fixing it.`);
+  }
+
+  const config = findConfig(projectRoot);
+  const wiki = await finalizeSetupWiki({
+    projectRoot,
+    scaffoldRoot: mexDir,
+    exclude: config.wiki?.exclude,
+    readOnly: config.wiki?.readOnly,
+    onProgress: info,
+    onWarning: warn,
+  });
+  if (!wiki.ready) {
+    const codes = [...new Set(wiki.diagnostics.map((entry) => entry.code))].join(", ");
+    const suffix = codes.length === 0 ? "" : ` (${codes})`;
+    throw new Error(`${wiki.reason ?? "Wiki setup did not finish."}${suffix} Fix the issue and rerun mex setup.`);
+  }
+  ok(`Wiki ready with ${wiki.indexedEntities} indexed entit${wiki.indexedEntities === 1 ? "y" : "ies"}`);
 }
 
-function launchClaude(prompt: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    // cross-spawn resolves the Windows `claude.cmd` wrapper and escapes the
-    // prompt correctly. Plain spawn threw ENOENT on Windows (issue #85).
-    const child = crossSpawn("claude", [prompt], {
-      stdio: "inherit",
-    });
+export function assertGroundingCaptureReady(result: GroundingBaselineCaptureResult): void {
+  if (result.skipped > 0) {
+    throw new Error(
+      `${result.skipped} authored grounding reference${result.skipped === 1 ? "" : "s"} could not be verified against the code graph.`,
+    );
+  }
+}
 
-    child.on("close", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`Claude exited with code ${code}`));
-    });
-
-    child.on("error", (err) => {
-      reject(new Error(`Failed to launch Claude: ${err.message}`));
-    });
-  });
+function printCommitCheckpoint(selectedTools: readonly AiTool[]): void {
+  header("Commit the canonical MEX setup before opening Hub");
+  console.log();
+  info("Review the scoped files, then commit them. MEX will not stage or commit automatically.");
+  console.log("    git status --short");
+  console.log("    git add .mex");
+  if (selectedTools.includes("claude")) {
+    console.log("    git add CLAUDE.md .claude/skills/mex-inbox .claude/skills/mex-relay");
+  }
+  if (selectedTools.includes("codex")) {
+    console.log("    git add AGENTS.md .agents/skills/mex-inbox .agents/skills/mex-relay");
+  }
+  if (selectedTools.includes("cursor")) console.log("    git add .cursorrules");
+  if (selectedTools.includes("windsurf")) console.log("    git add .windsurfrules");
+  if (selectedTools.includes("copilot")) console.log("    git add .github/copilot-instructions.md");
+  if (selectedTools.includes("opencode")) console.log("    git add .opencode/opencode.json");
+  console.log('    git commit -m "chore: initialize MEX"');
+  console.log();
+  info("After that commit, start Hub with `mex hub` (or `npx mex-agent hub`).");
 }
 
 async function promptGlobalInstall(): Promise<void> {
+  if (!stdin.isTTY) {
+    printNextSteps(false);
+    return;
+  }
   const rl = createInterface({ input: stdin, output: stdout });
   try {
     header("One more thing");
@@ -616,9 +713,9 @@ async function promptGlobalInstall(): Promise<void> {
     info("Install mex globally so `mex check` works anywhere?");
     console.log();
 
-    const answer = (await rl.question("  Install mex globally? [Y/n] ")).trim().toLowerCase();
+    const answer = (await rl.question("  Install mex globally? [y/N] ")).trim().toLowerCase();
 
-    if (answer === "" || answer === "y" || answer === "yes") {
+    if (answer === "y" || answer === "yes") {
       console.log();
       info("Installing mex-agent globally...");
       try {

--- a/src/setup/population.ts
+++ b/src/setup/population.ts
@@ -1,0 +1,136 @@
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { relative, resolve } from "node:path";
+import { isCliAvailable } from "../cli-tools.js";
+import { runToolInteractive } from "../sync/index.js";
+import { AI_TOOLS, type AiTool } from "../types.js";
+
+export type SetupAgentTool = Extract<AiTool, "claude" | "codex">;
+
+export interface SetupPopulationLaunchResult {
+  tool: SetupAgentTool | null;
+  completed: boolean;
+}
+
+interface SetupPopulationDependencies {
+  isAvailable?: (command: string) => boolean;
+  run?: typeof runToolInteractive;
+}
+
+export class SetupPopulationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "SetupPopulationError";
+  }
+}
+
+/** Use the user's selected order and never launch an unselected agent. */
+export function selectSetupAgent(
+  selectedTools: readonly AiTool[],
+  isAvailable: (command: string) => boolean = isCliAvailable,
+): SetupAgentTool | null {
+  for (const tool of selectedTools) {
+    if (tool !== "claude" && tool !== "codex") continue;
+    const command = AI_TOOLS[tool].cli;
+    if (command !== null && isAvailable(command)) return tool;
+  }
+  return null;
+}
+
+/** Launch first-time population with no sync timeout, from the project root. */
+export function launchSetupPopulation(
+  selectedTools: readonly AiTool[],
+  prompt: string,
+  projectRoot: string,
+  dependencies: SetupPopulationDependencies = {},
+): SetupPopulationLaunchResult {
+  const tool = selectSetupAgent(selectedTools, dependencies.isAvailable);
+  if (tool === null) return { tool: null, completed: false };
+
+  const root = resolve(projectRoot);
+  const localDirectory = ensureLocalPopulationDirectory(root);
+  let sessionDirectory: string;
+  try {
+    sessionDirectory = mkdtempSync(resolve(localDirectory, "setup-population-"));
+  } catch (error) {
+    throw new SetupPopulationError(
+      `Could not create a private setup population prompt under ${localDirectory}.`,
+      { cause: error },
+    );
+  }
+
+  try {
+    const promptPath = resolve(sessionDirectory, "prompt.md");
+    writeFileSync(promptPath, prompt, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    const pointer = relative(root, promptPath).replaceAll("\\", "/");
+    const instruction = `Read the full setup population prompt from \`${pointer}\`, then follow it exactly.`;
+    const completed = (dependencies.run ?? runToolInteractive)(
+      tool,
+      instruction,
+      root,
+      { timeoutMs: null },
+    );
+    return { tool, completed };
+  } finally {
+    rmSync(sessionDirectory, { recursive: true, force: true });
+  }
+}
+
+function ensureLocalPopulationDirectory(projectRoot: string): string {
+  const mexDirectory = resolve(projectRoot, ".mex");
+  requireRegularDirectory(mexDirectory, ".mex");
+
+  const localDirectory = resolve(mexDirectory, "local");
+  const localStats = lstatIfExists(localDirectory);
+  if (localStats === null) {
+    try {
+      mkdirSync(localDirectory, { mode: 0o700 });
+    } catch (error) {
+      if (!isAlreadyExists(error)) {
+        throw new SetupPopulationError(
+          `Could not create the setup population directory at ${localDirectory}.`,
+          { cause: error },
+        );
+      }
+    }
+  }
+  requireRegularDirectory(localDirectory, ".mex/local");
+  return localDirectory;
+}
+
+function requireRegularDirectory(path: string, label: string): void {
+  const stats = lstatIfExists(path);
+  if (!stats || stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new SetupPopulationError(
+      `Cannot store the setup population prompt: ${label} at ${path} is not a regular directory.`,
+    );
+  }
+}
+
+function lstatIfExists(path: string): ReturnType<typeof lstatSync> | null {
+  try {
+    return lstatSync(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw new SetupPopulationError(`Could not inspect setup population path ${path}.`, {
+      cause: error,
+    });
+  }
+}
+
+function isMissing(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+function isAlreadyExists(error: unknown): boolean {
+  return error instanceof Error
+    && "code" in error
+    && (error as NodeJS.ErrnoException).code === "EEXIST";
+}

--- a/src/setup/wiki-finalize.ts
+++ b/src/setup/wiki-finalize.ts
@@ -1,0 +1,161 @@
+import { resolve } from "node:path";
+import {
+  createWikiEngine,
+  type MigrationApplyResult,
+  type ServiceResult,
+  type WikiDiagnostic,
+} from "../wiki/service.js";
+
+export type SetupWikiFinalizationStage =
+  | "plan"
+  | "migration"
+  | "index"
+  | "validation"
+  | "complete";
+
+export interface SetupWikiFinalizationOptions {
+  projectRoot: string;
+  scaffoldRoot: string;
+  exclude?: readonly string[];
+  readOnly?: readonly string[];
+  onProgress?: (message: string) => void;
+  onWarning?: (message: string) => void;
+}
+
+/** A compact, setup-oriented summary over the existing Wiki service results. */
+export interface SetupWikiFinalizationResult {
+  ready: boolean;
+  stage: SetupWikiFinalizationStage;
+  reason: string | null;
+  migrated: boolean;
+  plannedEntities: number;
+  indexedEntities: number;
+  filesScanned: number;
+  entitiesChecked: number;
+  abstentions: number;
+  warningCount: number;
+  diagnostics: WikiDiagnostic[];
+}
+
+/**
+ * Canonicalize and index the populated setup scaffold.
+ *
+ * Migration remains plan-first: the Wiki engine re-plans before apply and
+ * refuses if the scaffold changed under the reviewed plan. Every underlying
+ * operation is already restartable, so calling this again only rebuilds the
+ * derived index and validates the same canonical Markdown.
+ */
+export async function finalizeSetupWiki(
+  options: SetupWikiFinalizationOptions,
+): Promise<SetupWikiFinalizationResult> {
+  const projectRoot = resolve(options.projectRoot);
+  const scaffoldRoot = resolve(options.scaffoldRoot);
+  const engine = createWikiEngine({
+    scaffoldRoot,
+    ...(options.exclude === undefined ? {} : { exclude: options.exclude }),
+    ...(options.readOnly === undefined ? {} : { readOnly: options.readOnly }),
+  });
+  const diagnostics = new Map<string, WikiDiagnostic>();
+  const warnings = new Set<string>();
+  let plannedEntities = 0;
+  let indexedEntities = 0;
+  let filesScanned = 0;
+  let entitiesChecked = 0;
+  let abstentions = 0;
+  let migrated = false;
+
+  const collectDiagnostics = (entries: readonly WikiDiagnostic[]): void => {
+    for (const entry of entries) {
+      const key = JSON.stringify([
+        entry.code,
+        entry.severity,
+        entry.file ?? null,
+        entry.entityId ?? null,
+        entry.message,
+      ]);
+      diagnostics.set(key, entry);
+      if (entry.severity !== "warning") continue;
+      const message = `${entry.code}${entry.file === undefined ? "" : ` ${entry.file}`}: ${entry.message}`;
+      if (warnings.has(message)) continue;
+      warnings.add(message);
+      options.onWarning?.(message);
+    }
+  };
+
+  const result = (
+    ready: boolean,
+    stage: SetupWikiFinalizationStage,
+    reason: string | null,
+  ): SetupWikiFinalizationResult => ({
+    ready,
+    stage,
+    reason,
+    migrated,
+    plannedEntities,
+    indexedEntities,
+    filesScanned,
+    entitiesChecked,
+    abstentions,
+    warningCount: warnings.size,
+    diagnostics: [...diagnostics.values()],
+  });
+
+  options.onProgress?.("Planning Wiki migration...");
+  const plan = await engine.planMigration();
+  collectDiagnostics(plan.diagnostics);
+  plannedEntities = plan.data.report.planned.length;
+  filesScanned = plan.data.report.filesScanned;
+  abstentions = plan.data.report.abstentions.length;
+  for (const abstention of plan.data.report.abstentions) {
+    const message = `Wiki migration left ${abstention.file} for review: ${abstention.reason}`;
+    if (warnings.has(message)) continue;
+    warnings.add(message);
+    options.onWarning?.(message);
+  }
+  // The migration planner deliberately abstains on malformed entity blocks;
+  // validation supplies the blocking diagnostic that keeps setup from writing
+  // other files around a scaffold which is already structurally unsafe.
+  const preflight = await engine.validate({ projectRoot });
+  collectDiagnostics(preflight.diagnostics);
+  filesScanned = preflight.data.filesScanned;
+  entitiesChecked = preflight.data.entitiesChecked;
+  if (plan.data.blocked || hasErrors(plan) || hasErrors(preflight)) {
+    return result(false, "plan", "Wiki migration is blocked by errors in the populated scaffold.");
+  }
+
+  options.onProgress?.("Applying Wiki migration...");
+  const applied = await engine.applyMigration(plan.data);
+  collectDiagnostics(applied.diagnostics);
+  migrated = migrationChangedFiles(applied).length > 0;
+  if (!applied.data.applied || hasErrors(applied)) {
+    return result(false, "migration", "Wiki migration could not be applied safely.");
+  }
+
+  options.onProgress?.("Rebuilding Wiki index...");
+  const rebuilt = await engine.rebuildIndex();
+  collectDiagnostics(rebuilt.diagnostics);
+  indexedEntities = rebuilt.data.entityCount;
+  if (hasErrors(rebuilt)) {
+    return result(false, "index", "Wiki index rebuild failed validation.");
+  }
+
+  options.onProgress?.("Validating Wiki scaffold...");
+  const validated = await engine.validate({ projectRoot });
+  collectDiagnostics(validated.diagnostics);
+  filesScanned = validated.data.filesScanned;
+  entitiesChecked = validated.data.entitiesChecked;
+  if (hasErrors(validated)) {
+    return result(false, "validation", "Wiki scaffold validation found blocking errors.");
+  }
+
+  options.onProgress?.("Wiki migration and index are ready.");
+  return result(true, "complete", null);
+}
+
+function hasErrors(result: ServiceResult<unknown>): boolean {
+  return result.diagnostics.some((entry) => entry.severity === "error");
+}
+
+function migrationChangedFiles(result: ServiceResult<MigrationApplyResult>): readonly string[] {
+  return result.data.report.diffs;
+}

--- a/src/sync/index.ts
+++ b/src/sync/index.ts
@@ -11,6 +11,11 @@ import { captureGroundingBaselines, loadGroundingRuntime, persistMovedGroundings
 
 const INTERACTIVE_AI_TIMEOUT_MS = 15 * 60_000;
 
+export interface RunToolInteractiveOptions {
+  /** Sync keeps its bounded default; setup passes null for a user-driven session. */
+  timeoutMs?: number | null;
+}
+
 function askUser(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
@@ -21,7 +26,12 @@ function askUser(question: string): Promise<string> {
   });
 }
 
-export function runToolInteractive(tool: AiTool, brief: string, cwd: string): boolean {
+export function runToolInteractive(
+  tool: AiTool,
+  brief: string,
+  cwd: string,
+  options: RunToolInteractiveOptions = {},
+): boolean {
   const meta = AI_TOOLS[tool];
   if (!meta.cli) return false;
 
@@ -32,7 +42,9 @@ export function runToolInteractive(tool: AiTool, brief: string, cwd: string): bo
   const result = crossSpawn.sync(meta.cli, args, {
     cwd,
     stdio: "inherit",
-    timeout: INTERACTIVE_AI_TIMEOUT_MS,
+    ...(options.timeoutMs === null
+      ? {}
+      : { timeout: options.timeoutMs ?? INTERACTIVE_AI_TIMEOUT_MS }),
   });
   // A spawn failure (ENOENT, etc.) sets `error` and leaves `status` null — don't
   // mistake that for success, or launch problems get silently swallowed.

--- a/templates/.tool-configs/CLAUDE.md
+++ b/templates/.tool-configs/CLAUDE.md
@@ -59,6 +59,7 @@ For full project context, patterns, and task guidance — everything is there.
 
 <!-- mex-agent:skills:start -->
 ## MEX agent skills
+- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.
 - Use `/mex-inbox` for durable governed Spec proposals and `/mex-relay` for durable team handoffs. Invoke them automatically when intent clearly matches; explicit invocation remains available.
 - When MEX context materially influences an answer or implementation, include one concise acknowledgement: `MEX context used: <specific records/files/entities consulted>.`
 - Do not claim an author, date, or historical event unless the retrieved data actually provides it.

--- a/templates/SETUP.md
+++ b/templates/SETUP.md
@@ -10,11 +10,14 @@ This scaffold is currently empty. Follow the steps below to populate it for your
 mex setup
 ```
 
-The command handles everything automatically:
-1. Detects your project state (existing codebase, fresh project, or partial)
-2. Asks which AI tool you use and installs the right project instructions
-3. Pre-scans your codebase with `mex init` to build a structured brief (~5-8k tokens vs ~50k from AI exploration)
-4. Builds and runs the population prompt — or prints it for manual paste
+The command handles the setup workflow:
+1. Detects your project state without overwriting existing scaffold files
+2. Protects `.mex/graph.db*`, `.mex/wiki.db*`, and `.mex/local/` from Git
+3. Asks which AI tool you use and installs the right project instructions
+4. Scans the codebase and builds the local code graph
+5. Launches the first selected available Claude Code or Codex CLI, or prints the prompt for manual paste
+6. Captures grounding, migrates the populated Markdown, builds the Wiki index, and validates it
+7. Prints the canonical files to review and commit before running `mex hub`
 
 For Claude Code and Codex, setup also copies the packaged `mex-inbox` and
 `mex-relay` skills into the project. No plugin or separate skill installer is
@@ -222,6 +225,11 @@ Codex uses `$mex-inbox` and `$mex-relay`. Clear natural-language requests work
 too. Commit the project skill copies so teammates receive them; MEX never
 stages, commits, or pushes them automatically.
 
+Setup prints the scoped Git commands for the selected tools. Review those files
+and commit them before running `mex hub`; Hub requires `.mex/config.json` to
+match the version committed at the current Git `HEAD`. The local Graph/Wiki
+databases and `.mex/local/` remain ignored.
+
 **Verify** by starting a fresh session and asking your agent:
 "Read `.mex/ROUTER.md` and tell me what you now know about this project."
 
@@ -236,6 +244,6 @@ A well-populated scaffold should give the agent enough to:
 Once the scaffold is populated, use these to keep it aligned with your codebase:
 
 - **`mex check`** — detect drift (zero tokens, zero AI)
-- **`.mex/sync.sh`** — interactive drift check + targeted or full resync
+- **`mex sync`** — interactive drift check + targeted resync
 - **`mex skills sync`** — safely receive updated official agent skills after a package upgrade
 - **`mex watch`** — auto drift score after every commit

--- a/templates/SYNC.md
+++ b/templates/SYNC.md
@@ -1,12 +1,12 @@
 # Sync — Realign This Scaffold
 
-## Recommended: Use sync.sh
+## Recommended: Use `mex sync`
 
 ```bash
-.mex/sync.sh
+mex sync
 ```
 
-The script runs drift detection first, shows you exactly what's wrong, then offers:
+The command runs drift detection first, shows you exactly what's wrong, then offers:
 1. **Targeted sync** — AI fixes only the flagged files (fastest, cheapest)
 2. **Full resync** — AI re-reads everything and updates all scaffold files
 3. **Prompt export** — shows the prompts for manual paste

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import { findConfig, saveAiTools, ensureScaffoldIdentity, getScaffoldIdentity } from "../src/config.js";
@@ -344,5 +354,23 @@ describe("saveAiTools", () => {
     saveAiTools(mexPath, ["opencode", "codex"]);
     const raw = JSON.parse(readFileSync(join(mexPath, "config.json"), "utf-8"));
     expect(raw.aiTools).toEqual(["opencode", "codex"]);
+  });
+
+  it("publishes atomically without following a config symlink", () => {
+    const mexPath = join(tmpDir, ".mex");
+    const outside = join(tmpDir, "outside.json");
+    mkdirSync(mexPath, { recursive: true });
+    writeFileSync(outside, JSON.stringify({ outside: true }));
+    symlinkSync(outside, join(mexPath, "config.json"), "file");
+
+    saveAiTools(mexPath, ["codex"]);
+
+    expect(readFileSync(outside, "utf8")).toBe(JSON.stringify({ outside: true }));
+    expect(lstatSync(join(mexPath, "config.json")).isSymbolicLink()).toBe(false);
+    expect(JSON.parse(readFileSync(join(mexPath, "config.json"), "utf8"))).toEqual({
+      outside: true,
+      aiTools: ["codex"],
+    });
+    expect(readdirSync(mexPath).filter((name) => name.includes("mex-stage"))).toEqual([]);
   });
 });

--- a/test/setup-grounding-e2e.test.ts
+++ b/test/setup-grounding-e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import { extractGroundings, findMexAnchors, writeGroundings } from "../src/markd
 import { checkBrokenLinks } from "../src/drift/checkers/broken-link.js";
 import { runDriftCheckWithGraphStatus } from "../src/drift/index.js";
 import { captureGroundingBaselines, loadGroundingRuntime } from "../src/graph/runtime.js";
+import { finalizeSetupWiki } from "../src/setup/wiki-finalize.js";
 
 const roots: string[] = [];
 
@@ -94,6 +95,12 @@ export function calculateCheckoutTotal(items: number[], member: boolean): number
     expect(runtime!.fingerprints.getGroundedSource(".mex/patterns/navigation.md", groundings[0].node))
       .not.toBeNull();
     runtime!.close();
+
+    // Setup then migrates the legacy frontmatter and builds the Wiki index.
+    const finalized = await finalizeSetupWiki({ projectRoot: root, scaffoldRoot: join(root, ".mex") });
+    expect(finalized.ready).toBe(true);
+    expect(existsSync(join(root, ".mex", "wiki.db"))).toBe(true);
+    expect(extractGroundings(readFileSync(pattern, "utf-8"))[0]?.bodyHash).toMatch(/^[0-9a-f]{64}$/u);
 
     writeFileSync(join(sourceDir, "checkout.ts"), readFileSync(join(sourceDir, "checkout.ts"), "utf-8")
       .replace("subtotal >= 100 ? 0 : 12", "subtotal >= 125 ? 0 : 15"));

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -24,6 +24,16 @@ describe("runToolInteractive return-value logic", () => {
     }));
   });
 
+  it("can leave a setup population session unbounded and launches Codex in the project root", () => {
+    mockSync.mockReturnValue({ status: 0 });
+    const cwd = process.cwd();
+    expect(runToolInteractive("codex", "populate", cwd, { timeoutMs: null })).toBe(true);
+    expect(mockSync).toHaveBeenCalledWith("codex", ["populate"], {
+      cwd,
+      stdio: "inherit",
+    });
+  });
+
   it("treats a non-zero exit (status 1) as failure", () => {
     mockSync.mockReturnValue({ status: 1 });
     expect(runToolInteractive("claude", "brief", process.cwd())).toBe(false);

--- a/test/wiki-architecture.test.ts
+++ b/test/wiki-architecture.test.ts
@@ -762,6 +762,8 @@ describe("no unscoped scaffold writes", () => {
       "src/global-config.ts": "writes the global config and telemetry id",
       "src/events.ts": "appends to events/decisions.jsonl",
       "src/pattern/index.ts": "creates a new pattern file from a template",
+      "src/setup/ignore.ts": "creates or appends only the setup-managed .mex/.gitignore rules",
+      "src/setup/population.ts": "writes and removes one ignored private prompt file for the interactive setup session",
       "src/team/artifacts/filesystem.ts": "atomically publishes bounded team-owned canonical artifacts",
       "src/team/local-state/receipt-signer.ts": "atomically provisions the bounded local-only C preview signing credential",
       "src/watch.ts": "installs and removes git hooks",


### PR DESCRIPTION
## Summary

- preserve existing scaffold content while installing verified local-data ignore protection and atomically persisting setup config
- launch the first selected available Claude Code or Codex client from the repository root, with a Windows-safe ignored prompt-file transport and resumable manual fallback
- capture verified Graph grounding, migrate and index the Wiki with configured scope, and block false readiness
- print the exact canonical Git commit checkpoint required before `mex hub`
- bootstrap future Claude Code and Codex sessions into `.mex/AGENTS.md` and `.mex/ROUTER.md`
- add a true packed fresh-consumer setup smoke without expanding the CI matrix

## Validation

- `npm run typecheck`
- focused setup and integration tests: 99 passed
- merged PR #165 release-benchmark tests: 49 passed
- `npm run test:hub:package`
- `git diff --check`

## Integration

This branch includes the latest `integration/human-team-memory-v1` head (`28cdc79`, PR #165) through merge commit `0395b7c`.