### PR TITLE
fix(drift): stop reporting broken links and dead edges that are not broken

### DIFF
--- a/src/drift/checkers/broken-link.ts
+++ b/src/drift/checkers/broken-link.ts
@@ -5,6 +5,50 @@ import type { DriftIssue } from "../../types.js";
 
 const LINK_RE = /\[([^\]]*)\]\(([^)]+)\)/g;
 
+const COMMENT_OPEN = "<!--";
+const COMMENT_CLOSE = "-->";
+
+/**
+ * Remove the commented-out spans of one line, continuing a comment that opened
+ * on an earlier line. Markdown renders nothing inside `<!-- -->`, so a link
+ * there is illustrative text rather than a claim the scaffold makes -- the
+ * shipped `patterns/INDEX.md` documents its own table format that way, and
+ * scanning it made every fresh scaffold flag links to files that were never
+ * meant to exist. See https://github.com/mex-memory/mex/issues/108
+ *
+ * An unterminated comment runs to the end of the file, matching how a renderer
+ * treats it: the rest of the document is swallowed rather than shown.
+ */
+export function stripHtmlComments(
+  line: string,
+  inComment: boolean
+): { text: string; inComment: boolean } {
+  let text = "";
+  let index = 0;
+  let open = inComment;
+
+  while (index < line.length) {
+    if (open) {
+      const close = line.indexOf(COMMENT_CLOSE, index);
+      if (close === -1) break;
+      open = false;
+      index = close + COMMENT_CLOSE.length;
+      continue;
+    }
+
+    const start = line.indexOf(COMMENT_OPEN, index);
+    if (start === -1) {
+      text += line.slice(index);
+      break;
+    }
+    text += line.slice(index, start);
+    open = true;
+    index = start + COMMENT_OPEN.length;
+  }
+
+  return { text, inComment: open };
+}
+
 /** Scan scaffold markdown for local links whose target file does not exist. */
 export function checkBrokenLinks(
   scaffoldFiles: string[],
@@ -25,17 +69,30 @@ export function checkBrokenLinks(
     const fileDir = dirname(filePath);
     const lines = content.split("\n");
     let inFence = false;
+    let inComment = false;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      const trimmed = line.trim();
-      if (trimmed.startsWith("```")) {
-        inFence = !inFence;
-        continue;
-      }
-      if (inFence) continue;
 
-      const scanLine = line.replace(/`[^`]+`/g, "");
+      // A fence marker inside a comment is commented-out text, not a fence, so
+      // the fence state only advances on lines the renderer would show.
+      if (!inComment) {
+        const trimmed = line.trim();
+        if (trimmed.startsWith("```")) {
+          inFence = !inFence;
+          continue;
+        }
+        if (inFence) continue;
+      }
+
+      // Inline code is stripped first so a documented marker -- `<!--` written
+      // as an example -- cannot open a comment that swallows the rest of the
+      // file. Inside an open comment there is nothing to protect.
+      const withoutInlineCode = inComment ? line : line.replace(/`[^`]+`/g, "");
+      const stripped = stripHtmlComments(withoutInlineCode, inComment);
+      inComment = stripped.inComment;
+      const scanLine = stripped.text;
+
       LINK_RE.lastIndex = 0;
       let match: RegExpExecArray | null;
       while ((match = LINK_RE.exec(scanLine)) !== null) {

--- a/src/drift/checkers/broken-link.ts
+++ b/src/drift/checkers/broken-link.ts
@@ -19,7 +19,7 @@ const COMMENT_CLOSE = "-->";
  * An unterminated comment runs to the end of the file, matching how a renderer
  * treats it: the rest of the document is swallowed rather than shown.
  */
-export function stripHtmlComments(
+function stripHtmlComments(
   line: string,
   inComment: boolean
 ): { text: string; inComment: boolean } {

--- a/src/drift/checkers/edges.ts
+++ b/src/drift/checkers/edges.ts
@@ -17,10 +17,16 @@ export function checkEdges(
   for (const edge of frontmatter.edges) {
     if (!edge.target) continue;
 
-    // Try project root, then scaffold root
-    const fromProject = resolve(projectRoot, edge.target);
+    // Try the declaring file's own directory first, then scaffold root, then
+    // project root. Only ROUTER.md sits at the scaffold root, so resolving
+    // from the roots alone made every relative edge written from a pattern
+    // file -- `../context/architecture.md`, or a sibling pattern -- look dead
+    // while the target was right there. Markdown links in the same scaffold
+    // already resolve this way.
+    const fromFile = resolve(dirname(filePath), edge.target);
     const fromScaffold = resolve(scaffoldRoot, edge.target);
-    if (!existsSync(fromProject) && !existsSync(fromScaffold)) {
+    const fromProject = resolve(projectRoot, edge.target);
+    if (!existsSync(fromFile) && !existsSync(fromScaffold) && !existsSync(fromProject)) {
       issues.push({
         code: "DEAD_EDGE",
         severity: "error",

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -812,6 +812,79 @@ describe("checkBrokenLinks", () => {
     expect(issues).toHaveLength(0);
   });
 
+  it("does not scan links inside a single-line HTML comment", () => {
+    const file = join(tmpDir, "ROUTER.md");
+    writeFileSync(file, "Intro.\n\n<!-- [example](./nowhere.md) -->\n");
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("does not scan links inside a multi-line HTML comment", () => {
+    mkdirSync(join(tmpDir, "patterns"), { recursive: true });
+    const file = join(tmpDir, "patterns/INDEX.md");
+    writeFileSync(
+      file,
+      "# Pattern Index\n\n<!-- This file is populated during setup.\n" +
+      "     | [filename.md](filename.md) | One-line description |\n" +
+      "     | [add-api-client.md](add-api-client.md) | Adding an integration |\n" +
+      "     Keep this table sorted alphabetically. -->\n\n| Pattern | Use when |\n"
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("still flags a link on the visible side of a same-line comment", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "context/guide.md");
+    writeFileSync(file, "See [real](./missing.md) <!-- [hidden](./hidden.md) -->\n");
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe("Markdown link target does not exist: ./missing.md");
+  });
+
+  it("resumes scanning after a comment closes", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "context/guide.md");
+    writeFileSync(
+      file,
+      "<!-- [hidden](./hidden.md)\nstill hidden -->\n\nSee [real](./missing.md).\n"
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      line: 4,
+      message: "Markdown link target does not exist: ./missing.md",
+    });
+  });
+
+  it("treats an unclosed comment as running to the end of the file", () => {
+    const file = join(tmpDir, "SYNC.md");
+    writeFileSync(file, "Intro.\n\n<!-- draft notes\n[never](./nowhere.md)\n");
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("does not open a comment from a marker inside inline code", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "context/guide.md");
+    writeFileSync(file, "Write `<!--` to open one.\n\nSee [real](./missing.md).\n");
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe("Markdown link target does not exist: ./missing.md");
+  });
+
+  it("does not treat a comment marker inside a fence as a comment", () => {
+    mkdirSync(join(tmpDir, "context"), { recursive: true });
+    const file = join(tmpDir, "context/guide.md");
+    writeFileSync(
+      file,
+      "```html\n<!-- how to comment\n```\n\nSee [real](./missing.md).\n"
+    );
+    const issues = checkBrokenLinks([file], tmpDir, tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toBe("Markdown link target does not exist: ./missing.md");
+  });
+
   it("downgrades broken links in patterns/ to warning", () => {
     mkdirSync(join(tmpDir, "patterns"), { recursive: true });
     const file = join(tmpDir, "patterns/example.md");

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -223,6 +223,50 @@ describe("checkEdges", () => {
     expect(issues).toHaveLength(0);
   });
 
+  it("resolves an edge target relative to the file that declares it", () => {
+    const mexDir = join(tmpDir, ".mex");
+    mkdirSync(join(mexDir, "context"), { recursive: true });
+    mkdirSync(join(mexDir, "patterns"), { recursive: true });
+    writeFileSync(join(mexDir, "context/architecture.md"), "");
+    const file = join(mexDir, "patterns/durable-change-signal.md");
+    writeFileSync(file, "");
+    const fm: ScaffoldFrontmatter = {
+      edges: [{ target: "../context/architecture.md" }],
+    };
+    const issues = checkEdges(fm, file, ".mex/patterns/durable-change-signal.md", tmpDir, mexDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("resolves a sibling edge target from inside patterns/", () => {
+    const mexDir = join(tmpDir, ".mex");
+    mkdirSync(join(mexDir, "patterns"), { recursive: true });
+    writeFileSync(join(mexDir, "patterns/safe-graph-snapshot-evolution.md"), "");
+    const file = join(mexDir, "patterns/durable-change-signal.md");
+    writeFileSync(file, "");
+    const fm: ScaffoldFrontmatter = {
+      edges: [{ target: "safe-graph-snapshot-evolution.md" }],
+    };
+    const issues = checkEdges(fm, file, ".mex/patterns/durable-change-signal.md", tmpDir, mexDir);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("still reports an edge target that resolves nowhere", () => {
+    const mexDir = join(tmpDir, ".mex");
+    mkdirSync(join(mexDir, "patterns"), { recursive: true });
+    const file = join(mexDir, "patterns/example.md");
+    writeFileSync(file, "");
+    const fm: ScaffoldFrontmatter = {
+      edges: [{ target: "../context/nowhere.md" }],
+    };
+    const issues = checkEdges(fm, file, ".mex/patterns/example.md", tmpDir, mexDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      code: "DEAD_EDGE",
+      file: ".mex/patterns/example.md",
+      message: "Frontmatter edge target does not exist: ../context/nowhere.md",
+    });
+  });
+
   it("returns empty for no frontmatter", () => {
     expect(checkEdges(null, "f", "f", tmpDir, tmpDir)).toEqual([]);
   });


### PR DESCRIPTION
## What

Two false-positive fixes in the drift checkers, both in scaffold parsing:

- **`BROKEN_LINK` inside HTML comments.** `checkBrokenLinks` stripped fenced
  blocks and inline code but scanned commented-out text. The shipped
  `templates/patterns/INDEX.md` documents its own table format inside a
  `<!-- -->` block, so every fresh scaffold reported seven broken links to
  files that were never meant to exist. Comment state is now tracked across
  lines the way fence state already was.

- **`DEAD_EDGE` for relative frontmatter edges.** `checkEdges` resolved every
  edge target against the scaffold root and the project root, never against
  the directory of the file that declared it. Only `ROUTER.md` sits at the
  scaffold root, so a pattern file writing `../context/architecture.md` or a
  sibling pattern name had its target reported dead while the file was right
  there. The declaring file's own directory is now tried first, the way
  Markdown links in the same scaffold already resolve.

Two ordering details in the first fix are deliberate and covered by tests:
inline code is stripped before comment detection, so a marker written as an
example (`` `<!--` ``) cannot open a comment that swallows the rest of the
file; and a fence marker inside a comment no longer toggles the fence.

## Why

Closes #108.

The dead-edge half has no separate issue — it was found while measuring #109
and is included here because it is the same class of defect (the checker
reporting a problem that does not exist) and the same one-file shape. It is
the single largest contributor to this repo's own drift score: ten of its
eighteen errors were false.

Both bugs make `mex check` untrustworthy in the way #106–#109 describe: a
scaffold is penalised for documentation that is correct.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

## How to test

Scaffold a fresh project and check it — this is the case users hit first:

1. `mkdir demo && cd demo && git init && npm init -y`
2. Copy `templates/{ROUTER,AGENTS,SETUP,SYNC}.md`, `templates/context/*.md` and
   `templates/patterns/{README,INDEX}.md` into `demo/.mex/` (this is what
   `mex setup` writes before the AI population pass).
3. `mex check`

Before: `79/100 — 0 errors, 7 warnings`, all seven `BROKEN_LINK` pointing at
`filename.md`, `add-api-client.md`, `crud-operations.md` — the example rows
inside the comment at `INDEX.md:5-22`.
After: `100/100 — 0 errors, 0 warnings`.

For the dead-edge half, run `mex check` in this repo. Before: 18 errors,
ten of them `DEAD_EDGE` on `.mex/patterns/*.md` targets such as
`../context/architecture.md` and `safe-graph-snapshot-evolution.md`, all of
which exist. After: 8 errors, all genuine `STALE_FILE`.

## Checklist

- [x] Tests pass (`npm test`) — see note below
- [x] No breaking changes (or documented below)
- [x] Tested locally with a real project

**Note on `npm test`:** the 21 tests covering these checkers pass
(13 `checkBrokenLinks`, 8 `checkEdges`), and `npm run typecheck` is clean.
The full suite does not pass on this branch — but it does not pass on `main`
either. Measured with a hermetic `TMPDIR` on the same machine, `main` at
c3383a1 fails 47 tests and this branch fails 40; comparing failures by name
across two full runs, the set of failures unique to this branch is **empty**.
The differences are flaky tests in
`team-inbox-spec-authoring-real.contract.test.ts` that fail on `main` and pass
here. Happy to attach both JSON reports if useful.

**Verified against real scaffolds**, comparing a `main` build to this branch:

| Scaffold | main | this branch |
|---|---|---|
| fresh scaffold from `templates/` | 79/100 (7 warnings) | **100/100 (clean)** |
| a populated v0.8 scaffold | 54/100 (1E, 12W) | 54/100 (1E, 12W) |
| a populated v0.7 scaffold | 78/100 (1E, 4W) | 78/100 (1E, 4W) |
| this repo | 0/100 (18E, 11W) | 0/100 (**8E**, 11W) |

The populated scaffolds are byte-identical before and after, which is the
property that matters: this removes noise without starting to hide real
broken links or dead edges.

## Code-graph changes

- [ ] This PR targets `main`
- [ ] A linked issue agrees on the bounded extractor/resolver scope
- [ ] The change follows the frozen `LanguageExtractor` or `FrameworkResolver` interface
- [ ] A focused fixture and assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered
- [ ] No graph identity, reconciliation, schema, or drift-semantics changes are included, or a `core / discuss-first` issue is linked above