### PR TITLE
fix(setup): link the scaffold from every tool anchor, and detect when nothing does

### DIFF
--- a/src/agent-skills/instructions.ts
+++ b/src/agent-skills/instructions.ts
@@ -1,9 +1,5 @@
-import { createHash } from "node:crypto";
-import type {
-  AgentAssetActionName,
-  AgentInstructionChange,
-  AgentSkillClient,
-} from "./types.js";
+import { planManagedBlockEdit } from "../managed-block.js";
+import type { AgentInstructionChange, AgentSkillClient } from "./types.js";
 import { AGENT_SKILL_TARGETS } from "./types.js";
 
 export const MEX_INSTRUCTIONS_START = "<!-- mex-agent:skills:start -->";
@@ -28,7 +24,7 @@ export const KNOWN_LEGACY_INSTRUCTION_SHA256: Readonly<
 };
 
 export interface ManagedInstructionEdit {
-  readonly action: Extract<AgentAssetActionName, "create" | "migrate" | "update" | "noop" | "conflict">;
+  readonly action: "create" | "migrate" | "update" | "noop" | "conflict";
   readonly desiredBytes?: Uint8Array;
   readonly instructionChange?: AgentInstructionChange;
   readonly reason:
@@ -72,116 +68,24 @@ export function planManagedInstructionEdit(
   currentBytes: Uint8Array | null,
   additionalLegacyHashes: readonly string[] = [],
 ): ManagedInstructionEdit {
-  if (currentBytes === null) {
-    const after = renderManagedInstructionBlock(client);
-    return {
-      action: "create",
-      desiredBytes: Buffer.from(`${after}\n`, "utf8"),
-      instructionChange: { scope: "create", before: null, after },
-      reason: "absent",
-    };
-  }
+  const edit = planManagedBlockEdit(
+    {
+      start: MEX_INSTRUCTIONS_START,
+      end: MEX_INSTRUCTIONS_END,
+      render: (eol) => renderManagedInstructionBlock(client, eol),
+      maxPreviewBytes: MAX_MANAGED_INSTRUCTION_PREVIEW_BYTES,
+      legacyHashes: new Set([
+        ...KNOWN_LEGACY_INSTRUCTION_SHA256[client],
+        ...additionalLegacyHashes.map((hash) => hash.toLowerCase()),
+      ]),
+    },
+    currentBytes,
+  );
 
-  let current: string;
-  try {
-    // `ignoreBOM: true` counterintuitively means "do not consume the BOM".
-    // Keeping U+FEFF in the decoded string preserves the original BOM bytes.
-    current = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(currentBytes);
-  } catch {
-    return { action: "conflict", reason: "invalid-encoding" };
-  }
-
-  const starts = allIndexesOf(current, MEX_INSTRUCTIONS_START);
-  const ends = allIndexesOf(current, MEX_INSTRUCTIONS_END);
-  if (starts.length === 0 && ends.length === 0) {
-    const currentHash = sha256(currentBytes);
-    const legacyHashes = new Set([
-      ...KNOWN_LEGACY_INSTRUCTION_SHA256[client],
-      ...additionalLegacyHashes.map((hash) => hash.toLowerCase()),
-    ]);
-    if (legacyHashes.has(currentHash)) {
-      const eol = detectEol(current);
-      const after = renderManagedInstructionBlock(client, eol);
-      return {
-        action: "migrate",
-        desiredBytes: Buffer.from(`${after}${eol}`, "utf8"),
-        instructionChange: {
-          scope: "known-legacy-migration",
-          before: null,
-          after,
-        },
-        reason: "legacy",
-      };
-    }
-
-    const eol = detectEol(current);
-    const after = renderManagedInstructionBlock(client, eol);
-    const separator = current.length === 0 ? "" : current.endsWith("\n") ? eol : `${eol}${eol}`;
-    const desired = `${current}${separator}${after}${eol}`;
-    return {
-      action: "update",
-      desiredBytes: Buffer.from(desired, "utf8"),
-      instructionChange: { scope: "append", before: null, after },
-      reason: "append",
-    };
-  }
-
-  if (
-    starts.length !== 1 ||
-    ends.length !== 1 ||
-    starts[0]! >= ends[0]! ||
-    !isStandaloneMarker(current, starts[0]!, MEX_INSTRUCTIONS_START) ||
-    !isStandaloneMarker(current, ends[0]!, MEX_INSTRUCTIONS_END)
-  ) {
-    return { action: "conflict", reason: "malformed-markers" };
-  }
-
-  const eol = detectEol(current);
-  const before = current.slice(starts[0]!, ends[0]! + MEX_INSTRUCTIONS_END.length);
-  if (Buffer.byteLength(before, "utf8") > MAX_MANAGED_INSTRUCTION_PREVIEW_BYTES) {
-    return { action: "conflict", reason: "managed-block-too-large" };
-  }
-  const after = renderManagedInstructionBlock(client, eol);
-  const desired =
-    current.slice(0, starts[0]!) +
-    after +
-    current.slice(ends[0]! + MEX_INSTRUCTIONS_END.length);
-  if (desired === current) {
-    return { action: "noop", reason: "exact" };
-  }
   return {
-    action: "update",
-    desiredBytes: Buffer.from(desired, "utf8"),
-    instructionChange: { scope: "replace", before, after },
-    reason: "replace",
+    action: edit.action,
+    desiredBytes: edit.desiredBytes,
+    instructionChange: edit.change,
+    reason: edit.reason,
   };
-}
-
-function sha256(bytes: Uint8Array): string {
-  return createHash("sha256").update(bytes).digest("hex");
-}
-
-function detectEol(content: string): "\n" | "\r\n" {
-  return content.includes("\r\n") ? "\r\n" : "\n";
-}
-
-function allIndexesOf(content: string, needle: string): number[] {
-  const indexes: number[] = [];
-  let offset = 0;
-  while (offset <= content.length - needle.length) {
-    const found = content.indexOf(needle, offset);
-    if (found < 0) break;
-    indexes.push(found);
-    offset = found + needle.length;
-  }
-  return indexes;
-}
-
-function isStandaloneMarker(content: string, index: number, marker: string): boolean {
-  const before = index === 0 ? "" : content[index - 1];
-  const afterIndex = index + marker.length;
-  const after = afterIndex === content.length ? "" : content[afterIndex];
-  const beginsLine = before === "" || before === "\n";
-  const endsLine = after === "" || after === "\n" || (after === "\r" && content[afterIndex + 1] === "\n");
-  return beginsLine && endsLine;
 }

--- a/src/drift/checkers/anchor-link.ts
+++ b/src/drift/checkers/anchor-link.ts
@@ -27,6 +27,23 @@ import {
 const FIX_HINT =
   "Add a line naming `.mex/ROUTER.md` to it, or rerun `mex setup` to have one appended.";
 
+/**
+ * Whether the scaffold records an explicit decision to install no tool config.
+ * Absent or malformed config is not a decision, so it does not silence the
+ * check -- only an `aiTools` present and empty does.
+ */
+function optedOutOfToolConfigs(scaffoldRoot: string): boolean {
+  try {
+    const raw = readFileSync(resolve(scaffoldRoot, "config.json"), "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return false;
+    const tools = (parsed as Record<string, unknown>).aiTools;
+    return Array.isArray(tools) && tools.length === 0;
+  } catch {
+    return false;
+  }
+}
+
 /** Whether one anchor file points at the scaffold. */
 function anchorPointsAtScaffold(projectRoot: string, path: string, format: string): boolean {
   const abs = resolve(projectRoot, path);
@@ -58,6 +75,11 @@ export function checkAnchorLink(projectRoot: string, scaffoldRoot: string): Drif
   // the "scaffold is incomplete" story; this one only asks about reachability.
   if (!existsSync(resolve(scaffoldRoot, "ROUTER.md"))) return [];
 
+  // Setup offers "None / skip", whose whole point is that `.mex/AGENTS.md`
+  // works with any tool that can read files. Someone who chose that made this
+  // trade-off deliberately and does not need it reported back at them.
+  if (optedOutOfToolConfigs(scaffoldRoot)) return [];
+
   const present = ANCHOR_FILES.filter((anchor) =>
     existsSync(resolve(projectRoot, anchor.path)),
   );
@@ -84,20 +106,21 @@ export function checkAnchorLink(projectRoot: string, scaffoldRoot: string): Drif
   // Report against the anchor itself, not the scaffold: that is the file the
   // user has to edit, and `mex check` output is read as a worklist.
   const paths = present.map((anchor) => anchor.path);
+  const subject =
+    paths.length === 1
+      ? `${paths[0]} never mentions \`.mex/\``
+      : `${describe(paths)} exist, but none of them mentions \`.mex/\``;
   return [
     {
       code: "SCAFFOLD_ORPHANED",
       severity: "error",
       file: paths[0]!,
       line: null,
-      message:
-        `${describe(paths)} exist but none of them mentions \`.mex/\`, so the populated scaffold is never loaded. `
-        + FIX_HINT,
+      message: `${subject}, so the populated scaffold is never loaded. ${FIX_HINT}`,
     },
   ];
 }
 
 function describe(paths: readonly string[]): string {
-  if (paths.length === 1) return paths[0]!;
   return `${paths.slice(0, -1).join(", ")} and ${paths[paths.length - 1]}`;
 }

--- a/src/drift/checkers/anchor-link.ts
+++ b/src/drift/checkers/anchor-link.ts
@@ -1,0 +1,103 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { DriftIssue } from "../../types.js";
+import {
+  ANCHOR_FILES,
+  opencodeInstructions,
+  referencesScaffold,
+} from "../../tool-config.js";
+
+/**
+ * Does anything actually load the scaffold?
+ *
+ * A `.mex/` directory is only worth its population cost if some always-loaded
+ * file tells the agent to read it. Claude Code loads `CLAUDE.md`, Cursor loads
+ * `.cursorrules`; none of them go looking for `.mex/ROUTER.md` unaided. So a
+ * scaffold with no anchor pointing at it is correct, complete, and inert --
+ * and nothing else in `mex check` notices, because every other checker
+ * validates the scaffold's contents rather than its reachability.
+ *
+ * Setup now writes the pointer itself, but this check is the durable half: it
+ * keeps working when the anchor is deleted later, restored from a template, or
+ * replaced by a teammate who never ran setup.
+ *
+ * See https://github.com/mex-memory/mex/issues/106
+ */
+
+const FIX_HINT =
+  "Add a line naming `.mex/ROUTER.md` to it, or rerun `mex setup` to have one appended.";
+
+/** Whether one anchor file points at the scaffold. */
+function anchorPointsAtScaffold(projectRoot: string, path: string, format: string): boolean {
+  const abs = resolve(projectRoot, path);
+  if (!existsSync(abs)) return false;
+  let content: string;
+  try {
+    content = readFileSync(abs, "utf-8");
+  } catch {
+    // Unreadable file: treat as no evidence rather than reporting a
+    // checker-internal error the user cannot act on.
+    return false;
+  }
+  if (format === "json") {
+    const instructions = opencodeInstructions(content);
+    if (instructions === null) return false;
+    return instructions.some((entry) => entry.startsWith(".mex/") || referencesScaffold(entry));
+  }
+  return referencesScaffold(content);
+}
+
+/**
+ * Report a populated scaffold that no root anchor references.
+ *
+ * `scaffoldRoot` is passed rather than assumed so a scaffold configured
+ * somewhere other than `<root>/.mex` is still checked.
+ */
+export function checkAnchorLink(projectRoot: string, scaffoldRoot: string): DriftIssue[] {
+  // Without a router there is no scaffold to orphan. The other checkers own
+  // the "scaffold is incomplete" story; this one only asks about reachability.
+  if (!existsSync(resolve(scaffoldRoot, "ROUTER.md"))) return [];
+
+  const present = ANCHOR_FILES.filter((anchor) =>
+    existsSync(resolve(projectRoot, anchor.path)),
+  );
+
+  if (present.length === 0) {
+    return [
+      {
+        code: "SCAFFOLD_ORPHANED",
+        severity: "error",
+        file: ".mex/ROUTER.md",
+        line: null,
+        message:
+          "The scaffold is populated but no AI tool config exists to load it, so no agent will read it. "
+          + `Run \`mex setup\` to create one (${ANCHOR_FILES.map((a) => a.path).join(", ")}).`,
+      },
+    ];
+  }
+
+  const linked = present.filter((anchor) =>
+    anchorPointsAtScaffold(projectRoot, anchor.path, anchor.format),
+  );
+  if (linked.length > 0) return [];
+
+  // Report against the anchor itself, not the scaffold: that is the file the
+  // user has to edit, and `mex check` output is read as a worklist.
+  const paths = present.map((anchor) => anchor.path);
+  return [
+    {
+      code: "SCAFFOLD_ORPHANED",
+      severity: "error",
+      file: paths[0]!,
+      line: null,
+      message:
+        `${describe(paths)} exist but none of them mentions \`.mex/\`, so the populated scaffold is never loaded. `
+        + FIX_HINT,
+    },
+  ];
+}
+
+function describe(paths: readonly string[]): string {
+  if (paths.length === 1) return paths[0]!;
+  return `${paths.slice(0, -1).join(", ")} and ${paths[paths.length - 1]}`;
+}

--- a/src/drift/checkers/tool-config-sync.ts
+++ b/src/drift/checkers/tool-config-sync.ts
@@ -1,12 +1,14 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import type { DriftIssue } from "../../types.js";
+import { MEX_ANCHOR_END, MEX_ANCHOR_START, isToolConfigCopy } from "../../tool-config.js";
+import { MEX_INSTRUCTIONS_END, MEX_INSTRUCTIONS_START } from "../../agent-skills/instructions.js";
 
 /**
- * Files that `setup.sh` may copy with identical content from `.tool-configs/`.
+ * Files that setup may copy with identical content from `.tool-configs/`.
  * If a user installs more than one tool and later edits one of these files in
  * place, the copies can silently drift out of sync. `.opencode/opencode.json`
- * is intentionally excluded -- it's a different format and references
+ * is intentionally excluded -- it is a different format and references
  * `.mex/AGENTS.md` rather than embedding the same text.
  */
 const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
@@ -18,35 +20,33 @@ const TOOL_CONFIG_FILES: ReadonlyArray<string> = [
 ];
 
 /**
- * A file only participates in the sync check when it is actually a copy of the
- * mex tool config -- recognised by the sentinel comment every generated
- * template carries. Repos commonly have a hand-written CLAUDE.md or a
- * generated AGENTS.md that never came from `.tool-configs/`; those may still
- * mention ROUTER.md in ordinary guidance, so only the dedicated sentinel is
- * proof of scaffold origin.
+ * Blocks mex maintains inside an anchor, which are expected to differ between
+ * copies and must not count as drift.
  *
- * Anchored to the start of a line so a file that merely quotes the sentinel in
- * prose is not mistaken for a copy.
+ * `CLAUDE.md` carries the agent-skills policy block and `.cursorrules` cannot
+ * -- Cursor has no mex skills to invoke. Comparing the raw bytes therefore
+ * reported an install of both tools as permanently drifted, with no edit the
+ * user could make to clear it: matching the files would mean deleting a block
+ * the installer rewrites on every sync. Compare what the user owns instead.
  */
-const SCAFFOLD_MARKER = /^<!-- mex-tool-config\b/m;
+const MANAGED_BLOCKS: ReadonlyArray<readonly [string, string]> = [
+	[MEX_INSTRUCTIONS_START, MEX_INSTRUCTIONS_END],
+	[MEX_ANCHOR_START, MEX_ANCHOR_END],
+];
 
-/**
- * Copies installed before the sentinel shipped do not carry it, and nothing
- * rewrites them: `mex setup` skips any destination that already exists, so an
- * installed anchor is never re-copied. Without a second signal the check would
- * go silent for every pre-existing install -- real drift, no warning.
- *
- * This frontmatter line has been byte-stable across every tool config template
- * since the initial commit, so it identifies those copies with no migration
- * step. It is mex's own template prose and does not appear in an independently
- * owned config. Bridge only: drop it at a major version once installs have
- * turned over, leaving the sentinel as the sole contract.
- */
-const LEGACY_MARKER = "Always-loaded project anchor. Read this first.";
-
-/** Whether a file is a copy of the mex tool config, new sentinel or legacy. */
-function isScaffoldCopy(content: string): boolean {
-	return SCAFFOLD_MARKER.test(content) || content.includes(LEGACY_MARKER);
+/** Remove every mex-managed block, leaving the user-owned remainder. */
+function stripManagedBlocks(content: string): string {
+	let result = content;
+	for (const [start, end] of MANAGED_BLOCKS) {
+		const from = result.indexOf(start);
+		if (from === -1) continue;
+		const to = result.indexOf(end, from);
+		if (to === -1) continue;
+		result = result.slice(0, from) + result.slice(to + end.length);
+	}
+	// Line endings are a checkout artifact, not an edit: a repo without a
+	// `text` attribute hands CRLF to Windows and LF to CI for the same commit.
+	return result.replace(/\r\n/g, "\n").trim();
 }
 
 /** One copy differs from what the others agree on. */
@@ -68,8 +68,8 @@ export function checkToolConfigSync(projectRoot: string): DriftIssue[] {
 		if (!existsSync(abs)) continue;
 		try {
 			const content = readFileSync(abs, "utf-8");
-			if (!isScaffoldCopy(content)) continue;
-			present.push({ path: rel, content });
+			if (!isToolConfigCopy(content)) continue;
+			present.push({ path: rel, content: stripManagedBlocks(content) });
 		} catch {
 			// Unreadable file -- ignore rather than reporting a checker-internal error.
 		}

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -16,6 +16,7 @@ import { checkDependencies } from "./checkers/dependency.js";
 import { checkCrossFile } from "./checkers/cross-file.js";
 import { checkScriptCoverage } from "./checkers/script-coverage.js";
 import { checkToolConfigSync } from "./checkers/tool-config-sync.js";
+import { checkAnchorLink } from "./checkers/anchor-link.js";
 import { checkTodoFixme } from "./checkers/todo-fixme.js";
 import { checkBrokenLinks } from "./checkers/broken-link.js";
 import { toPosix } from "../paths.js";
@@ -282,6 +283,10 @@ export async function runDriftCheckWithGraphStatus(
     const scriptCoverageIssues = checkScriptCoverage(scaffoldFiles, projectRoot);
     allIssues.push(...scriptCoverageIssues);
     checkerIssueCounts.push(["script-coverage", scriptCoverageIssues.length]);
+
+    const anchorLinkIssues = checkAnchorLink(projectRoot, scaffoldRoot);
+    allIssues.push(...anchorLinkIssues);
+    checkerIssueCounts.push(["anchor-link", anchorLinkIssues.length]);
 
     const toolConfigSyncIssues = checkToolConfigSync(projectRoot);
     allIssues.push(...toolConfigSyncIssues);

--- a/src/managed-block.ts
+++ b/src/managed-block.ts
@@ -1,0 +1,191 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Merging a mex-owned block into a file the user already wrote.
+ *
+ * Two callers need this and they must not diverge: the agent-skills installer
+ * maintains the skills policy block in `CLAUDE.md` / `AGENTS.md`, and setup
+ * maintains a scaffold pointer block in the anchors that have no skills
+ * (`.cursorrules`, `.windsurfrules`, `.github/copilot-instructions.md`). Both
+ * face the same hazard -- a hand-written file whose bytes outside the block
+ * must survive byte-for-byte -- so the marker parsing, EOL detection and
+ * append/replace decision live here once.
+ */
+
+export type ManagedBlockAction =
+  | "create"
+  | "migrate"
+  | "update"
+  | "noop"
+  | "conflict";
+
+export type ManagedBlockScope =
+  | "create"
+  | "append"
+  | "replace"
+  | "known-legacy-migration";
+
+export type ManagedBlockReason =
+  | "absent"
+  | "legacy"
+  | "append"
+  | "replace"
+  | "exact"
+  | "managed-block-too-large"
+  | "malformed-markers"
+  | "invalid-encoding";
+
+/** Bounded exact block preview; never contains arbitrary user-file bytes. */
+export interface ManagedBlockChange {
+  readonly scope: ManagedBlockScope;
+  /** Exact previous marker-delimited block, or null when none existed. */
+  readonly before: string | null;
+  /** Exact marker-delimited block that will be installed. */
+  readonly after: string;
+}
+
+export interface ManagedBlockEdit {
+  readonly action: ManagedBlockAction;
+  readonly desiredBytes?: Uint8Array;
+  readonly change?: ManagedBlockChange;
+  readonly reason: ManagedBlockReason;
+}
+
+export interface ManagedBlockSpec {
+  readonly start: string;
+  readonly end: string;
+  /** Renders the full block, markers included, using the file's own EOL. */
+  readonly render: (eol: "\n" | "\r\n") => string;
+  /** Refuse to preview a block larger than this, in bytes. */
+  readonly maxPreviewBytes: number;
+  /**
+   * Exact SHA-256 values of files a previous mex version wrote verbatim. Such
+   * a file is replaced wholesale rather than appended to, since every byte of
+   * it is already mex's. A hand-edited descendant does not match and is
+   * appended to instead.
+   */
+  readonly legacyHashes?: ReadonlySet<string>;
+  /**
+   * Recognises a file that already carries mex's pointer by other means -- an
+   * older full-template copy, say. Such a file needs no block: appending one
+   * would duplicate guidance the file already gives.
+   */
+  readonly isAlreadyPointing?: (content: string) => boolean;
+}
+
+/**
+ * Compute an edit without writing. Bytes outside a valid managed block are
+ * copied into the desired output unchanged.
+ */
+export function planManagedBlockEdit(
+  spec: ManagedBlockSpec,
+  currentBytes: Uint8Array | null,
+): ManagedBlockEdit {
+  if (currentBytes === null) {
+    const after = spec.render("\n");
+    return {
+      action: "create",
+      desiredBytes: Buffer.from(`${after}\n`, "utf8"),
+      change: { scope: "create", before: null, after },
+      reason: "absent",
+    };
+  }
+
+  let current: string;
+  try {
+    // `ignoreBOM: true` counterintuitively means "do not consume the BOM".
+    // Keeping U+FEFF in the decoded string preserves the original BOM bytes.
+    current = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(currentBytes);
+  } catch {
+    return { action: "conflict", reason: "invalid-encoding" };
+  }
+
+  const starts = allIndexesOf(current, spec.start);
+  const ends = allIndexesOf(current, spec.end);
+
+  if (starts.length === 0 && ends.length === 0) {
+    const eol = detectEol(current);
+
+    if (spec.legacyHashes?.has(sha256(currentBytes))) {
+      const after = spec.render(eol);
+      return {
+        action: "migrate",
+        desiredBytes: Buffer.from(`${after}${eol}`, "utf8"),
+        change: { scope: "known-legacy-migration", before: null, after },
+        reason: "legacy",
+      };
+    }
+
+    if (spec.isAlreadyPointing?.(current)) {
+      return { action: "noop", reason: "exact" };
+    }
+
+    const after = spec.render(eol);
+    const separator = current.length === 0 ? "" : current.endsWith("\n") ? eol : `${eol}${eol}`;
+    return {
+      action: "update",
+      desiredBytes: Buffer.from(`${current}${separator}${after}${eol}`, "utf8"),
+      change: { scope: "append", before: null, after },
+      reason: "append",
+    };
+  }
+
+  if (
+    starts.length !== 1 ||
+    ends.length !== 1 ||
+    starts[0]! >= ends[0]! ||
+    !isStandaloneMarker(current, starts[0]!, spec.start) ||
+    !isStandaloneMarker(current, ends[0]!, spec.end)
+  ) {
+    return { action: "conflict", reason: "malformed-markers" };
+  }
+
+  const eol = detectEol(current);
+  const before = current.slice(starts[0]!, ends[0]! + spec.end.length);
+  if (Buffer.byteLength(before, "utf8") > spec.maxPreviewBytes) {
+    return { action: "conflict", reason: "managed-block-too-large" };
+  }
+
+  const after = spec.render(eol);
+  const desired =
+    current.slice(0, starts[0]!) + after + current.slice(ends[0]! + spec.end.length);
+  if (desired === current) {
+    return { action: "noop", reason: "exact" };
+  }
+  return {
+    action: "update",
+    desiredBytes: Buffer.from(desired, "utf8"),
+    change: { scope: "replace", before, after },
+    reason: "replace",
+  };
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function detectEol(content: string): "\n" | "\r\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function allIndexesOf(content: string, needle: string): number[] {
+  const indexes: number[] = [];
+  let offset = 0;
+  while (offset <= content.length - needle.length) {
+    const found = content.indexOf(needle, offset);
+    if (found < 0) break;
+    indexes.push(found);
+    offset = found + needle.length;
+  }
+  return indexes;
+}
+
+function isStandaloneMarker(content: string, index: number, marker: string): boolean {
+  const before = index === 0 ? "" : content[index - 1];
+  const afterIndex = index + marker.length;
+  const after = afterIndex === content.length ? "" : content[afterIndex];
+  const beginsLine = before === "" || before === "\n";
+  const endsLine =
+    after === "" || after === "\n" || (after === "\r" && content[afterIndex + 1] === "\n");
+  return beginsLine && endsLine;
+}

--- a/src/setup/anchor.ts
+++ b/src/setup/anchor.ts
@@ -1,0 +1,176 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { planManagedBlockEdit } from "../managed-block.js";
+import {
+  MEX_ANCHOR_END,
+  MEX_ANCHOR_START,
+  isToolConfigCopy,
+  opencodeInstructions,
+  referencesScaffold,
+} from "../tool-config.js";
+
+export { MEX_ANCHOR_END, MEX_ANCHOR_START };
+
+/**
+ * Writing the scaffold pointer into a tool anchor the user may already own.
+ *
+ * Setup used to skip any anchor that already existed, which is the default
+ * outcome for the most likely adopter -- an established repo with a
+ * hand-written `.cursorrules`. The scaffold got populated, at the cost of a
+ * full AI pass over the codebase, and then nothing ever loaded it.
+ *
+ * Claude Code and Codex were rescued in 0.8 by the agent-skills installer.
+ * This is the same treatment for the four anchors that have no skills, and so
+ * never went through it. See https://github.com/mex-memory/mex/issues/106
+ */
+
+/** Matches the agent-skills cap: refuse to preview an unreasonable block. */
+const MAX_ANCHOR_PREVIEW_BYTES = 32 * 1024;
+
+/** The scaffold file OpenCode is pointed at, matching the shipped template. */
+const OPENCODE_INSTRUCTION = ".mex/AGENTS.md";
+
+export type AnchorOutcome =
+  /** No anchor existed; the full template was copied. */
+  | "created"
+  /** A pointer block was appended to the user's existing file. */
+  | "appended"
+  /** An existing mex-owned pointer block was brought up to date. */
+  | "updated"
+  /** The anchor already pointed at the scaffold; nothing to do. */
+  | "already-linked"
+  /** The file could not be edited safely and was left untouched. */
+  | "conflict";
+
+export interface AnchorWriteResult {
+  readonly outcome: AnchorOutcome;
+  /** Present only for `conflict`, explaining what to do by hand. */
+  readonly reason?: string;
+}
+
+/** The block appended to a markdown anchor that has no mex pointer. */
+export function renderAnchorPointerBlock(eol: "\n" | "\r\n" = "\n"): string {
+  return [
+    MEX_ANCHOR_START,
+    "## MEX project context",
+    "- At the start of every session, read `.mex/AGENTS.md` and `.mex/ROUTER.md` before project work; follow `ROUTER.md` to load only the relevant context.",
+    "- Treat the scaffold as the source of truth for architecture, stack, conventions, and decisions; prefer it over re-deriving context from the code.",
+    "- Do not claim an author, date, or historical event unless the retrieved data actually provides it.",
+    MEX_ANCHOR_END,
+  ].join(eol);
+}
+
+/**
+ * Plan the edit for a markdown anchor. Split out from the write so `--dry-run`
+ * reports the branch that will actually be taken -- the old dry-run message
+ * claimed setup would overwrite the file when the real run skipped it.
+ */
+export function planAnchorPointer(currentBytes: Uint8Array | null): AnchorWriteResult & {
+  readonly desiredBytes?: Uint8Array;
+} {
+  const edit = planManagedBlockEdit(
+    {
+      start: MEX_ANCHOR_START,
+      end: MEX_ANCHOR_END,
+      render: renderAnchorPointerBlock,
+      maxPreviewBytes: MAX_ANCHOR_PREVIEW_BYTES,
+      // A file mex itself wrote from `.tool-configs/` already carries the
+      // pointer in its own prose. Appending a block would restate it.
+      isAlreadyPointing: (content) => isToolConfigCopy(content) || referencesScaffold(content),
+    },
+    currentBytes,
+  );
+
+  switch (edit.action) {
+    case "create":
+      return { outcome: "created", desiredBytes: edit.desiredBytes };
+    case "noop":
+      return { outcome: "already-linked" };
+    case "update":
+      return {
+        outcome: edit.reason === "append" ? "appended" : "updated",
+        desiredBytes: edit.desiredBytes,
+      };
+    default:
+      return { outcome: "conflict", reason: conflictReason(edit.reason) };
+  }
+}
+
+function conflictReason(reason: string): string {
+  if (reason === "invalid-encoding") return "the file is not valid UTF-8";
+  if (reason === "malformed-markers") {
+    return `it contains unbalanced ${MEX_ANCHOR_START} / ${MEX_ANCHOR_END} markers`;
+  }
+  return "its existing mex block is too large to edit safely";
+}
+
+/**
+ * Ensure a markdown anchor points at the scaffold, preserving every byte the
+ * user wrote. Copies the template when the file is absent, appends a pointer
+ * block when it is not.
+ */
+export function ensureMarkdownAnchor(
+  projectRoot: string,
+  relativePath: string,
+  templatePath: string,
+): AnchorWriteResult {
+  const dest = resolve(projectRoot, relativePath);
+
+  if (!existsSync(dest)) {
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(templatePath, dest);
+    return { outcome: "created" };
+  }
+
+  const plan = planAnchorPointer(readFileSync(dest));
+  if (plan.desiredBytes) writeFileSync(dest, plan.desiredBytes);
+  return { outcome: plan.outcome, reason: plan.reason };
+}
+
+/**
+ * Plan the OpenCode edit without writing, so `--dry-run` reports the branch
+ * the real run will take.
+ */
+export function planOpencodeAnchor(content: string): AnchorWriteResult & {
+  readonly serialized?: string;
+} {
+  const instructions = opencodeInstructions(content);
+  if (instructions === null) {
+    return {
+      outcome: "conflict",
+      reason: "it is not a JSON object with an optional string `instructions` array",
+    };
+  }
+  if (instructions.some((entry) => entry.startsWith(".mex/") || referencesScaffold(entry))) {
+    return { outcome: "already-linked" };
+  }
+
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+  parsed.instructions = [...instructions, OPENCODE_INSTRUCTION];
+  const eol = content.includes("\r\n") ? "\r\n" : "\n";
+  const serialized = `${JSON.stringify(parsed, null, 2)}\n`.split("\n").join(eol);
+  return { outcome: "appended", serialized };
+}
+
+/**
+ * Ensure OpenCode's config lists a scaffold instruction file. OpenCode reads
+ * a JSON array rather than prose, so the merge is a list insertion; the rest
+ * of the user's config is preserved and re-serialized.
+ */
+export function ensureOpencodeAnchor(
+  projectRoot: string,
+  relativePath: string,
+  templatePath: string,
+): AnchorWriteResult {
+  const dest = resolve(projectRoot, relativePath);
+
+  if (!existsSync(dest)) {
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(templatePath, dest);
+    return { outcome: "created" };
+  }
+
+  const plan = planOpencodeAnchor(readFileSync(dest, "utf-8"));
+  if (plan.serialized !== undefined) writeFileSync(dest, plan.serialized, "utf-8");
+  return { outcome: plan.outcome, reason: plan.reason };
+}

--- a/src/setup/anchor.ts
+++ b/src/setup/anchor.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync } from
 import { dirname, resolve } from "node:path";
 import { planManagedBlockEdit } from "../managed-block.js";
 import {
+  ANCHOR_FILES,
   MEX_ANCHOR_END,
   MEX_ANCHOR_START,
   isToolConfigCopy,
@@ -26,6 +27,24 @@ export { MEX_ANCHOR_END, MEX_ANCHOR_START };
 
 /** Matches the agent-skills cap: refuse to preview an unreasonable block. */
 const MAX_ANCHOR_PREVIEW_BYTES = 32 * 1024;
+
+/**
+ * Fail closed on any destination that is not a known root tool config.
+ *
+ * This module writes into files a human wrote, so it is one of the few writers
+ * outside the wiki engine (see the pinned inventory in
+ * test/wiki-architecture.test.ts). It never touches `.mex/`, and this is what
+ * makes that a fact rather than a claim about current call sites: the
+ * destination comes from the fixed registry, not from the caller.
+ */
+function assertAnchorPath(relativePath: string): void {
+  if (!ANCHOR_FILES.some((anchor) => anchor.path === relativePath)) {
+    throw new Error(
+      `Refusing to write ${relativePath}: not a known AI tool config. `
+        + `Expected one of ${ANCHOR_FILES.map((a) => a.path).join(", ")}.`,
+    );
+  }
+}
 
 /** The scaffold file OpenCode is pointed at, matching the shipped template. */
 const OPENCODE_INSTRUCTION = ".mex/AGENTS.md";
@@ -114,6 +133,7 @@ export function ensureMarkdownAnchor(
   relativePath: string,
   templatePath: string,
 ): AnchorWriteResult {
+  assertAnchorPath(relativePath);
   const dest = resolve(projectRoot, relativePath);
 
   if (!existsSync(dest)) {
@@ -162,6 +182,7 @@ export function ensureOpencodeAnchor(
   relativePath: string,
   templatePath: string,
 ): AnchorWriteResult {
+  assertAnchorPath(relativePath);
   const dest = resolve(projectRoot, relativePath);
 
   if (!existsSync(dest)) {

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -31,6 +31,13 @@ import {
   verifySetupIgnoreProtection,
 } from "./ignore.js";
 import { finalizeSetupWiki } from "./wiki-finalize.js";
+import {
+  ensureMarkdownAnchor,
+  ensureOpencodeAnchor,
+  planAnchorPointer,
+  planOpencodeAnchor,
+  type AnchorWriteResult,
+} from "./anchor.js";
 
 // ── Constants ──
 
@@ -253,6 +260,7 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   // ── Step 3: Tool config selection ──
 
   let selectedTools: AiTool[] = [];
+  let anchorNotes: string[] = [];
 
   const configuredTools = scaffoldPopulatedAtStart ? findConfig(projectRoot).aiTools : [];
   if (configuredTools.length > 0) {
@@ -261,7 +269,9 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   } else {
     const rl = createInterface({ input: stdin, output: stdout });
     try {
-      selectedTools = await selectToolConfig(rl, projectRoot, dryRun);
+      const selection = await selectToolConfig(rl, projectRoot, dryRun);
+      selectedTools = selection.tools;
+      anchorNotes = selection.anchorNotes;
     } finally {
       rl.close();
     }
@@ -403,6 +413,7 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
     ok("Setup complete.");
   }
 
+  printAnchorNotes(anchorNotes);
   await promptGlobalInstall();
 }
 
@@ -468,7 +479,7 @@ async function selectToolConfig(
   rl: ReturnType<typeof createInterface>,
   projectRoot: string,
   dryRun: boolean,
-): Promise<AiTool[]> {
+): Promise<{ tools: AiTool[]; anchorNotes: string[] }> {
   header("Which AI tool do you use?");
   console.log();
   console.log("  1) Claude Code");
@@ -484,6 +495,7 @@ async function selectToolConfig(
   const choice = (await rl.question("Choice [1-8] (default: 1): ")).trim() || "1";
 
   const selectedTools: AiTool[] = [];
+  const anchorNotes: string[] = [];
 
   const copyConfig = (key: string) => {
     const tool = TOOL_CHOICE_MAP[key];
@@ -500,26 +512,56 @@ async function selectToolConfig(
 
     const src = resolve(TEMPLATES_DIR, config.src);
     const dest = resolve(projectRoot, config.dest);
+    const isJson = config.dest.endsWith(".json");
 
+    // Setup used to skip any anchor that already existed, which left the
+    // scaffold populated but unreferenced -- nothing loads `.mex/` unless an
+    // always-loaded file says to. Append a pointer instead, preserving every
+    // byte the user wrote. See https://github.com/mex-memory/mex/issues/106
     if (dryRun) {
-      if (existsSync(dest)) {
-        info(`(dry run) Would keep existing ${config.dest}`);
-      } else {
+      if (!existsSync(dest)) {
         ok(`(dry run) Would copy ${config.dest}`);
+        return;
       }
+      const plan: AnchorWriteResult = isJson
+        ? planOpencodeAnchor(readFileSync(dest, "utf-8"))
+        : planAnchorPointer(readFileSync(dest));
+      reportAnchor(config.dest, plan, true);
       return;
     }
 
-    if (existsSync(dest)) {
-      // Can't ask interactively here since we already have rl,
-      // so just warn and skip
-      warn(`${config.dest} already exists — skipped (delete it first to replace)`);
-      return;
-    }
+    const result = isJson
+      ? ensureOpencodeAnchor(projectRoot, config.dest, src)
+      : ensureMarkdownAnchor(projectRoot, config.dest, src);
+    reportAnchor(config.dest, result, false);
+  };
 
-    mkdirSync(dirname(dest), { recursive: true });
-    copyFileSync(src, dest);
-    ok(`Copied ${config.dest}`);
+  /** Print an anchor outcome, and remember the ones the user must act on. */
+  const reportAnchor = (dest: string, result: AnchorWriteResult, dry: boolean) => {
+    const prefix = dry ? "(dry run) Would " : "";
+    switch (result.outcome) {
+      case "created":
+        ok(`${prefix}${dry ? "copy" : "Copied"} ${dest}`);
+        return;
+      case "appended":
+        ok(`${prefix}${dry ? "add" : "Added"} a MEX pointer to your existing ${dest}`);
+        return;
+      case "updated":
+        ok(`${prefix}${dry ? "refresh" : "Refreshed"} the MEX pointer in ${dest}`);
+        return;
+      case "already-linked":
+        info(`${dest} already points at .mex/ — left unchanged`);
+        return;
+      case "conflict": {
+        const note =
+          `${dest} was left untouched because ${result.reason}. `
+          + "Add this line to it by hand so the scaffold is loaded: "
+          + "`At the start of every session, read .mex/AGENTS.md and .mex/ROUTER.md.`";
+        warn(note);
+        anchorNotes.push(note);
+        return;
+      }
+    }
   };
 
   switch (choice) {
@@ -552,7 +594,7 @@ async function selectToolConfig(
     saveAiTools(mexDir, selectedTools);
   }
 
-  return [...new Set(selectedTools)];
+  return { tools: [...new Set(selectedTools)], anchorNotes };
 }
 
 function renderAgentAssetsReport(report: AgentAssetsReport): void {
@@ -678,6 +720,25 @@ export function assertGroundingCaptureReady(result: GroundingBaselineCaptureResu
       `${result.skipped} authored grounding reference${result.skipped === 1 ? "" : "s"} could not be verified against the code graph.`,
     );
   }
+}
+
+/**
+ * Repeat anchors that could not be linked automatically.
+ *
+ * The warning at the moment of the decision scrolls past behind population
+ * output and the readiness report, and the whole failure mode of #106 is that
+ * the user never learns the scaffold is not being loaded. Saying it again at
+ * the end is the last point where it is still in front of them.
+ */
+function printAnchorNotes(notes: readonly string[]): void {
+  if (notes.length === 0) return;
+  console.log();
+  header("Action needed: these files do not point at the scaffold yet");
+  console.log();
+  for (const note of notes) warn(note);
+  console.log();
+  info("Until one always-loaded file names `.mex/`, your agent will not read the scaffold.");
+  info("Run `mex check` after fixing them to confirm.");
 }
 
 function printCommitCheckpoint(selectedTools: readonly AiTool[]): void {

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -400,6 +400,9 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   if (!populationFinished || !isScaffoldPopulated(mexDir)) {
     console.log();
     info("Setup paused at population. After the agent finishes, rerun `mex setup` to finalize Graph and Wiki readiness.");
+    // The anchors were written before population, so an unlinked one is just
+    // as true on this path -- and this is the last output the user sees.
+    printAnchorNotes(anchorNotes);
     return;
   }
 

--- a/src/setup/index.ts
+++ b/src/setup/index.ts
@@ -114,6 +114,98 @@ const TOOL_CONFIGS: Record<string, { src: string; dest: string }> = {
   "5": { src: ".tool-configs/opencode.json", dest: ".opencode/opencode.json" },
 };
 
+/**
+ * The anchor each non-agent tool loads, and the template to seed it from.
+ *
+ * Keyed by tool rather than by menu number because linking has to happen on
+ * every setup run, not only the one where the menu was shown. Claude Code and
+ * Codex are absent deliberately: the agent-skills installer owns their files
+ * and already runs on every setup.
+ */
+const TOOL_ANCHORS: Partial<Record<AiTool, { src: string; dest: string }>> = {
+  cursor: TOOL_CONFIGS["2"],
+  windsurf: TOOL_CONFIGS["3"],
+  copilot: TOOL_CONFIGS["4"],
+  opencode: TOOL_CONFIGS["5"],
+};
+
+/**
+ * Point every selected tool's anchor at the scaffold.
+ *
+ * Runs on every setup, including one that reuses a saved tool selection and so
+ * never shows the menu. That path is the one that matters: an install
+ * orphaned by the old skip already has a populated scaffold and saved
+ * `aiTools`, so it takes exactly this branch, and linking only from the menu
+ * would have left the people who actually hit the bug unable to fix it by
+ * rerunning setup. See https://github.com/mex-memory/mex/issues/106
+ *
+ * Returns the anchors that could not be linked, for the closing summary.
+ */
+export function ensureToolAnchors(
+  projectRoot: string,
+  templatesDir: string,
+  tools: readonly AiTool[],
+  dryRun: boolean,
+): string[] {
+  const notes: string[] = [];
+
+  for (const tool of new Set(tools)) {
+    const config = TOOL_ANCHORS[tool];
+    if (!config) continue;
+
+    const src = resolve(templatesDir, config.src);
+    const dest = resolve(projectRoot, config.dest);
+    const isJson = config.dest.endsWith(".json");
+
+    let result: AnchorWriteResult;
+    if (dryRun) {
+      if (!existsSync(dest)) {
+        ok(`(dry run) Would copy ${config.dest}`);
+        continue;
+      }
+      result = isJson
+        ? planOpencodeAnchor(readFileSync(dest, "utf-8"))
+        : planAnchorPointer(readFileSync(dest));
+    } else {
+      result = isJson
+        ? ensureOpencodeAnchor(projectRoot, config.dest, src)
+        : ensureMarkdownAnchor(projectRoot, config.dest, src);
+    }
+
+    const note = reportAnchor(config.dest, result, dryRun);
+    if (note) notes.push(note);
+  }
+
+  return notes;
+}
+
+/** Print an anchor outcome; return a note for the ones the user must act on. */
+function reportAnchor(dest: string, result: AnchorWriteResult, dry: boolean): string | null {
+  const prefix = dry ? "(dry run) Would " : "";
+  switch (result.outcome) {
+    case "created":
+      ok(`${prefix}${dry ? "copy" : "Copied"} ${dest}`);
+      return null;
+    case "appended":
+      ok(`${prefix}${dry ? "add" : "Added"} a MEX pointer to your existing ${dest}`);
+      return null;
+    case "updated":
+      ok(`${prefix}${dry ? "refresh" : "Refreshed"} the MEX pointer in ${dest}`);
+      return null;
+    case "already-linked":
+      info(`${dest} already points at .mex/ — left unchanged`);
+      return null;
+    case "conflict": {
+      const note =
+        `${dest} was left untouched because ${result.reason}. `
+        + "Add this line to it by hand so the scaffold is loaded: "
+        + "`At the start of every session, read .mex/AGENTS.md and .mex/ROUTER.md.`";
+      warn(note);
+      return note;
+    }
+  }
+}
+
 // ── Helpers ──
 
 const ok = (msg: string) => console.log(`${chalk.green("✓")} ${msg}`);
@@ -265,6 +357,10 @@ export async function runSetup(opts: { dryRun?: boolean; mode?: string } = {}): 
   const configuredTools = scaffoldPopulatedAtStart ? findConfig(projectRoot).aiTools : [];
   if (configuredTools.length > 0) {
     selectedTools = configuredTools;
+    // A scaffold orphaned by the old skip lands here, not in the menu
+    // branch: it is populated and its aiTools are saved. Link on this path
+    // too, or rerunning setup could never repair the installs that need it.
+    anchorNotes = ensureToolAnchors(projectRoot, TEMPLATES_DIR, selectedTools, dryRun);
     info(`Using configured AI tools: ${selectedTools.map((tool) => AI_TOOLS[tool].name).join(", ")}`);
   } else {
     const rl = createInterface({ input: stdin, output: stdout });
@@ -498,73 +594,11 @@ async function selectToolConfig(
   const choice = (await rl.question("Choice [1-8] (default: 1): ")).trim() || "1";
 
   const selectedTools: AiTool[] = [];
-  const anchorNotes: string[] = [];
 
   const copyConfig = (key: string) => {
     const tool = TOOL_CHOICE_MAP[key];
     if (!tool) return;
     selectedTools.push(tool);
-
-    // Claude Code and Codex receive a short managed instruction block plus
-    // packaged project skills. The reusable agent-assets installer owns those
-    // paths so setup never overwrites a hand-written root instruction file.
-    if (tool === "claude" || tool === "codex") return;
-
-    const config = TOOL_CONFIGS[key];
-    if (!config) return;
-
-    const src = resolve(TEMPLATES_DIR, config.src);
-    const dest = resolve(projectRoot, config.dest);
-    const isJson = config.dest.endsWith(".json");
-
-    // Setup used to skip any anchor that already existed, which left the
-    // scaffold populated but unreferenced -- nothing loads `.mex/` unless an
-    // always-loaded file says to. Append a pointer instead, preserving every
-    // byte the user wrote. See https://github.com/mex-memory/mex/issues/106
-    if (dryRun) {
-      if (!existsSync(dest)) {
-        ok(`(dry run) Would copy ${config.dest}`);
-        return;
-      }
-      const plan: AnchorWriteResult = isJson
-        ? planOpencodeAnchor(readFileSync(dest, "utf-8"))
-        : planAnchorPointer(readFileSync(dest));
-      reportAnchor(config.dest, plan, true);
-      return;
-    }
-
-    const result = isJson
-      ? ensureOpencodeAnchor(projectRoot, config.dest, src)
-      : ensureMarkdownAnchor(projectRoot, config.dest, src);
-    reportAnchor(config.dest, result, false);
-  };
-
-  /** Print an anchor outcome, and remember the ones the user must act on. */
-  const reportAnchor = (dest: string, result: AnchorWriteResult, dry: boolean) => {
-    const prefix = dry ? "(dry run) Would " : "";
-    switch (result.outcome) {
-      case "created":
-        ok(`${prefix}${dry ? "copy" : "Copied"} ${dest}`);
-        return;
-      case "appended":
-        ok(`${prefix}${dry ? "add" : "Added"} a MEX pointer to your existing ${dest}`);
-        return;
-      case "updated":
-        ok(`${prefix}${dry ? "refresh" : "Refreshed"} the MEX pointer in ${dest}`);
-        return;
-      case "already-linked":
-        info(`${dest} already points at .mex/ — left unchanged`);
-        return;
-      case "conflict": {
-        const note =
-          `${dest} was left untouched because ${result.reason}. `
-          + "Add this line to it by hand so the scaffold is loaded: "
-          + "`At the start of every session, read .mex/AGENTS.md and .mex/ROUTER.md.`";
-        warn(note);
-        anchorNotes.push(note);
-        return;
-      }
-    }
   };
 
   switch (choice) {
@@ -590,6 +624,8 @@ async function selectToolConfig(
       warn("Unknown choice, skipping tool config");
       break;
   }
+
+  const anchorNotes = ensureToolAnchors(projectRoot, TEMPLATES_DIR, selectedTools, dryRun);
 
   // Persist tool selection
   if (selectedTools.length > 0 && !dryRun) {

--- a/src/tool-config.ts
+++ b/src/tool-config.ts
@@ -1,0 +1,110 @@
+/**
+ * The root files an AI tool loads on its own, and what makes one of them point
+ * at the scaffold.
+ *
+ * A populated `.mex/` is inert unless some always-loaded file tells the agent
+ * to read it: Claude Code loads `CLAUDE.md`, Cursor loads `.cursorrules`, and
+ * neither goes looking for `.mex/ROUTER.md` unaided. Three places need to
+ * agree on that list -- setup when it writes an anchor, the sync checker when
+ * it compares copies, and the orphan checker when it asks whether anything
+ * points at the scaffold at all -- so the registry lives here rather than
+ * being restated in each. See https://github.com/mex-memory/mex/issues/106
+ */
+
+/**
+ * Delimiters of the pointer block setup maintains inside a markdown anchor it
+ * did not write. Defined here rather than in setup because the sync checker
+ * must strip the block before comparing copies, and a checker importing setup
+ * would invert the dependency.
+ */
+export const MEX_ANCHOR_START = "<!-- mex-anchor:start -->";
+export const MEX_ANCHOR_END = "<!-- mex-anchor:end -->";
+
+export type AnchorFormat = "markdown" | "json";
+
+export interface AnchorFile {
+  /** Project-relative, forward-slash path. */
+  readonly path: string;
+  readonly format: AnchorFormat;
+  readonly displayName: string;
+}
+
+/**
+ * `CLAUDE.md` and `AGENTS.md` are owned by the agent-skills installer, which
+ * maintains its own managed block in them. They are listed because the orphan
+ * checker must still see them -- a scaffold is not orphaned when `CLAUDE.md`
+ * points at it, whoever wrote that pointer.
+ */
+export const ANCHOR_FILES: readonly AnchorFile[] = [
+  { path: "CLAUDE.md", format: "markdown", displayName: "Claude Code" },
+  { path: "AGENTS.md", format: "markdown", displayName: "Codex" },
+  { path: ".cursorrules", format: "markdown", displayName: "Cursor" },
+  { path: ".windsurfrules", format: "markdown", displayName: "Windsurf" },
+  {
+    path: ".github/copilot-instructions.md",
+    format: "markdown",
+    displayName: "GitHub Copilot",
+  },
+  { path: ".opencode/opencode.json", format: "json", displayName: "OpenCode" },
+];
+
+/**
+ * A file only counts as a copy of the mex tool config when it carries the
+ * sentinel every generated template ships with. Repos commonly have a
+ * hand-written `CLAUDE.md` that mentions ROUTER.md in ordinary guidance;
+ * only the dedicated sentinel is proof of scaffold origin.
+ *
+ * Anchored to the start of a line so a file that merely quotes the sentinel in
+ * prose is not mistaken for a copy.
+ */
+export const TOOL_CONFIG_MARKER = /^<!-- mex-tool-config\b/m;
+
+/**
+ * Copies installed before the sentinel shipped do not carry it. This
+ * frontmatter line has been byte-stable across every tool config template
+ * since the initial commit, so it identifies those copies with no migration
+ * step. Bridge only: drop it at a major version once installs have turned
+ * over, leaving the sentinel as the sole contract.
+ */
+export const LEGACY_TOOL_CONFIG_MARKER = "Always-loaded project anchor. Read this first.";
+
+/** Whether a file is a copy of the mex tool config, new sentinel or legacy. */
+export function isToolConfigCopy(content: string): boolean {
+  return TOOL_CONFIG_MARKER.test(content) || content.includes(LEGACY_TOOL_CONFIG_MARKER);
+}
+
+/**
+ * Any mention of a path inside `.mex/` counts as pointing at the scaffold.
+ *
+ * Deliberately looser than naming ROUTER.md specifically: a user who wrote
+ * their own pointer at `.mex/AGENTS.md`, or who routes through some other
+ * scaffold file, has solved the problem this check exists to catch, and
+ * failing them for phrasing it differently would be noise. Bare `mex` is not
+ * enough -- it appears in prose about the tool without loading anything.
+ */
+const SCAFFOLD_REFERENCE = /(^|[^\w./-])\.mex\//;
+
+/** Whether a markdown anchor's text points the agent at the scaffold. */
+export function referencesScaffold(content: string): boolean {
+  return SCAFFOLD_REFERENCE.test(content);
+}
+
+/**
+ * OpenCode names its instruction files in a JSON array rather than in prose,
+ * so its anchor points at the scaffold when that array holds a `.mex/` path.
+ * Returns null when the file is not the object shape we know how to read, so
+ * callers can stay silent rather than guess.
+ */
+export function opencodeInstructions(content: string): string[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+  const instructions = (parsed as Record<string, unknown>).instructions;
+  if (instructions === undefined) return [];
+  if (!Array.isArray(instructions)) return null;
+  return instructions.filter((entry): entry is string => typeof entry === "string");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,9 @@ export type IssueCode =
   | "BROKEN_LINK"
   | "MISSING_FRONTMATTER_FIELD"
   | "STALE_PATTERN"
+  // Populated scaffold that no always-loaded tool config points at, so no
+  // agent ever reads it. See src/drift/checkers/anchor-link.ts and #106.
+  | "SCAFFOLD_ORPHANED"
   // ── Code-graph grounding (checker #12; emitted by src/drift/checkers/grounding.ts) ──
   // Added in Phase 0 so the grounding-checker contract typechecks and Track B
   // never has to reopen this shared union. See src/graph/grounding.ts.

--- a/test/anchor.test.ts
+++ b/test/anchor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -12,6 +12,7 @@ import {
   MEX_ANCHOR_END,
 } from "../src/setup/anchor.js";
 import { checkAnchorLink } from "../src/drift/checkers/anchor-link.js";
+import { ensureToolAnchors } from "../src/setup/index.js";
 
 // Setup used to skip any tool anchor that already existed, so a repo with a
 // hand-written .cursorrules got a fully populated .mex/ that nothing loaded.
@@ -339,5 +340,126 @@ describe("checkAnchorLink", () => {
     const [issue] = run();
     expect(issue.message).toContain("CLAUDE.md");
     expect(issue.message).toContain(".cursorrules");
+  });
+});
+
+// ── The path setup actually takes ──
+
+describe("ensureToolAnchors", () => {
+  // Everything above tests the writers directly. These test the wiring setup
+  // uses: the tool list in, the console reporting and the sticky notes out.
+  let logs: string[];
+  let templates: string;
+
+  beforeEach(() => {
+    logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    // Mirrors templates/.tool-configs/, which is what TEMPLATES_DIR resolves to.
+    templates = mkdtempSync(join(tmpdir(), "mex-anchor-td-"));
+    mkdirSync(join(templates, ".tool-configs"), { recursive: true });
+    for (const name of [".cursorrules", ".windsurfrules", "copilot-instructions.md"]) {
+      writeFileSync(
+        join(templates, ".tool-configs", name),
+        "<!-- mex-tool-config -->\ntemplate body\n",
+      );
+    }
+    writeFileSync(
+      join(templates, ".tool-configs/opencode.json"),
+      `${JSON.stringify({ instructions: [".mex/AGENTS.md"] }, null, 2)}\n`,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(templates, { recursive: true, force: true });
+  });
+
+  it("appends a pointer to every selected tool's existing anchor", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    writeFileSync(join(tmpDir, ".windsurfrules"), HAND_WRITTEN);
+
+    const notes = ensureToolAnchors(tmpDir, templates, ["cursor", "windsurf"], false);
+
+    expect(notes).toEqual([]);
+    for (const file of [".cursorrules", ".windsurfrules"]) {
+      const after = readFileSync(join(tmpDir, file), "utf-8");
+      expect(after.startsWith(HAND_WRITTEN)).toBe(true);
+      expect(after).toContain(".mex/ROUTER.md");
+    }
+  });
+
+  it("leaves Claude and Codex to the agent-skills installer", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+    ensureToolAnchors(tmpDir, templates, ["claude", "codex"], false);
+    // Untouched here: appending twice would duplicate the installer's block.
+    expect(readFileSync(join(tmpDir, "CLAUDE.md"), "utf-8")).toBe(HAND_WRITTEN);
+  });
+
+  it("creates a missing anchor from the template", () => {
+    const notes = ensureToolAnchors(tmpDir, templates, ["copilot"], false);
+    expect(notes).toEqual([]);
+    expect(readFileSync(join(tmpDir, ".github/copilot-instructions.md"), "utf-8"))
+      .toContain("template body");
+  });
+
+  it("links OpenCode's JSON config", () => {
+    mkdirSync(join(tmpDir, ".opencode"), { recursive: true });
+    writeFileSync(join(tmpDir, ".opencode/opencode.json"), JSON.stringify({ theme: "dark" }));
+
+    ensureToolAnchors(tmpDir, templates, ["opencode"], false);
+
+    const parsed = JSON.parse(readFileSync(join(tmpDir, ".opencode/opencode.json"), "utf-8"));
+    expect(parsed.instructions).toEqual([".mex/AGENTS.md"]);
+    expect(parsed.theme).toBe("dark");
+  });
+
+  it("returns a note for an anchor it could not link, so setup can repeat it", () => {
+    const broken = `${HAND_WRITTEN}\n${MEX_ANCHOR_START}\nno end marker\n`;
+    writeFileSync(join(tmpDir, ".cursorrules"), broken);
+
+    const notes = ensureToolAnchors(tmpDir, templates, ["cursor"], false);
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toContain(".cursorrules");
+    expect(notes[0]).toContain(".mex/ROUTER.md");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(broken);
+  });
+
+  it("writes nothing on a dry run, and says what the real run would do", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+
+    ensureToolAnchors(tmpDir, templates, ["cursor"], true);
+
+    // The bug this replaces: --dry-run promised to overwrite while the real
+    // path skipped. Plan and write are now the same function.
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(HAND_WRITTEN);
+    expect(logs.join("\n")).toContain("(dry run)");
+    expect(logs.join("\n")).toContain(".cursorrules");
+  });
+
+  it("is quiet and idempotent when every anchor is already linked", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    ensureToolAnchors(tmpDir, templates, ["cursor"], false);
+    const once = readFileSync(join(tmpDir, ".cursorrules"), "utf-8");
+
+    const notes = ensureToolAnchors(tmpDir, templates, ["cursor"], false);
+
+    expect(notes).toEqual([]);
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(once);
+  });
+
+  it("repairs an install the old skip orphaned", () => {
+    // The case that matters: a populated scaffold whose aiTools are already
+    // saved never shows the menu, so linking has to happen on that path too.
+    mkdirSync(join(tmpDir, ".mex"), { recursive: true });
+    writeFileSync(join(tmpDir, ".mex/ROUTER.md"), "# Router\n");
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    expect(checkAnchorLink(tmpDir, join(tmpDir, ".mex"))).toHaveLength(1);
+
+    ensureToolAnchors(tmpDir, templates, ["cursor"], false);
+
+    expect(checkAnchorLink(tmpDir, join(tmpDir, ".mex"))).toHaveLength(0);
   });
 });

--- a/test/anchor.test.ts
+++ b/test/anchor.test.ts
@@ -247,6 +247,27 @@ describe("checkAnchorLink", () => {
     expect(issues[0].file).toBe("CLAUDE.md");
   });
 
+  it("stays silent when the user chose to install no tool config", () => {
+    // Setup's "None / skip" option says .mex/AGENTS.md works with any tool
+    // that can read files. That is a deliberate trade-off, not drift.
+    scaffold();
+    writeFileSync(join(tmpDir, ".mex/config.json"), JSON.stringify({ aiTools: [] }));
+    expect(run()).toHaveLength(0);
+  });
+
+  it("still reports when a tool was selected but its anchor does not point at the scaffold", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, ".mex/config.json"), JSON.stringify({ aiTools: ["claude"] }));
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+    expect(run()).toHaveLength(1);
+  });
+
+  it("does not treat unreadable config as an opt-out", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, ".mex/config.json"), "{ not json");
+    expect(run()).toHaveLength(1);
+  });
+
   it("flags a scaffold with no tool config at all", () => {
     scaffold();
     const issues = run();

--- a/test/anchor.test.ts
+++ b/test/anchor.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  ensureMarkdownAnchor,
+  ensureOpencodeAnchor,
+  planAnchorPointer,
+  planOpencodeAnchor,
+  renderAnchorPointerBlock,
+  MEX_ANCHOR_START,
+  MEX_ANCHOR_END,
+} from "../src/setup/anchor.js";
+import { checkAnchorLink } from "../src/drift/checkers/anchor-link.js";
+
+// Setup used to skip any tool anchor that already existed, so a repo with a
+// hand-written .cursorrules got a fully populated .mex/ that nothing loaded.
+// See https://github.com/mex-memory/mex/issues/106
+
+let tmpDir: string;
+let templateDir: string;
+
+const HAND_WRITTEN = "# My rules\n\nAlways run the linter before committing.\n";
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mex-anchor-"));
+  templateDir = mkdtempSync(join(tmpdir(), "mex-anchor-tpl-"));
+  writeFileSync(join(templateDir, ".cursorrules"), "<!-- mex-tool-config -->\ntemplate body\n");
+  writeFileSync(
+    join(templateDir, "opencode.json"),
+    `${JSON.stringify({ $schema: "https://opencode.ai/config.json", instructions: [".mex/AGENTS.md"] }, null, 2)}\n`,
+  );
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  rmSync(templateDir, { recursive: true, force: true });
+});
+
+// ── Markdown anchors ──
+
+describe("ensureMarkdownAnchor", () => {
+  it("copies the template when no anchor exists", () => {
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+    expect(result.outcome).toBe("created");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toContain("template body");
+  });
+
+  it("appends a pointer to a hand-written anchor instead of skipping it", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    expect(result.outcome).toBe("appended");
+    const after = readFileSync(join(tmpDir, ".cursorrules"), "utf-8");
+    // The user's bytes survive untouched, at the front, byte for byte.
+    expect(after.startsWith(HAND_WRITTEN)).toBe(true);
+    expect(after).toContain(".mex/ROUTER.md");
+    expect(after).toContain(MEX_ANCHOR_START);
+  });
+
+  it("creates the parent directory for a nested anchor", () => {
+    const result = ensureMarkdownAnchor(
+      tmpDir,
+      ".github/copilot-instructions.md",
+      join(templateDir, ".cursorrules"),
+    );
+    expect(result.outcome).toBe("created");
+    expect(readFileSync(join(tmpDir, ".github/copilot-instructions.md"), "utf-8"))
+      .toContain("template body");
+  });
+
+  it("leaves an anchor that already names .mex/ alone", () => {
+    const own = "# My rules\n\nRead `.mex/ROUTER.md` first.\n";
+    writeFileSync(join(tmpDir, ".cursorrules"), own);
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    expect(result.outcome).toBe("already-linked");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(own);
+  });
+
+  it("leaves a mex template copy alone rather than restating its pointer", () => {
+    const copy = "<!-- mex-tool-config: managed copy -->\nRead ROUTER.md first.\n";
+    writeFileSync(join(tmpDir, ".cursorrules"), copy);
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    expect(result.outcome).toBe("already-linked");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(copy);
+  });
+
+  it("refreshes an existing mex block without disturbing the rest", () => {
+    writeFileSync(
+      join(tmpDir, ".cursorrules"),
+      `${HAND_WRITTEN}\n${MEX_ANCHOR_START}\nstale contents\n${MEX_ANCHOR_END}\n\n## After\ntail text\n`,
+    );
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    expect(result.outcome).toBe("updated");
+    const after = readFileSync(join(tmpDir, ".cursorrules"), "utf-8");
+    expect(after).not.toContain("stale contents");
+    expect(after.startsWith(HAND_WRITTEN)).toBe(true);
+    expect(after).toContain("## After\ntail text\n");
+  });
+
+  it("is idempotent: a second run changes nothing", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+    const first = readFileSync(join(tmpDir, ".cursorrules"), "utf-8");
+
+    const second = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+    expect(second.outcome).toBe("already-linked");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(first);
+  });
+
+  it("preserves CRLF line endings", () => {
+    writeFileSync(join(tmpDir, ".cursorrules"), "# My rules\r\n\r\nRun the linter.\r\n");
+    ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    const after = readFileSync(join(tmpDir, ".cursorrules"), "utf-8");
+    expect(after).toContain(`${MEX_ANCHOR_START}\r\n`);
+    expect(after.includes("\n\n")).toBe(false); // no bare LF crept in
+  });
+
+  it("refuses to edit a file with unbalanced markers and leaves it untouched", () => {
+    const broken = `${HAND_WRITTEN}\n${MEX_ANCHOR_START}\nno end marker\n`;
+    writeFileSync(join(tmpDir, ".cursorrules"), broken);
+    const result = ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+
+    expect(result.outcome).toBe("conflict");
+    expect(result.reason).toContain("unbalanced");
+    expect(readFileSync(join(tmpDir, ".cursorrules"), "utf-8")).toBe(broken);
+  });
+
+  it("reports a conflict on invalid UTF-8 rather than corrupting the file", () => {
+    const plan = planAnchorPointer(Buffer.from([0xff, 0xfe, 0x00]));
+    expect(plan.outcome).toBe("conflict");
+    expect(plan.desiredBytes).toBeUndefined();
+  });
+
+  it("renders a block that names both scaffold entry points", () => {
+    const block = renderAnchorPointerBlock();
+    expect(block).toContain(".mex/AGENTS.md");
+    expect(block).toContain(".mex/ROUTER.md");
+    expect(block.startsWith(MEX_ANCHOR_START)).toBe(true);
+    expect(block.endsWith(MEX_ANCHOR_END)).toBe(true);
+  });
+});
+
+// ── OpenCode's JSON anchor ──
+
+describe("ensureOpencodeAnchor", () => {
+  const write = (value: unknown) => {
+    mkdirSync(join(tmpDir, ".opencode"), { recursive: true });
+    writeFileSync(join(tmpDir, ".opencode/opencode.json"), `${JSON.stringify(value, null, 2)}\n`);
+  };
+  const read = () =>
+    JSON.parse(readFileSync(join(tmpDir, ".opencode/opencode.json"), "utf-8")) as Record<
+      string,
+      unknown
+    >;
+
+  it("copies the template when no config exists", () => {
+    const result = ensureOpencodeAnchor(
+      tmpDir,
+      ".opencode/opencode.json",
+      join(templateDir, "opencode.json"),
+    );
+    expect(result.outcome).toBe("created");
+    expect(read().instructions).toEqual([".mex/AGENTS.md"]);
+  });
+
+  it("adds the scaffold to an existing instructions list, keeping the user's entries", () => {
+    write({ $schema: "https://opencode.ai/config.json", instructions: ["docs/house-style.md"] });
+    const result = ensureOpencodeAnchor(
+      tmpDir,
+      ".opencode/opencode.json",
+      join(templateDir, "opencode.json"),
+    );
+
+    expect(result.outcome).toBe("appended");
+    expect(read().instructions).toEqual(["docs/house-style.md", ".mex/AGENTS.md"]);
+    expect(read().$schema).toBe("https://opencode.ai/config.json");
+  });
+
+  it("adds an instructions list to a config that has none", () => {
+    write({ theme: "dark" });
+    ensureOpencodeAnchor(tmpDir, ".opencode/opencode.json", join(templateDir, "opencode.json"));
+
+    expect(read().instructions).toEqual([".mex/AGENTS.md"]);
+    expect(read().theme).toBe("dark");
+  });
+
+  it("leaves a config that already points at the scaffold alone", () => {
+    write({ instructions: [".mex/ROUTER.md"] });
+    const before = readFileSync(join(tmpDir, ".opencode/opencode.json"), "utf-8");
+    const result = ensureOpencodeAnchor(
+      tmpDir,
+      ".opencode/opencode.json",
+      join(templateDir, "opencode.json"),
+    );
+
+    expect(result.outcome).toBe("already-linked");
+    expect(readFileSync(join(tmpDir, ".opencode/opencode.json"), "utf-8")).toBe(before);
+  });
+
+  it("refuses to rewrite a config it cannot read, rather than clobbering it", () => {
+    mkdirSync(join(tmpDir, ".opencode"), { recursive: true });
+    const broken = "{ not json";
+    writeFileSync(join(tmpDir, ".opencode/opencode.json"), broken);
+    const result = ensureOpencodeAnchor(
+      tmpDir,
+      ".opencode/opencode.json",
+      join(templateDir, "opencode.json"),
+    );
+
+    expect(result.outcome).toBe("conflict");
+    expect(readFileSync(join(tmpDir, ".opencode/opencode.json"), "utf-8")).toBe(broken);
+  });
+
+  it("treats a non-string instructions field as a conflict", () => {
+    expect(planOpencodeAnchor('{"instructions": "docs.md"}').outcome).toBe("conflict");
+  });
+});
+
+// ── The durable half: detection ──
+
+describe("checkAnchorLink", () => {
+  const scaffold = () => {
+    mkdirSync(join(tmpDir, ".mex"), { recursive: true });
+    writeFileSync(join(tmpDir, ".mex/ROUTER.md"), "# Router\n");
+  };
+  const run = () => checkAnchorLink(tmpDir, join(tmpDir, ".mex"));
+
+  it("stays silent when there is no scaffold to orphan", () => {
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+    expect(run()).toHaveLength(0);
+  });
+
+  it("flags a populated scaffold that the only anchor never mentions", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+
+    const issues = run();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("SCAFFOLD_ORPHANED");
+    expect(issues[0].severity).toBe("error");
+    // Reported against the file the user has to edit, not the scaffold.
+    expect(issues[0].file).toBe("CLAUDE.md");
+  });
+
+  it("flags a scaffold with no tool config at all", () => {
+    scaffold();
+    const issues = run();
+    expect(issues).toHaveLength(1);
+    expect(issues[0].code).toBe("SCAFFOLD_ORPHANED");
+    expect(issues[0].file).toBe(".mex/ROUTER.md");
+    expect(issues[0].message).toContain("mex setup");
+  });
+
+  it("is satisfied by any one anchor pointing at the scaffold", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+    writeFileSync(join(tmpDir, ".cursorrules"), "See `.mex/ROUTER.md` for context.\n");
+    expect(run()).toHaveLength(0);
+  });
+
+  it("accepts the pointer setup appends", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+    ensureMarkdownAnchor(tmpDir, ".cursorrules", join(templateDir, ".cursorrules"));
+    expect(run()).toHaveLength(0);
+  });
+
+  it("accepts OpenCode's JSON pointer", () => {
+    scaffold();
+    mkdirSync(join(tmpDir, ".opencode"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".opencode/opencode.json"),
+      JSON.stringify({ instructions: [".mex/AGENTS.md"] }),
+    );
+    expect(run()).toHaveLength(0);
+  });
+
+  it("does not accept an OpenCode config whose instructions ignore the scaffold", () => {
+    scaffold();
+    mkdirSync(join(tmpDir, ".opencode"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".opencode/opencode.json"),
+      JSON.stringify({ instructions: ["docs/house-style.md"] }),
+    );
+    expect(run()).toHaveLength(1);
+  });
+
+  it("does not mistake the word mex for a scaffold pointer", () => {
+    scaffold();
+    // Prose about the tool loads nothing. This is exactly the state the issue
+    // describes: `grep -c mex CLAUDE.md` is non-zero, yet nothing is loaded.
+    writeFileSync(join(tmpDir, "CLAUDE.md"), "# Rules\n\nWe use mex for context.\n");
+    expect(run()).toHaveLength(1);
+  });
+
+  it("names every anchor it looked at so the fix is unambiguous", () => {
+    scaffold();
+    writeFileSync(join(tmpDir, "CLAUDE.md"), HAND_WRITTEN);
+    writeFileSync(join(tmpDir, ".cursorrules"), HAND_WRITTEN);
+
+    const [issue] = run();
+    expect(issue.message).toContain("CLAUDE.md");
+    expect(issue.message).toContain(".cursorrules");
+  });
+});

--- a/test/anchor.test.ts
+++ b/test/anchor.test.ts
@@ -136,6 +136,18 @@ describe("ensureMarkdownAnchor", () => {
     expect(plan.desiredBytes).toBeUndefined();
   });
 
+  it("refuses a destination that is not a known tool config", () => {
+    // This module writes into files a human wrote, so it is one of the few
+    // writers outside the wiki engine. The fixed registry, not the caller,
+    // decides what it may touch -- including that it never touches .mex/.
+    expect(() =>
+      ensureMarkdownAnchor(tmpDir, ".mex/ROUTER.md", join(templateDir, ".cursorrules")),
+    ).toThrow(/not a known AI tool config/);
+    expect(() =>
+      ensureMarkdownAnchor(tmpDir, "../escape.md", join(templateDir, ".cursorrules")),
+    ).toThrow(/not a known AI tool config/);
+  });
+
   it("renders a block that names both scaffold entry points", () => {
     const block = renderAnchorPointerBlock();
     expect(block).toContain(".mex/AGENTS.md");

--- a/test/checkers.test.ts
+++ b/test/checkers.test.ts
@@ -706,6 +706,52 @@ describe("checkToolConfigSync", () => {
     expect(issues[0].file).toBe(".github/copilot-instructions.md");
   });
 
+  it("does not report the agent-skills block as drift", () => {
+    // CLAUDE.md carries the managed skills block and .cursorrules cannot --
+    // Cursor has no mex skills to invoke. Comparing raw bytes reported an
+    // install of both tools as permanently drifted, with no edit the user
+    // could make to clear it. See https://github.com/mex-memory/mex/issues/106
+    const body = `${marker}shared project anchor\n`;
+    writeFileSync(
+      join(tmpDir, "CLAUDE.md"),
+      `${body}\n<!-- mex-agent:skills:start -->\n## MEX agent skills\n- read .mex/ROUTER.md\n<!-- mex-agent:skills:end -->\n`,
+    );
+    writeFileSync(join(tmpDir, ".cursorrules"), body);
+    expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
+  });
+
+  it("does not report the appended anchor pointer as drift", () => {
+    // Same shape from the other direction: setup appends a pointer block to a
+    // pre-existing .cursorrules, which CLAUDE.md has no reason to carry.
+    const body = `${marker}shared project anchor\n`;
+    writeFileSync(join(tmpDir, "CLAUDE.md"), body);
+    writeFileSync(
+      join(tmpDir, ".cursorrules"),
+      `${body}\n<!-- mex-anchor:start -->\n- read .mex/ROUTER.md\n<!-- mex-anchor:end -->\n`,
+    );
+    expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
+  });
+
+  it("still reports a real edit made outside the managed blocks", () => {
+    const body = `${marker}shared project anchor\n`;
+    writeFileSync(
+      join(tmpDir, "CLAUDE.md"),
+      `${body}\n<!-- mex-agent:skills:start -->\nblock\n<!-- mex-agent:skills:end -->\n`,
+    );
+    writeFileSync(join(tmpDir, ".cursorrules"), `${body}a line only this copy has\n`);
+    const issues = checkToolConfigSync(tmpDir);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].file).toBe(".cursorrules");
+  });
+
+  it("treats a line-ending difference as a checkout artifact, not drift", () => {
+    // A repo with no `text` attribute hands CRLF to Windows and LF to CI for
+    // the same commit; neither is an edit anyone made.
+    writeFileSync(join(tmpDir, "CLAUDE.md"), `${marker}shared anchor\n`);
+    writeFileSync(join(tmpDir, ".cursorrules"), `${marker}shared anchor\n`.replace(/\n/g, "\r\n"));
+    expect(checkToolConfigSync(tmpDir)).toHaveLength(0);
+  });
+
   it("ignores tool config files that are not scaffold copies", () => {
     // A hand-written CLAUDE.md and a generated AGENTS.md (e.g. a managed skill
     // pack) coexist without ever having been copied from .tool-configs/.

--- a/test/tool-config-templates.test.ts
+++ b/test/tool-config-templates.test.ts
@@ -31,16 +31,26 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
+/**
+ * Templates are checked out with the platform's line endings -- this repo has
+ * no `text` attribute for them, so Windows gets CRLF and CI gets LF from the
+ * same commit -- while the renderers always emit LF. Comparing raw bytes made
+ * three of these assertions fail for every Windows contributor and pass in CI,
+ * which is a property of the checkout, not of the templates under test.
+ */
+const readText = (path: string): string =>
+  readFileSync(path, "utf-8").replace(/\r\n/g, "\n");
+
 describe("shipped code-graph agent guidance", () => {
   it("models grounding slots and inert inline-anchor examples in templates and dogfood", () => {
     for (const area of ["templates", ".mex"]) {
       for (const name of ["architecture", "conventions", "decisions", "setup", "stack"]) {
-        const content = readFileSync(join(area, "context", `${name}.md`), "utf-8");
+        const content = readText(join(area, "context", `${name}.md`));
         expect(extractFrontmatter(content)?.grounds_to, `${area}/${name}`).toEqual([]);
         expect(content, `${area}/${name}`).toContain("[`someFunction()`](mex://function:<tier-1-id>)");
         expect(findMexAnchors(content), `${area}/${name} examples must stay inert`).toEqual([]);
       }
-      const patterns = readFileSync(join(area, "patterns/README.md"), "utf-8");
+      const patterns = readText(join(area, "patterns/README.md"));
       expect(patterns).toContain("grounds_to:");
       expect(patterns).toContain('fingerprint: "mh:64:<hex-fingerprint>"');
       expect(patterns).toContain("[`someFunction()`](mex://function:<tier-1-id>)");
@@ -50,7 +60,7 @@ describe("shipped code-graph agent guidance", () => {
 
   it("keeps common guidance aligned without promising skills to unsupported clients", () => {
     const unsupported = unsupportedEmbedded.map((name) => (
-      readFileSync(join("templates/.tool-configs", name), "utf-8")
+      readText(join("templates/.tool-configs", name))
     ));
     expect(new Set(unsupported).size).toBe(1);
     for (const content of unsupported) {
@@ -64,7 +74,7 @@ describe("shipped code-graph agent guidance", () => {
       expect(content).not.toContain(supersededBlanketApprovalGuidance);
     }
 
-    const claude = readFileSync("templates/.tool-configs/CLAUDE.md", "utf-8");
+    const claude = readText("templates/.tool-configs/CLAUDE.md");
     expect(claude).toContain(renderManagedInstructionBlock("claude"));
     expect(claude).toContain("/mex-inbox");
     expect(claude).not.toContain("$mex-inbox");
@@ -73,39 +83,39 @@ describe("shipped code-graph agent guidance", () => {
 
   it("keeps maintained equivalents aligned and OpenCode delegated to guided AGENTS.md", () => {
     const maintainedUnsupported = unsupportedEmbedded.map((name) => (
-      readFileSync(join(".mex/.tool-configs", name), "utf-8")
+      readText(join(".mex/.tool-configs", name))
     ));
     expect(new Set(maintainedUnsupported).size).toBe(1);
     expect(maintainedUnsupported[0]).toContain("mex impact <symbol|file>");
-    expect(readFileSync(".mex/.tool-configs/CLAUDE.md", "utf-8"))
+    expect(readText(".mex/.tool-configs/CLAUDE.md"))
       .toContain(renderManagedInstructionBlock("claude"));
-    const agents = readFileSync("templates/AGENTS.md", "utf-8");
+    const agents = readText("templates/AGENTS.md");
     expect(agents).toContain("mex graph query <who-calls|what-calls|where-defined> <symbol>");
     expect(agents).toContain(MEX_INSTRUCTIONS_START);
     expect(agents).toContain("MEX context used: <specific records/files/entities consulted>.");
     expect(agents).not.toMatch(/[/$]mex-(?:inbox|relay)/u);
     for (const guidance of capabilityGuidance) expect(agents).toContain(guidance);
     expect(agents).not.toContain(supersededBlanketApprovalGuidance);
-    const agentMemory = readFileSync("templates/agent-memory/AGENTS.md", "utf-8");
+    const agentMemory = readText("templates/agent-memory/AGENTS.md");
     for (const guidance of capabilityGuidance) expect(agentMemory).toContain(guidance);
     expect(agentMemory).not.toContain(supersededBlanketApprovalGuidance);
     expect(agentMemory).toContain(MEX_INSTRUCTIONS_START);
     expect(agentMemory).not.toMatch(/[/$]mex-(?:inbox|relay)/u);
-    const maintainedAgents = readFileSync(".mex/AGENTS.md", "utf-8");
+    const maintainedAgents = readText(".mex/AGENTS.md");
     for (const guidance of capabilityGuidance) expect(maintainedAgents).toContain(guidance);
     expect(maintainedAgents).not.toContain(supersededBlanketApprovalGuidance);
     expect(maintainedAgents).toContain(MEX_INSTRUCTIONS_START);
     expect(maintainedAgents).not.toMatch(/[/$]mex-(?:inbox|relay)/u);
     for (const guidance of capabilityGuidance) expect(maintainedUnsupported[0]).toContain(guidance);
     for (const file of ["templates/.tool-configs/opencode.json", ".mex/.tool-configs/opencode.json"]) {
-      expect(JSON.parse(readFileSync(file, "utf-8")).instructions).toContain(".mex/AGENTS.md");
+      expect(JSON.parse(readText(file)).instructions).toContain(".mex/AGENTS.md");
     }
   });
 
   it("keeps root dogfood instructions minimal and client-specific", () => {
-    expect(readFileSync("CLAUDE.md", "utf-8"))
+    expect(readText("CLAUDE.md"))
       .toBe(`${renderManagedInstructionBlock("claude")}\n`);
-    expect(readFileSync("AGENTS.md", "utf-8"))
+    expect(readText("AGENTS.md"))
       .toBe(`${renderManagedInstructionBlock("codex")}\n`);
   });
 
@@ -114,13 +124,13 @@ describe("shipped code-graph agent guidance", () => {
     roots.push(root);
     writeFileSync(join(root, "CLAUDE.md"), `${renderManagedInstructionBlock("claude")}\n`);
     writeFileSync(join(root, "AGENTS.md"), `${renderManagedInstructionBlock("codex")}\n`);
-    const content = readFileSync("templates/.tool-configs/.cursorrules", "utf-8");
+    const content = readText("templates/.tool-configs/.cursorrules");
     for (const path of [".cursorrules", ".windsurfrules", ".github/copilot-instructions.md"]) {
       const destination = join(root, path);
       mkdirSync(dirname(destination), { recursive: true });
       writeFileSync(destination, content);
     }
     expect(checkToolConfigSync(root)).toEqual([]);
-    expect(readFileSync(join(root, "CLAUDE.md"), "utf-8")).toContain(MEX_INSTRUCTIONS_END);
+    expect(readText(join(root, "CLAUDE.md"))).toContain(MEX_INSTRUCTIONS_END);
   });
 });

--- a/test/wiki-architecture.test.ts
+++ b/test/wiki-architecture.test.ts
@@ -762,6 +762,7 @@ describe("no unscoped scaffold writes", () => {
       "src/global-config.ts": "writes the global config and telemetry id",
       "src/events.ts": "appends to events/decisions.jsonl",
       "src/pattern/index.ts": "creates a new pattern file from a template",
+      "src/setup/anchor.ts": "edits root tool configs only, never .mex/, and only inside its own markers",
       "src/setup/ignore.ts": "creates or appends only the setup-managed .mex/.gitignore rules",
       "src/setup/population.ts": "writes and removes one ignored private prompt file for the interactive setup session",
       "src/team/artifacts/filesystem.ts": "atomically publishes bounded team-owned canonical artifacts",


### PR DESCRIPTION
## What

Stops `mex setup` leaving a scaffold that nothing loads, and teaches `mex check` to notice when one exists.

Setup skipped any tool config that already existed, warned once mid-run, and populated the scaffold anyway. That is the default outcome for the most likely adopter — an established repo with a hand-written `.cursorrules` — and the result is a `.mex/` nothing references. Cursor loads `.cursorrules`; it does not go looking for `.mex/ROUTER.md` unaided. The scaffold ends up correct, complete and inert, after the user has paid a full AI pass over their codebase for it.

0.8 fixed this for Claude Code and Codex by routing them through the agent-skills installer, which appends a managed block rather than skipping. The other four anchors never went through it.

**Setup** now appends for all of them. An absent anchor is copied from the template as before; an existing one gets a marker-delimited pointer block, leaving every byte the user wrote in place. Rerunning is a no-op, and an anchor that already names `.mex/` in its own prose is left alone rather than having the same instruction restated at it. `.opencode/opencode.json` is JSON, so its merge is a list insertion into `instructions` with the rest of the config preserved. A file that does not parse, or whose markers are unbalanced, is reported and left untouched rather than rewritten on a guess.

Linking happens on **every** setup run, not only the one that shows the menu. This matters more than it sounds: the menu is skipped whenever the scaffold is already populated and `aiTools` are saved, which is exactly the state an install orphaned by the old skip is in. Linking only from the menu would have left the people who actually hit this bug unable to repair it by rerunning setup — which is what both the setup output and the new check tell them to do.

**`mex check`** gains `SCAFFOLD_ORPHANED`: when `ROUTER.md` exists but no root anchor mentions `.mex/`, that is an error naming the anchors it looked at. This is the durable half — setup runs once, but a `CLAUDE.md` restored from a template, replaced by a teammate who never ran setup, or edited down later takes the pointer with it, and nothing would say so. It is deliberately loose about what counts as a pointer: any mention of a path under `.mex/` satisfies it, whoever wrote it. Bare `mex` does not, since prose about the tool loads nothing — which is the issue's own reproduction, where `grep -c mex CLAUDE.md` is non-zero and no agent finds the scaffold. An `aiTools` that is present and empty silences the check, since setup's "None / skip" option is a deliberate choice and says so.

Two repairs found while verifying:

- **`checkToolConfigSync` reported unfixable drift.** `CLAUDE.md` carries the agent-skills block and `.cursorrules` cannot — Cursor has no mex skills to invoke — so installing both tools produced a permanent `TOOL_CONFIG_DRIFT` with no edit that could clear it: matching the files would mean deleting a block the installer rewrites on the next sync. Managed blocks are now stripped before comparing, so the comparison is over what the user owns. An edit outside those blocks is still reported, still attributed to the copy that moved.
- **`--dry-run` could not disagree with the real run.** Plan and write are now the same function, so the class of bug the issue describes — dry-run promising to overwrite while the real path skipped — cannot recur.

The setup warning is also repeated in the final summary, including on the population-paused exit. Said once mid-run it scrolls behind population output, and the whole failure mode is the user never learning the scaffold is not being loaded.

## Why

Closes #106.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

## How to test

In a repo with a populated `.mex/` and a hand-written `.cursorrules` that does not mention mex:

```
mex check
```

Before: `100/100 — 0 errors`. The scaffold is never loaded and nothing says so.
After: `90/100`, one `SCAFFOLD_ORPHANED` naming `.cursorrules`.

Then `mex setup`. The pointer block is appended below your own rules, your bytes untouched, and `mex check` returns to `100/100`. Running setup again reports `already points at .mex/ — left unchanged`. Worth trying both with and without a saved `aiTools` in `.mex/config.json` — those are different branches and both link now.

For the sync fix, install two tools and run `mex check`: previously a `TOOL_CONFIG_DRIFT` warning that no edit could clear, now clean.

## Checklist

- [x] Tests pass (`npm test`) — see note below
- [x] No breaking changes (or documented below)
- [x] Tested locally with a real project

**Note on `npm test`:** 38 tests in `test/anchor.test.ts` and 4 added to `test/checkers.test.ts`, all passing, and `npm run typecheck` is clean. The full suite does not pass on this branch, but it does not pass on `main` either. Measured with a hermetic `TMPDIR` and compared by test name: `main` fails 42, this branch fails 40, and this branch **fixes 3** with **no branch-only regressions**. One name appears branch-only — a team inbox envelope-expiry contract — which passes when run alone and shares no code with this diff; the same suite flaked across runs on previous PRs.

Worth flagging: nothing in the suite called `runSetup` or `selectToolConfig`, so the wiring between setup and the anchor writers had no coverage at all. `ensureToolAnchors` is exported and now covered, including an orphaned-install repair asserted end to end against the drift checker.

**Verified by running the built CLI**, not only through unit tests:

| Scenario | Result |
|---|---|
| `setup --dry-run`, menu → Cursor | reports the append, writes nothing |
| `setup`, menu → Cursor, hand-written anchor | pointer appended, user's lines intact, 90 → **100** |
| `setup` rerun with saved `aiTools`, no prompt shown | linked on the no-menu branch, 90 → **100** |
| `check` on a fresh 0.8 scaffold | 100/100, unchanged |
| `check` on a populated scaffold already linked | 100/100, unchanged |
| `check` on a populated scaffold with an orphaned anchor | 60 → **50**, a true positive |

The last row drops because the check finds a real orphan: a live 0.8 scaffold whose root instruction file contains no reference to `.mex/` at all. No false positives appeared on the scaffolds that are correctly linked, and this repo's own score is unchanged at 8 errors / 12 warnings.

**Not verified:** the multi-select branch (option 7). Piping stdin makes its second prompt hit EOF, and stock `main` behaves identically, so this is a harness limit rather than a regression — but that path, and options 4/5/6/8 through the live binary, are covered by unit tests only.

**Behaviour changes:**

- Setup modifies an existing tool config instead of skipping it. Only inside its own `<!-- mex-anchor:start/end -->` markers; the rest of the file is copied byte for byte, and the write refuses any destination outside the fixed anchor registry.
- `mex check` can report a new error code on scaffolds that previously passed. That is the point of the issue, but an orphaned install will see its score drop until the anchor is linked.
- `src/setup/anchor.ts` is a new filesystem writer and is registered in the pinned inventory in `test/wiki-architecture.test.ts`, with a fail-closed guard behind that entry. `templates/.tool-configs/` is unchanged.

## Code-graph changes

- [ ] This PR targets `main`
- [ ] A linked issue agrees on the bounded extractor/resolver scope
- [ ] The change follows the frozen `LanguageExtractor` or `FrameworkResolver` interface
- [ ] A focused fixture and assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered
- [ ] No graph identity, reconciliation, schema, or drift-semantics changes are included, or a `core / discuss-first` issue is linked above
