### PR TITLE
fix(graph): migrate inline anchors with their grounds_to entry (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- `mex sync` now migrates an inline `mex://` anchor together with a `grounds_to` entry for the same moved node. The anchor used to reconcile on its own against the stored baseline instead of the refreshed frontmatter fingerprint. When that baseline was missing, or still listed a neighbour that had since been re-identified, the anchor was skipped or scored `AMBIGUOUS`, sync moved the shared baseline row anyway, and the next `mex check` reported `GROUNDING_GONE` until the link was edited by hand (#128).
+
 ## [0.8.1] - 2026-09-10
 
 ### Added

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -310,6 +310,13 @@ export function persistMovedGroundings(
     const scaffoldFile = relative(config.projectRoot, filePath).replaceAll("\\", "/");
     let dirty = false;
     const pendingMoves = new Map<string, { previous: GroundedSource; newId: string }>();
+    // Per-node migration is atomic (#128): a node grounded both in
+    // grounds_to and as an inline mex:// anchor must migrate through ONE
+    // resolution. The grounds_to pass records its resolution per old id so
+    // the anchor pass can follow it even when the store has already lost
+    // the old node's rows (no baseline, no fingerprint, no alias) — instead
+    // of skipping the anchor and leaving GROUNDING_GONE behind.
+    const migratedNodes = new Map<string, string>();
     for (const grounding of groundings) {
       const aliasedNode = runtime.graph.getNode(grounding.node);
       if (aliasedNode) {
@@ -320,6 +327,7 @@ export function persistMovedGroundings(
         const fingerprint = runtime.reconciler.getFingerprint(aliasedNode.id);
         if (fingerprint) grounding.fingerprint = serializeFingerprint(fingerprint);
         moveGroundingBaseline(scaffoldFile, oldId, grounding.node, runtime, pendingMoves, grounding);
+        migratedNodes.set(oldId, grounding.node);
         dirty = true;
         moved += 1;
         continue;
@@ -336,6 +344,7 @@ export function persistMovedGroundings(
       const fingerprint = runtime.reconciler.getFingerprint(resolution.nodeId);
       if (fingerprint) grounding.fingerprint = serializeFingerprint(fingerprint);
       moveGroundingBaseline(scaffoldFile, oldId, grounding.node, runtime, pendingMoves, grounding);
+      migratedNodes.set(oldId, grounding.node);
       dirty = true;
       moved += 1;
     }
@@ -343,6 +352,13 @@ export function persistMovedGroundings(
     let anchoredContent = groundedContent;
     const anchors = findMexAnchors(anchoredContent);
     for (const anchor of [...anchors].reverse()) {
+      const migratedId = migratedNodes.get(anchor.nodeId);
+      if (migratedId !== undefined) {
+        if (migratedId === anchor.nodeId) continue;
+        anchoredContent = rewriteMexAnchor(anchoredContent, anchor, migratedId);
+        moved += 1;
+        continue;
+      }
       const aliasedNode = runtime.graph.getNode(anchor.nodeId);
       if (aliasedNode) {
         if (aliasedNode.id === anchor.nodeId) continue;

--- a/src/graph/runtime.ts
+++ b/src/graph/runtime.ts
@@ -354,7 +354,6 @@ export function persistMovedGroundings(
     for (const anchor of [...anchors].reverse()) {
       const migratedId = migratedNodes.get(anchor.nodeId);
       if (migratedId !== undefined) {
-        if (migratedId === anchor.nodeId) continue;
         anchoredContent = rewriteMexAnchor(anchoredContent, anchor, migratedId);
         moved += 1;
         continue;

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -26,7 +26,7 @@ import {
 } from "../src/graph/runtime.js";
 import { extractGroundings, writeGroundings } from "../src/markdown.js";
 import { buildCombinedBrief } from "../src/sync/brief-builder.js";
-import { serializeFingerprint } from "../src/graph/fingerprint.js";
+import { deserializeFingerprint, serializeFingerprint } from "../src/graph/fingerprint.js";
 import { openSqlite } from "../src/graph/db/sqlite.js";
 import {
   inspectGraphSidecars,
@@ -503,6 +503,69 @@ describe("code-graph grounding integration", () => {
 
     const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
     expect(report.issues.filter((issue) => issue.code === "GROUNDING_GONE")).toHaveLength(0);
+  }, 20_000);
+
+  it("migrates the inline anchor with its grounds_to entry when the anchor's own baseline is stale (#128)", async () => {
+    const { root, scaffold, config } = fixture();
+    const source = join(root, "src", "service.ts");
+    writeFileSync(source, "export function calculateTotal(items: number[]): number {\n  return items.reduce((a, b) => a + b, 0);\n}\n");
+
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const node = engine.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    engine.close();
+
+    let runtime = await loadGroundingRuntime(config);
+    const fingerprint = runtime!.reconciler.getFingerprint(node.id);
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{
+      node: node.id,
+      fingerprint: serializeFingerprint(fingerprint!),
+    }]) + `\n[\`calculateTotal()\`](mex://${node.id})\n`);
+    refreshGroundingBaselines(config, [scaffold], runtime!);
+    runtime!.close();
+
+    const movedSource = join(root, "src", "moved.ts");
+    writeFileSync(movedSource, readFileSync(source, "utf-8"));
+    writeFileSync(source, "export const unrelated = 1;\n");
+    const rebuilt = createGraphEngine({ rootDir: root });
+    await rebuilt.build();
+    const movedNode = rebuilt.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    rebuilt.close();
+
+    // The shape real stores reach without losing any rows: migrations refresh
+    // the frontmatter fingerprint but copy the stored baseline verbatim, so the
+    // stored row can keep a neighbour id that has since been re-identified.
+    // That alone scores the anchor AMBIGUOUS while grounds_to scores MOVED.
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      const row = db.prepare("SELECT fingerprint FROM _mex_grounded_source WHERE node_id = ?")
+        .get(node.id) as { fingerprint: string };
+      const stored = deserializeFingerprint(row.fingerprint)!;
+      const staleNeighbors = [...stored.neighbors, "function:00000000000000000000000000000000"].sort();
+      db.prepare("UPDATE _mex_grounded_source SET fingerprint = ? WHERE node_id = ?")
+        .run(serializeFingerprint({ ...stored, neighbors: staleNeighbors }), node.id);
+      db.prepare("DELETE FROM node_fingerprints WHERE node_id = ?").run(node.id);
+      db.prepare("DELETE FROM node_aliases WHERE alias_id = ?").run(node.id);
+    } finally {
+      db.close();
+    }
+
+    runtime = await loadGroundingRuntime(config);
+    // Precondition: on its own, the anchor's stale baseline is not enough to move.
+    const anchorBaseline = runtime!.reconciler.getGroundedSource(".mex/context/architecture.md", node.id)!;
+    expect(runtime!.reconciler.reconcile(node.id, deserializeFingerprint(anchorBaseline.fingerprint)!))
+      .toEqual({ kind: "AMBIGUOUS", candidate: movedNode.id });
+    const moved = persistMovedGroundings(config, [scaffold], runtime!);
+    runtime!.close();
+
+    expect(moved).toBe(2);
+    const persistedContent = readFileSync(scaffold, "utf-8");
+    expect(persistedContent).not.toContain(`mex://${node.id}`);
+    expect(persistedContent).toContain(`mex://${movedNode.id}`);
+    expect(extractGroundings(persistedContent)[0].node).toBe(movedNode.id);
+
+    const after = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
+    expect(after.issues.filter((issue) => issue.code.startsWith("GROUNDING_"))).toHaveLength(0);
   }, 20_000);
 
   it("keeps legacy checks running when the graph engine fails to load", async () => {

--- a/test/graph-integration.test.ts
+++ b/test/graph-integration.test.ts
@@ -404,6 +404,107 @@ describe("code-graph grounding integration", () => {
     ]);
   }, 20_000);
 
+  it("migrates an inline anchor atomically when grounds_to and the anchor share a moved node (#128)", async () => {
+    const { root, scaffold, config } = fixture();
+    const source = join(root, "src", "service.ts");
+    writeFileSync(source, "export function calculateTotal(items: number[]): number {\n  return items.reduce((a, b) => a + b, 0);\n}\n");
+
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const node = engine.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    engine.close();
+
+    // Ground the node BOTH in frontmatter and as an inline anchor — the shape
+    // the stack.md template encourages.
+    let runtime = await loadGroundingRuntime(config);
+    const fingerprint = runtime!.reconciler.getFingerprint(node.id);
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{
+      node: node.id,
+      fingerprint: serializeFingerprint(fingerprint!),
+    }]) + `\n[\`calculateTotal()\`](mex://${node.id})\n`);
+    refreshGroundingBaselines(config, [scaffold], runtime!);
+    runtime!.close();
+
+    // Move the function to another file with an identical body, replace the
+    // original, and rebuild: the old node id vanishes from the store entirely.
+    const movedSource = join(root, "src", "moved.ts");
+    writeFileSync(movedSource, readFileSync(source, "utf-8"));
+    writeFileSync(source, "export const unrelated = 1;\n");
+    const rebuilt = createGraphEngine({ rootDir: root });
+    await rebuilt.build();
+    const movedNode = rebuilt.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    expect(movedNode.id).not.toBe(node.id);
+    rebuilt.close();
+
+    runtime = await loadGroundingRuntime(config);
+    const moved = persistMovedGroundings(config, [scaffold], runtime!);
+    runtime!.close();
+
+    expect(moved).toBe(2); // grounds_to entry + inline anchor, one resolution
+    const persistedContent = readFileSync(scaffold, "utf-8");
+    expect(persistedContent).not.toContain(`mex://${node.id}`);
+    expect(persistedContent).toContain(`mex://${movedNode.id}`);
+    expect(extractGroundings(persistedContent)[0].node).toBe(movedNode.id);
+
+    // The next check must not report the anchor as gone.
+    const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
+    expect(report.issues.filter((issue) => issue.code === "GROUNDING_GONE")).toHaveLength(0);
+  }, 20_000);
+
+  it("migrates the inline anchor from the grounds_to resolution even when the store lost the old node's rows (#128)", async () => {
+    const { root, scaffold, config } = fixture();
+    const source = join(root, "src", "service.ts");
+    writeFileSync(source, "export function calculateTotal(items: number[]): number {\n  return items.reduce((a, b) => a + b, 0);\n}\n");
+
+    const engine = createGraphEngine({ rootDir: root });
+    await engine.build();
+    const node = engine.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    engine.close();
+
+    let runtime = await loadGroundingRuntime(config);
+    const fingerprint = runtime!.reconciler.getFingerprint(node.id);
+    writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{
+      node: node.id,
+      fingerprint: serializeFingerprint(fingerprint!),
+    }]) + `\n[\`calculateTotal()\`](mex://${node.id})\n`);
+    refreshGroundingBaselines(config, [scaffold], runtime!);
+    runtime!.close();
+
+    const movedSource = join(root, "src", "moved.ts");
+    writeFileSync(movedSource, readFileSync(source, "utf-8"));
+    writeFileSync(source, "export const unrelated = 1;\n");
+    const rebuilt = createGraphEngine({ rootDir: root });
+    await rebuilt.build();
+    const movedNode = rebuilt.searchNodes("calculateTotal").find((entry) => entry.kind === "function")!;
+    rebuilt.close();
+
+    // A store where the old node's rows are already gone (the reporter's
+    // post-move state): no grounded-source row, no fingerprint row, and no
+    // compatibility alias. Without per-node atomic migration the anchor pass
+    // finds no baseline and silently skips, leaving GROUNDING_GONE behind.
+    const db = openSqlite(join(root, ".mex", "graph.db"));
+    try {
+      db.prepare("DELETE FROM _mex_grounded_source WHERE node_id = ?").run(node.id);
+      db.prepare("DELETE FROM node_fingerprints WHERE node_id = ?").run(node.id);
+      db.prepare("DELETE FROM node_aliases WHERE alias_id = ?").run(node.id);
+    } finally {
+      db.close();
+    }
+
+    runtime = await loadGroundingRuntime(config);
+    const moved = persistMovedGroundings(config, [scaffold], runtime!);
+    runtime!.close();
+
+    expect(moved).toBe(2);
+    const persistedContent = readFileSync(scaffold, "utf-8");
+    expect(persistedContent).not.toContain(`mex://${node.id}`);
+    expect(persistedContent).toContain(`mex://${movedNode.id}`);
+    expect(extractGroundings(persistedContent)[0].node).toBe(movedNode.id);
+
+    const report = await runDriftCheckWithGraphStatus(config, { graphWarning: () => {} });
+    expect(report.issues.filter((issue) => issue.code === "GROUNDING_GONE")).toHaveLength(0);
+  }, 20_000);
+
   it("keeps legacy checks running when the graph engine fails to load", async () => {
     const { scaffold, config } = fixture();
     writeFileSync(scaffold, writeGroundings(readFileSync(scaffold, "utf-8"), [{


### PR DESCRIPTION
## What

When a scaffold file grounds the same node both in frontmatter `grounds_to` and as an inline `mex://` anchor, `mex sync` now migrates both through one resolution. Previously only the `grounds_to` entry moved; the inline anchor kept the dead id and the next `mex check` reported a permanent `GROUNDING_GONE`.

This branch carries @abhinav-phi's fix from #187 plus a follow-up commit:

- **Fix (#187):** the `grounds_to` pass records each `oldId → newId` it migrates, and the anchor pass follows that record before running its own reconcile.
- **Regression test for the real-world trigger:** the stored baseline row keeps a neighbour id that has since been re-identified. The anchor alone then reconciles `AMBIGUOUS` while its `grounds_to` entry reconciles `MOVED`, so sync moved one form and not the other.
- Dropped an unreachable same-id check in the anchor pass.
- CHANGELOG entry under `Unreleased → Fixed`.

## Why

Closes #128. Thanks to @tcconnally for the deterministic reproduction.

Since `e625b46` (0.8.1), `main` already defers the baseline delete until after the anchor pass, but the bug still reproduces there. The anchor reconciles independently against a different baseline from the `grounds_to` entry:

- `grounds_to` uses the frontmatter fingerprint, which every migration refreshes.
- The anchor falls back to the stored baseline row, which is copied over verbatim.

When the two disagree, only one form migrates, the shared baseline row moves anyway, and the anchor is left `GONE`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs
- [ ] CI/Tooling

## How to test

1. `npx vitest run test/graph-integration.test.ts -t "#128"`: three tests pass.
2. Replace `src/graph/runtime.ts` with `main`'s version and rerun: the two no-alias tests fail with `expected 1 to be 2` (the inline anchor is skipped). The alias-path test passes on both, as a regression guard.
3. End to end on a real scaffold that grounds a function both ways in two files: move the function with an identical body, then run `mex graph`, `mex sync` and `mex check`.

| case | `main` | this PR |
|---|---|---|
| identical move, alias present | both forms migrate | both forms migrate |
| identical move, no alias | `grounds_to` migrates, anchor stays stale → `GROUNDING_GONE` | both migrate, no `GROUNDING_GONE` |
| same, two inline anchors in one file | anchor stale → `GROUNDING_GONE` | all references migrate |

## Checklist

- [x] Tests pass (`npm test`) — compared against the base commit on Windows: no new failures; the three #128 tests pass
- [x] No breaking changes (or documented below)
- [x] Tested locally with a real project

## Code-graph changes

- [x] This PR targets `main`
- [ ] A linked issue agrees on the bounded extractor/resolver scope — n/a, no extractor/resolver
- [ ] The change follows the frozen `LanguageExtractor` or `FrameworkResolver` interface — n/a
- [x] A focused fixture and assertions for the expected node/edge shape are included
- [ ] Any new grammar WASM, extension mapping, extractor, or resolver is registered — n/a
- [x] No graph identity, reconciliation, schema, or drift-semantics changes are included, or a `core / discuss-first` issue is linked above — reconciler scoring, identity and schema are untouched; only `sync`'s migration of inline anchors changes, as the bug fix for #128