### PR TITLE
feat(graph): add Next.js App Router route resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,6 @@ All notable changes to this project will be documented in this file.
 - COMPATIBILITY.md documents the FTS5 requirement, a one-line command to check the Node you actually run, and that the v0.6.3 fallback predates the code graph. The preflight's error message pointed at a document that said nothing about FTS5 (#110).
 - `mex graph rebuild`/`refresh`/`repair` and `mex wiki rebuild-index` now ensure `.mex/.gitignore` exists before creating a store. Only `mex setup` did this, so building a store in a checkout that had never run setup left `graph.db`, `-wal` and `-shm` untracked, ready for the next `git add -A` to commit (#110).
 
-<<<<<<< HEAD
 ### Compatibility
 
 - New open-to-team Relays use schema v4. Teammates need MEX 0.8.1 before
@@ -106,11 +105,6 @@ All notable changes to this project will be documented in this file.
   projects to refresh managed skills and anchors and start a new agent session.
   A completed 0.8.0 setup does not need to run again solely for this upgrade;
   follow any explicit maintenance action reported by `mex graph status`.
-=======
-### Added
-- `mex telemetry disable` and `mex telemetry enable`, writing the same `~/.mex/config.json` key as `mex config set telemetry on|off`. `mex telemetry --help` and `mex telemetry status` now name the `DO_NOT_TRACK=1` and `MEX_TELEMETRY=0` env opt-outs and say which one is in effect; previously the only switch lived under `config` and the env vars appeared solely in the first-run notice (#110).
-- A bounded Next.js App Router resolver turning `app/**/route.ts|js` modules (including `src/app` roots) into route nodes: one per exported HTTP handler (`GET` through `HEAD`), with the URL path derived from the route file's directory, dynamic segments such as `[id]` and catch-alls preserved verbatim, and route groups `(marketing)` excluded the way Next resolves them. Same-file handlers resolve only when unambiguous; Pages Router, layouts, and pages stay out of scope (#95).
->>>>>>> a37a046 (feat(graph): add Next.js App Router route resolver)
 
 ## [0.8.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- A bounded Next.js App Router resolver turning `app/**/route.ts|js` modules (including `src/app` roots) into route nodes: one per exported HTTP handler (`GET` through `HEAD`), with the URL path derived from the route file's directory, dynamic segments such as `[id]` and catch-alls preserved verbatim, and route groups `(marketing)` excluded the way Next resolves them. Same-file handlers resolve only when unambiguous; Pages Router, layouts, and pages stay out of scope (#95).
+
 ### Fixed
 
 - `mex sync` now migrates an inline `mex://` anchor together with a `grounds_to` entry for the same moved node. The anchor used to reconcile on its own against the stored baseline instead of the refreshed frontmatter fingerprint. When that baseline was missing, or still listed a neighbour that had since been re-identified, the anchor was skipped or scored `AMBIGUOUS`, sync moved the shared baseline row anyway, and the next `mex check` reported `GROUNDING_GONE` until the link was edited by hand (#128).
@@ -91,6 +94,7 @@ All notable changes to this project will be documented in this file.
 - COMPATIBILITY.md documents the FTS5 requirement, a one-line command to check the Node you actually run, and that the v0.6.3 fallback predates the code graph. The preflight's error message pointed at a document that said nothing about FTS5 (#110).
 - `mex graph rebuild`/`refresh`/`repair` and `mex wiki rebuild-index` now ensure `.mex/.gitignore` exists before creating a store. Only `mex setup` did this, so building a store in a checkout that had never run setup left `graph.db`, `-wal` and `-shm` untracked, ready for the next `git add -A` to commit (#110).
 
+<<<<<<< HEAD
 ### Compatibility
 
 - New open-to-team Relays use schema v4. Teammates need MEX 0.8.1 before
@@ -102,6 +106,11 @@ All notable changes to this project will be documented in this file.
   projects to refresh managed skills and anchors and start a new agent session.
   A completed 0.8.0 setup does not need to run again solely for this upgrade;
   follow any explicit maintenance action reported by `mex graph status`.
+=======
+### Added
+- `mex telemetry disable` and `mex telemetry enable`, writing the same `~/.mex/config.json` key as `mex config set telemetry on|off`. `mex telemetry --help` and `mex telemetry status` now name the `DO_NOT_TRACK=1` and `MEX_TELEMETRY=0` env opt-outs and say which one is in effect; previously the only switch lived under `config` and the env vars appeared solely in the first-run notice (#110).
+- A bounded Next.js App Router resolver turning `app/**/route.ts|js` modules (including `src/app` roots) into route nodes: one per exported HTTP handler (`GET` through `HEAD`), with the URL path derived from the route file's directory, dynamic segments such as `[id]` and catch-alls preserved verbatim, and route groups `(marketing)` excluded the way Next resolves them. Same-file handlers resolve only when unambiguous; Pages Router, layouts, and pages stay out of scope (#95).
+>>>>>>> a37a046 (feat(graph): add Next.js App Router route resolver)
 
 ## [0.8.0] - 2026-09-02
 

--- a/src/graph/__tests__/fixtures/nextjs-items-route.js
+++ b/src/graph/__tests__/fixtures/nextjs-items-route.js
@@ -1,0 +1,7 @@
+export const DELETE = async (request: Request): Promise<Response> => {
+  return new Response(null, { status: 204 });
+};
+
+export function HEAD(): Response {
+  return new Response(null);
+}

--- a/src/graph/__tests__/fixtures/nextjs-items-route.js
+++ b/src/graph/__tests__/fixtures/nextjs-items-route.js
@@ -1,7 +1,7 @@
-export const DELETE = async (request: Request): Promise<Response> => {
+export const DELETE = async () => {
   return new Response(null, { status: 204 });
 };
 
-export function HEAD(): Response {
+export function HEAD() {
   return new Response(null);
 }

--- a/src/graph/__tests__/fixtures/nextjs-users-route.ts
+++ b/src/graph/__tests__/fixtures/nextjs-users-route.ts
@@ -1,0 +1,14 @@
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  return Response.json({ id: await params.then((p) => p.id) });
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return Response.json({ created: true });
+}
+
+function helper(): string {
+  return "not a handler";
+}

--- a/src/graph/__tests__/resolver-nextjs-integration.test.ts
+++ b/src/graph/__tests__/resolver-nextjs-integration.test.ts
@@ -52,7 +52,7 @@ describe("Next.js resolver integration", () => {
 
       const resolved = db.prepare(
         "SELECT e.target, n.name AS route_name FROM edges e JOIN nodes n ON n.id = e.source"
-        + " WHERE e.kind = 'references' AND e.provenance = 'framework' AND e.resolution_method = 'framework'",
+        + " WHERE e.kind = 'references' AND e.provenance = 'framework' AND e.resolution_method = 'nextjs-route-handler'",
       ).all() as Array<{ target: string; route_name: string }>;
       expect(resolved).toHaveLength(2);
       for (const edge of resolved) {

--- a/src/graph/__tests__/resolver-nextjs-integration.test.ts
+++ b/src/graph/__tests__/resolver-nextjs-integration.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { rebuildGraph } from "../maintenance.js";
+import { openSqlite } from "../db/sqlite.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Next.js resolver integration", () => {
+  it("persists route nodes and resolved edges through a real build", async () => {
+    const root = mkdtempSync(join(tmpdir(), "mex-nextjs-integration-"));
+    roots.push(root);
+    const routeDir = join(root, "app", "api", "users");
+    mkdirSync(routeDir, { recursive: true });
+    mkdirSync(join(root, ".mex"), { recursive: true });
+    writeFileSync(join(root, ".mex", "ROUTER.md"), "# Router\n");
+    writeFileSync(join(root, "package.json"), JSON.stringify({
+      name: "fixture", dependencies: { next: "^15.0.0" },
+    }));
+    writeFileSync(
+      join(routeDir, "route.ts"),
+      [
+        "export async function GET(): Promise<Response> {",
+        "  return Response.json({ ok: true });",
+        "}",
+        "",
+        "export const POST = async (): Promise<Response> => {",
+        "  return new Response(null, { status: 201 });",
+        "};",
+        "",
+      ].join("\n"),
+    );
+
+    const result = await rebuildGraph(root);
+    expect(result.status.status).toBe("fresh");
+
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      const routes = db.prepare(
+        "SELECT id, name, signature FROM nodes WHERE kind = 'route' ORDER BY name",
+      ).all() as Array<{ id: string; name: string; signature: string }>;
+      expect(routes.map((route) => route.name)).toEqual([
+        "GET /api/users",
+        "POST /api/users",
+      ]);
+      expect(routes[0]!.signature).toBe("GET /api/users -> GET");
+
+      const resolved = db.prepare(
+        "SELECT e.target, n.name AS route_name FROM edges e JOIN nodes n ON n.id = e.source"
+        + " WHERE e.kind = 'references' AND e.provenance = 'framework' AND e.resolution_method = 'framework'",
+      ).all() as Array<{ target: string; route_name: string }>;
+      expect(resolved).toHaveLength(2);
+      for (const edge of resolved) {
+        expect(edge.route_name).toMatch(/ \/api\/users$/);
+        const target = db.prepare("SELECT name FROM nodes WHERE id = ?").get(edge.target) as { name: string };
+        expect(["GET", "POST"]).toContain(target.name);
+      }
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/src/graph/__tests__/resolver-nextjs.test.ts
+++ b/src/graph/__tests__/resolver-nextjs.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+import { extractFile, loadGrammars } from "../extraction/index.js";
+import { generateNodeId } from "../extraction/node-id.js";
+import { deriveRoutePath, nextjsResolver } from "../resolution/frameworks/nextjs.js";
+import { FRAMEWORK_RESOLVERS } from "../resolution/frameworks/index.js";
+import type { GraphNode } from "../types.js";
+import type { ResolutionContext } from "../resolution/types.js";
+
+const usersFixture = join(
+  dirname(fileURLToPath(import.meta.url)), "fixtures", "nextjs-users-route.ts",
+);
+const itemsFixture = join(
+  dirname(fileURLToPath(import.meta.url)), "fixtures", "nextjs-items-route.js",
+);
+
+describe("Next.js App Router resolver", () => {
+  let usersNodes: GraphNode[];
+
+  beforeAll(async () => {
+    await loadGrammars(["typescript"]);
+    const source = readFileSync(usersFixture, "utf-8");
+    usersNodes = extractFile("app/api/users/[id]/route.ts", source, "typescript")!.nodes
+      .map((node) => ({ ...node, updatedAt: 0 }));
+  });
+
+  it.each([
+    ["the next dependency in package.json", { "package.json": '{"dependencies": {"next": "^15.0.0"}}' }, true],
+    ["a route file in the tree without a manifest", { "app/x/route.ts": "export function GET() {}\n" }, true],
+    ["no route files and no next dependency", { "src/index.ts": "export const x = 1;\n" }, false],
+  ])("detects Next.js from %s", (_name, files, expected) => {
+    expect(nextjsResolver.detect(fakeContext([], files))).toBe(expected);
+  });
+
+  it("derives route paths from both app/ and src/app/ roots", () => {
+    expect(deriveRoutePath("app/api/users/route.ts")).toBe("/api/users");
+    expect(deriveRoutePath("src/app/api/users/route.ts")).toBe("/api/users");
+    expect(deriveRoutePath("app/route.ts")).toBe("/");
+    expect(deriveRoutePath("app/(marketing)/pricing/route.ts")).toBe("/pricing");
+    expect(deriveRoutePath("app/blog/[slug]/route.ts")).toBe("/blog/[slug]");
+    expect(deriveRoutePath("app/docs/[...path]/route.ts")).toBe("/docs/[...path]");
+  });
+
+  it("returns null for paths outside an App Router root", () => {
+    expect(deriveRoutePath("pages/api/users.ts")).toBeNull();
+    expect(deriveRoutePath("src/components/route.ts")).toBeNull();
+    expect(deriveRoutePath("app/nested/page.tsx")).toBeNull();
+  });
+
+  it("emits one route node per exported HTTP handler and references it", () => {
+    const source = readFileSync(usersFixture, "utf-8");
+    const result = nextjsResolver.extract!("app/api/users/[id]/route.ts", source);
+
+    expect(result.nodes.map((node) => node.name)).toEqual([
+      "GET /api/users/[id]",
+      "POST /api/users/[id]",
+    ]);
+    for (const node of result.nodes) {
+      expect(node).toMatchObject({ kind: "route", language: "typescript", filePath: "app/api/users/[id]/route.ts" });
+      expect(node.id).toBe(generateNodeId(
+        "app/api/users/[id]/route.ts", "route", node.name, node.name, "nextjs-route", node.signature,
+      ));
+    }
+    expect(result.references.map((ref) => ref.referenceName)).toEqual(["GET", "POST"]);
+    expect(result.references.map((ref) => ref.referenceKind)).toEqual(["function_ref", "function_ref"]);
+  });
+
+  it("handles arrow-function exports and javascript route files", () => {
+    const source = readFileSync(itemsFixture, "utf-8");
+    const result = nextjsResolver.extract!("app/items/route.js", source);
+
+    expect(result.nodes.map((node) => node.name)).toEqual([
+      "DELETE /items",
+      "HEAD /items",
+    ]);
+    expect(result.references.map((ref) => ref.referenceName)).toEqual(["DELETE", "HEAD"]);
+    expect(result.nodes.every((node) => node.language === "javascript")).toBe(true);
+  });
+
+  it("ignores non-route files and non-handler exports", () => {
+    expect(nextjsResolver.extract!("app/page.tsx", "export default function Page() {}\n"))
+      .toEqual({ nodes: [], references: [] });
+    expect(nextjsResolver.extract!("lib/api.ts", "export async function GET() {}\n"))
+      .toEqual({ nodes: [], references: [] });
+
+    const result = nextjsResolver.extract!("app/api/users/[id]/route.ts", readFileSync(usersFixture, "utf-8"));
+    expect(result.references.some((ref) => ref.referenceName === "helper")).toBe(false);
+  });
+
+  it("resolves the unambiguous same-file handler function", () => {
+    const source = readFileSync(usersFixture, "utf-8");
+    const result = nextjsResolver.extract!("app/api/users/[id]/route.ts", source);
+    const context = fakeContext(usersNodes);
+
+    const ref = result.references[0]!;
+    const target = usersNodes.find((node) => node.name === "GET")!;
+    expect(nextjsResolver.resolve(ref, context)).toMatchObject({
+      targetNodeId: target.id,
+      confidence: 1,
+      resolvedBy: "framework",
+    });
+  });
+
+  it("leaves missing and ambiguous handlers unresolved", () => {
+    const source = readFileSync(usersFixture, "utf-8");
+    const result = nextjsResolver.extract!("app/api/users/[id]/route.ts", source);
+    const ref = result.references[0]!;
+
+    expect(nextjsResolver.resolve(ref, fakeContext([]))).toBeNull();
+
+    const first = node("function:first", "GET");
+    const second = node("method:second", "GET", "method");
+    expect(nextjsResolver.resolve(ref, fakeContext([first, second]))).toBeNull();
+  });
+
+  it("is registered in the framework registry", () => {
+    expect(FRAMEWORK_RESOLVERS).toContain(nextjsResolver);
+  });
+});
+
+function node(
+  id: string,
+  name: string,
+  kind: "function" | "method" = "function",
+): GraphNode {
+  return {
+    id,
+    kind,
+    name,
+    qualifiedName: name,
+    filePath: "app/api/users/[id]/route.ts",
+    language: "typescript",
+    startLine: 1,
+    endLine: 2,
+    startColumn: 0,
+    endColumn: 0,
+    updatedAt: 0,
+  };
+}
+
+function fakeContext(nodes: GraphNode[], files: Record<string, string> = {}): ResolutionContext {
+  return {
+    getNodesInFile: (path) => nodes.filter((entry) => entry.filePath === path),
+    getNodesByName: (name) => nodes.filter((entry) => entry.name === name),
+    getNodesByQualifiedName: (name) => nodes.filter((entry) => entry.qualifiedName === name),
+    getNodesByKind: (kind) => nodes.filter((entry) => entry.kind === kind),
+    getNodeById: (id) => nodes.find((entry) => entry.id === id) ?? null,
+    fileExists: (path) => path in files,
+    readFile: (path) => files[path] ?? null,
+    getProjectRoot: () => "/repo",
+    getAllFiles: () => Object.keys(files),
+  };
+}

--- a/src/graph/__tests__/resolver-nextjs.test.ts
+++ b/src/graph/__tests__/resolver-nextjs.test.ts
@@ -49,9 +49,12 @@ describe("Next.js App Router resolver", () => {
     expect(deriveRoutePath("apps/web/src/app/api/orders/route.ts")).toBe("/api/orders");
   });
 
-  it("drops private folders from derived paths", () => {
-    expect(deriveRoutePath("app/_lib/route.ts")).toBe("/");
-    expect(deriveRoutePath("app/users/_components/route.ts")).toBe("/users");
+  it("opts private folders and everything under them out of routing", () => {
+    expect(deriveRoutePath("app/_lib/route.ts")).toBeNull();
+    expect(deriveRoutePath("app/users/_components/route.ts")).toBeNull();
+    expect(deriveRoutePath("app/_internal/api/route.ts")).toBeNull();
+    expect(nextjsResolver.extract!("app/_lib/route.ts", "export function GET() {}\n"))
+      .toEqual({ nodes: [], references: [] });
   });
 
   it("returns null for paths outside an App Router root", () => {

--- a/src/graph/__tests__/resolver-nextjs.test.ts
+++ b/src/graph/__tests__/resolver-nextjs.test.ts
@@ -43,10 +43,37 @@ describe("Next.js App Router resolver", () => {
     expect(deriveRoutePath("app/docs/[...path]/route.ts")).toBe("/docs/[...path]");
   });
 
+  it("locates the App Router root as a segment, not a substring (#179 review)", () => {
+    expect(deriveRoutePath("apps/web/app/api/orders/route.ts")).toBe("/api/orders");
+    expect(deriveRoutePath("packages/webapp/app/api/users/route.ts")).toBe("/api/users");
+    expect(deriveRoutePath("apps/web/src/app/api/orders/route.ts")).toBe("/api/orders");
+  });
+
+  it("drops private folders from derived paths", () => {
+    expect(deriveRoutePath("app/_lib/route.ts")).toBe("/");
+    expect(deriveRoutePath("app/users/_components/route.ts")).toBe("/users");
+  });
+
   it("returns null for paths outside an App Router root", () => {
     expect(deriveRoutePath("pages/api/users.ts")).toBeNull();
     expect(deriveRoutePath("src/components/route.ts")).toBeNull();
     expect(deriveRoutePath("app/nested/page.tsx")).toBeNull();
+  });
+
+  it("emits at most one route node per method, so repeated declarations cannot collide (#179 review)", () => {
+    const overloaded = [
+      "export function GET(a: Request): Response;",
+      "export function GET(a: Request, b: unknown): Response;",
+      "export function GET(a: Request, b?: unknown): Response { return new Response(); }",
+      "",
+      "/*",
+      "export function GET(stale: Request): Response { return new Response(); }",
+      "*/",
+    ].join("\n");
+
+    const result = nextjsResolver.extract!("app/api/x/route.ts", overloaded);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]!.name).toBe("GET /api/x");
   });
 
   it("emits one route node per exported HTTP handler and references it", () => {
@@ -67,10 +94,13 @@ describe("Next.js App Router resolver", () => {
     expect(result.references.map((ref) => ref.referenceKind)).toEqual(["function_ref", "function_ref"]);
   });
 
-  it("handles arrow-function exports and javascript route files", () => {
+  it("handles typed arrow-function exports and javascript route files", () => {
+    const custom = "export const GET: RouteHandler = async () => {\n  return new Response();\n};\n";
+    const typed = nextjsResolver.extract!("app/typed/route.ts", custom);
+    expect(typed.nodes.map((node) => node.name)).toEqual(["GET /typed"]);
+
     const source = readFileSync(itemsFixture, "utf-8");
     const result = nextjsResolver.extract!("app/items/route.js", source);
-
     expect(result.nodes.map((node) => node.name)).toEqual([
       "DELETE /items",
       "HEAD /items",
@@ -98,8 +128,8 @@ describe("Next.js App Router resolver", () => {
     const target = usersNodes.find((node) => node.name === "GET")!;
     expect(nextjsResolver.resolve(ref, context)).toMatchObject({
       targetNodeId: target.id,
-      confidence: 1,
-      resolvedBy: "framework",
+      confidence: 0.8,
+      resolvedBy: "nextjs-route-handler",
     });
   });
 

--- a/src/graph/resolution/frameworks/index.ts
+++ b/src/graph/resolution/frameworks/index.ts
@@ -1,6 +1,8 @@
 import { expressResolver } from "./express.js";
+import { nextjsResolver } from "./nextjs.js";
 import type { FrameworkResolver } from "../types.js";
 
 /** Reference registry. Community resolvers add one entry here. */
-export const FRAMEWORK_RESOLVERS: readonly FrameworkResolver[] = [expressResolver];
+export const FRAMEWORK_RESOLVERS: readonly FrameworkResolver[] = [expressResolver, nextjsResolver];
 export { expressResolver } from "./express.js";
+export { nextjsResolver } from "./nextjs.js";

--- a/src/graph/resolution/frameworks/nextjs.ts
+++ b/src/graph/resolution/frameworks/nextjs.ts
@@ -11,7 +11,9 @@ const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"
 
 const NEXT_DEPENDENCY = /["']next["']\s*:/;
 const EXPORTED_FUNCTION = /^\s*export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/;
-const EXPORTED_ARROW = /^\s*export\s+const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*(?::[^=]*)?=>/;
+// The name may carry a type annotation (`export const GET: RouteHandler = …`)
+// while still binding a handler function (#179 review).
+const EXPORTED_ARROW = /^\s*export\s+const\s+([A-Za-z_$][\w$]*)\s*(?::[^=]+)?=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*(?::[^=]*)?=>/;
 
 /** Route files this resolver understands; everything else is another App Router concern. */
 const ROUTE_FILE = /(?:^|\/)route\.(ts|tsx|js|jsx|mts|mjs|cts|cjs)$/;
@@ -20,10 +22,11 @@ export const nextjsResolver: FrameworkResolver = {
   name: "nextjs",
   languages: ["typescript", "javascript", "tsx", "jsx"],
   detect(context) {
-    // Next.js route handlers live only in route files, so the files themselves
-    // are the reliable observable. package.json is checked when present for a
-    // stronger signal, but staged config globs already surface it when the
-    // repository has one at the root.
+    // The `next` dependency is the issue's primary signal. The route files
+    // themselves are an additional one: staged config globs only surface a
+    // ROOT package.json, so a monorepo app (packages/web/app/api/x/route.ts)
+    // would otherwise go undetected even though its route modules are staged
+    // corpus files the resolver can genuinely serve (#179 review).
     const pkg = context.readFile("package.json");
     if (pkg && NEXT_DEPENDENCY.test(pkg)) return true;
     return context.getAllFiles().some((filePath) => ROUTE_FILE.test(filePath.replace(/\\/g, "/")));
@@ -43,6 +46,11 @@ export const nextjsResolver: FrameworkResolver = {
     const nodes: GraphNode[] = [];
     const references: UnresolvedRef[] = [];
     const lines = content.split(/\r?\n/);
+    // A route module can export each HTTP verb at most once, so one route
+    // node per method per file is the contract. Repeated declarations —
+    // TypeScript overloads, a stale handler inside a block comment — used to
+    // emit colliding node ids and fail the whole build (#179 review).
+    const emitted = new Set<string>();
 
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
       const line = lines[lineIndex]!;
@@ -50,6 +58,8 @@ export const nextjsResolver: FrameworkResolver = {
       const arrowExport = fnExport ? null : EXPORTED_ARROW.exec(line);
       const handlerName = fnExport?.[1] ?? arrowExport?.[1];
       if (!handlerName || !isHttpMethod(handlerName)) continue;
+      if (emitted.has(handlerName)) continue;
+      emitted.add(handlerName);
 
       const routeName = `${handlerName} ${routePath}`;
       const signature = `${routeName} -> ${handlerName}`;
@@ -96,8 +106,8 @@ export const nextjsResolver: FrameworkResolver = {
     return {
       original: ref,
       targetNodeId: candidates[0]!.id,
-      confidence: 1,
-      resolvedBy: "framework",
+      confidence: 0.8,
+      resolvedBy: "nextjs-route-handler",
     };
   },
 };
@@ -114,25 +124,25 @@ function isHttpMethod(name: string): name is (typeof HTTP_METHODS)[number] {
  * `src` prefix. Dynamic segment text such as `[id]` and catch-alls such as
  * `[...slug]` is preserved verbatim — the brackets are Next's own route
  * syntax and rewriting them would lose the distinction between routes.
- * Route groups `(marketing)` never appear in URLs, so their segment is
- * dropped the way Next itself resolves them.
+ * Route groups `(marketing)` and private folders `_lib` never appear in
+ * URLs, so those segments are dropped the way Next itself resolves them.
+ *
+ * The App Router root is located as a path SEGMENT, not a substring: the
+ * first cut at `indexOf("app")` turned `apps/web/app/api/orders/route.ts`
+ * into `/s/web/app/api/orders` (#179 review).
  */
 export function deriveRoutePath(normalizedFilePath: string): string | null {
   if (!ROUTE_FILE.test(normalizedFilePath)) return null;
-  const withoutFile = normalizedFilePath.slice(0, normalizedFilePath.lastIndexOf("/"));
-  const appRoot = /(^|\/)src\/app(\/|$)/.test(withoutFile)
-    ? "src/app"
-    : /(^|\/)app(\/|$)/.test(withoutFile)
-      ? "app"
-      : null;
-  if (appRoot === null) return null;
+  const root = /(?:^|\/)src\/app(?:\/|$)/.exec(normalizedFilePath)
+    ?? /(?:^|\/)app(?:\/|$)/.exec(normalizedFilePath);
+  if (!root) return null;
 
-  const start = withoutFile.indexOf(appRoot) + appRoot.length;
-  const segments = withoutFile.slice(start)
+  const start = root.index + root[0].length;
+  const withoutFile = normalizedFilePath.slice(start, normalizedFilePath.lastIndexOf("/"));
+  const segments = withoutFile
     .split("/")
-    .filter((segment) => segment.length > 0 && !segment.startsWith("("));
-  const path = `/${segments.join("/")}`;
-  return path === "/" ? "/" : path.replace(/\/+$/, "");
+    .filter((segment) => segment.length > 0 && !segment.startsWith("(") && !segment.startsWith("_"));
+  return `/${segments.join("/")}`;
 }
 
 function languageFor(filePath: string): "typescript" | "javascript" | "tsx" | "jsx" | null {

--- a/src/graph/resolution/frameworks/nextjs.ts
+++ b/src/graph/resolution/frameworks/nextjs.ts
@@ -1,0 +1,144 @@
+import { canonicalNodeIdentity, generateNodeId } from "../../extraction/node-id.js";
+import type { GraphNode } from "../../types.js";
+import type {
+  FrameworkExtractionResult,
+  FrameworkResolver,
+  ResolvedRef,
+  UnresolvedRef,
+} from "../types.js";
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"] as const;
+
+const NEXT_DEPENDENCY = /["']next["']\s*:/;
+const EXPORTED_FUNCTION = /^\s*export\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/;
+const EXPORTED_ARROW = /^\s*export\s+const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*(?::[^=]*)?=>/;
+
+/** Route files this resolver understands; everything else is another App Router concern. */
+const ROUTE_FILE = /(?:^|\/)route\.(ts|tsx|js|jsx|mts|mjs|cts|cjs)$/;
+
+export const nextjsResolver: FrameworkResolver = {
+  name: "nextjs",
+  languages: ["typescript", "javascript", "tsx", "jsx"],
+  detect(context) {
+    // Next.js route handlers live only in route files, so the files themselves
+    // are the reliable observable. package.json is checked when present for a
+    // stronger signal, but staged config globs already surface it when the
+    // repository has one at the root.
+    const pkg = context.readFile("package.json");
+    if (pkg && NEXT_DEPENDENCY.test(pkg)) return true;
+    return context.getAllFiles().some((filePath) => ROUTE_FILE.test(filePath.replace(/\\/g, "/")));
+  },
+  claimsReference: (name) => /^(GET|POST|PUT|PATCH|DELETE|OPTIONS|HEAD)$/.test(name),
+  extract(filePath, content): FrameworkExtractionResult {
+    const normalized = filePath.replace(/\\/g, "/");
+    const routeMatch = ROUTE_FILE.exec(normalized);
+    if (!routeMatch) return { nodes: [], references: [] };
+
+    const language = languageFor(filePath);
+    if (!language) return { nodes: [], references: [] };
+
+    const routePath = deriveRoutePath(normalized);
+    if (routePath === null) return { nodes: [], references: [] };
+
+    const nodes: GraphNode[] = [];
+    const references: UnresolvedRef[] = [];
+    const lines = content.split(/\r?\n/);
+
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex]!;
+      const fnExport = EXPORTED_FUNCTION.exec(line);
+      const arrowExport = fnExport ? null : EXPORTED_ARROW.exec(line);
+      const handlerName = fnExport?.[1] ?? arrowExport?.[1];
+      if (!handlerName || !isHttpMethod(handlerName)) continue;
+
+      const routeName = `${handlerName} ${routePath}`;
+      const signature = `${routeName} -> ${handlerName}`;
+      const id = generateNodeId(filePath, "route", routeName, routeName, "nextjs-route", signature);
+      nodes.push({
+        id,
+        identityKey: canonicalNodeIdentity(filePath, "route", routeName, "nextjs-route", signature),
+        kind: "route",
+        name: routeName,
+        qualifiedName: routeName,
+        filePath,
+        language,
+        startLine: lineIndex + 1,
+        endLine: lineIndex + 1,
+        startColumn: 0,
+        endColumn: line.length,
+        signature,
+        isExported: true,
+        updatedAt: 0,
+      });
+      references.push({
+        fromNodeId: id,
+        referenceName: handlerName,
+        referenceKind: "function_ref",
+        filePath,
+        language,
+        line: lineIndex,
+        column: 0,
+      });
+    }
+
+    return { nodes, references };
+  },
+  resolve(ref, context): ResolvedRef | null {
+    if (ref.referenceKind !== "function_ref") return null;
+    const candidates = context.getNodesInFile(ref.filePath).filter((node) => (
+      (node.kind === "function" || node.kind === "method")
+      && node.name === ref.referenceName
+    ));
+    // The export proves the handler name in this file; anything beyond one
+    // same-file candidate is ambiguous and stays unresolved.
+    if (candidates.length !== 1) return null;
+
+    return {
+      original: ref,
+      targetNodeId: candidates[0]!.id,
+      confidence: 1,
+      resolvedBy: "framework",
+    };
+  },
+};
+
+/** True only for the seven explicitly supported App Router HTTP verbs. */
+function isHttpMethod(name: string): name is (typeof HTTP_METHODS)[number] {
+  return (HTTP_METHODS as readonly string[]).includes(name);
+}
+
+/**
+ * The URL path a route file serves, derived from its directory.
+ *
+ * `app/api/users/route.ts` serves `/api/users`; a `src/app` root strips the
+ * `src` prefix. Dynamic segment text such as `[id]` and catch-alls such as
+ * `[...slug]` is preserved verbatim — the brackets are Next's own route
+ * syntax and rewriting them would lose the distinction between routes.
+ * Route groups `(marketing)` never appear in URLs, so their segment is
+ * dropped the way Next itself resolves them.
+ */
+export function deriveRoutePath(normalizedFilePath: string): string | null {
+  if (!ROUTE_FILE.test(normalizedFilePath)) return null;
+  const withoutFile = normalizedFilePath.slice(0, normalizedFilePath.lastIndexOf("/"));
+  const appRoot = /(^|\/)src\/app(\/|$)/.test(withoutFile)
+    ? "src/app"
+    : /(^|\/)app(\/|$)/.test(withoutFile)
+      ? "app"
+      : null;
+  if (appRoot === null) return null;
+
+  const start = withoutFile.indexOf(appRoot) + appRoot.length;
+  const segments = withoutFile.slice(start)
+    .split("/")
+    .filter((segment) => segment.length > 0 && !segment.startsWith("("));
+  const path = `/${segments.join("/")}`;
+  return path === "/" ? "/" : path.replace(/\/+$/, "");
+}
+
+function languageFor(filePath: string): "typescript" | "javascript" | "tsx" | "jsx" | null {
+  if (/\.(ts|mts|cts)$/.test(filePath)) return "typescript";
+  if (/\.(js|mjs|cjs)$/.test(filePath)) return "javascript";
+  if (/\.(tsx)$/.test(filePath)) return "tsx";
+  if (/\.(jsx)$/.test(filePath)) return "jsx";
+  return null;
+}

--- a/src/graph/resolution/frameworks/nextjs.ts
+++ b/src/graph/resolution/frameworks/nextjs.ts
@@ -124,8 +124,10 @@ function isHttpMethod(name: string): name is (typeof HTTP_METHODS)[number] {
  * `src` prefix. Dynamic segment text such as `[id]` and catch-alls such as
  * `[...slug]` is preserved verbatim — the brackets are Next's own route
  * syntax and rewriting them would lose the distinction between routes.
- * Route groups `(marketing)` and private folders `_lib` never appear in
- * URLs, so those segments are dropped the way Next itself resolves them.
+ * Route groups `(marketing)` never appear in URLs, so those segments are
+ * dropped the way Next itself resolves them. A private folder `_lib` opts
+ * itself and everything under it out of routing, so a route file inside one
+ * serves no URL at all.
  *
  * The App Router root is located as a path SEGMENT, not a substring: the
  * first cut at `indexOf("app")` turned `apps/web/app/api/orders/route.ts`
@@ -139,9 +141,9 @@ export function deriveRoutePath(normalizedFilePath: string): string | null {
 
   const start = root.index + root[0].length;
   const withoutFile = normalizedFilePath.slice(start, normalizedFilePath.lastIndexOf("/"));
-  const segments = withoutFile
-    .split("/")
-    .filter((segment) => segment.length > 0 && !segment.startsWith("(") && !segment.startsWith("_"));
+  const rawSegments = withoutFile.split("/").filter((segment) => segment.length > 0);
+  if (rawSegments.some((segment) => segment.startsWith("_"))) return null;
+  const segments = rawSegments.filter((segment) => !segment.startsWith("("));
   return `/${segments.join("/")}`;
 }
 


### PR DESCRIPTION
Resolves #95.

## What

A bounded Next.js resolver following the `express.ts`/`flask.ts` pattern. It turns App Router route modules into route nodes and connects exported HTTP handler functions:

- Recognizes `app/**/route.ts` and `route.js`, including `src/app` roots
- One stable route node per exported handler for `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, `HEAD` — declared as `export async function GET()` or `export const GET = async () => ...`
- Route path derived from the route file's directory: `app/api/users/route.ts` → `/api/users`
- Dynamic segment text (`[id]`) and catch-alls (`[...slug]`) preserved verbatim; route groups (`(marketing)`) excluded from paths the way Next itself resolves them
- Only explicitly exported HTTP-handler names create route nodes; a same-file `helper()` export is ignored
- Detection keys on the `next` dependency in package.json or the presence of route files in the tree (positive and negative cases tested)
- Same-file handlers resolve only when unambiguous; missing or duplicate handlers stay unresolved

Out of scope, per the issue: Pages Router, route groups' URL composition nuances, parallel/intercepting routes, rewrites, middleware, server components, and any change to the TypeScript extractor or graph core. No identity, reconciliation, schema, or drift-semantics changes.

## Tests

- `resolver-nextjs.test.ts` (11): detection positive/negative (manifest and file-based), path derivation for both roots plus route groups/dynamic/catch-all segments and rejection of non-App-Router paths, function and arrow-function exports, JS route files, non-route files ignored, resolution and ambiguity, registry registration.
- `resolver-nextjs-integration.test.ts` (1): real `rebuildGraph` over a Next.js fixture — route nodes persist with the stable `nextjs-route` identity and both handlers resolve through framework edges.

`npm run typecheck`, `npm run build` pass; resolver suites green locally (the pre-existing Windows symlink/WAL failures in `test/graph-integration.test.ts` reproduce identically on clean `main` and are unrelated).